### PR TITLE
💡proposed `thebe` frontmatter changes

### DIFF
--- a/.changeset/grumpy-apes-check.md
+++ b/.changeset/grumpy-apes-check.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+`jupyter.local` options have been removed

--- a/.changeset/wet-moons-yell.md
+++ b/.changeset/wet-moons-yell.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+is specified, `jupyter.server` must be an object with valid `token` and `url` fields

--- a/docs/integrating-jupyter.md
+++ b/docs/integrating-jupyter.md
@@ -304,9 +304,9 @@ project:
     lite: boolean
     binder: undefined(false) | boolean | object
       url: string (url)
-      repo: string (org-name/repo-name)
-      ref: string (valid git refs only?)
-      provider: string (git | gitlab | github)
+      provider: string (git | gitlab | github | or custom)
+      repo: string (org-name/repo-name | url | string)
+      ref: string (undefined | string)
     server:  undefined | object
       url: string (url)
       token: string (any)

--- a/docs/integrating-jupyter.md
+++ b/docs/integrating-jupyter.md
@@ -23,74 +23,98 @@ Being able to connect a jupyter-based figure or output in any website page to a 
 
 ## Quick setup options
 
-MyST uses `thebe` for Jupyter connectivity which can be enabled using default settings by adding a single key (`thebe: true`) to the project frontmatter in your `myst.yml` file.
+MyST uses `thebe` for Jupyter connectivity which can be enabled using default settings by adding a single key `jupyter: true` (or `thebe: true`) to the project frontmatter in your `myst.yml` file.
 
 ```{code} yaml
 version: 1
 project:
   title: Geocomputing
-  thebe: true
+  jupyter: true
 site:
   template: book-theme
   title: My Computational Website
 ```
 
-When the boolean form of the `thebe` key is used, MyST will try to determine where to connect to from existing `github` and `binder` keys you may have on your project and is intended to allow for easy setup of a few key use cases. To go beyond or override these, you can provide various options in the `thebe` field.
+When the field `jupyter: true` is set, MyST will try to determine where to connect to automatically by looking at the `github` field if you supplied one. Otherwise it will use the demo repository at `https://github.com/executablebooks/thebe-binder-base` along with [mybinder.org](https://mybinder.org) to start a juptyer environment.
 
-### Case - `thebe: true` and no `github` or `binder` keys are present
+The intention here is to allow minimal setup to enable a few key use cases. To go beyond or override these, you can provide various options in the `jupyter` field which are documented below.
+
+````{tip} Equivalent Syntax
+:class: dropdown
+The following cases are all equivalent:
 
 ```yaml
 project:
-  thebe: true
+  jupyter: true
 ```
 
-When `thebe: true` and no `github` or `binder` keys are present MyST will try to connect to a binder using the default settings. The default settings will attempt to connect to [mybinder.org](https://mybinder.org) using the [thebe-binder-base](https://github.com/executablebooks/thebe-binder-base) repository for python environment configuration.
-
-Note this is equivalent to:
+```yaml
+project:
+  jupyter: 'binder'
+```
 
 ```yaml
 project:
-  thebe:
+  jupyter:
     binder: true
 ```
 
-### Case - `thebe: true` and the `github` key is present
-
 ```yaml
 project:
-  github: https://github.com/executablebooks/thebe-binder-base
-  thebe: true
+  jupyter:
+    binder:
+      repo: executablebooks/thebe-binder-base # default repo
 ```
 
-When `thebe: true` and the `github` key is present, MyST will attempt to connect to the public `mybinder.org` service using the repository information and a the default `ref: HEAD`. See [](#connecting-to-a-binder) to point to a different binder service or changing repository details.
+```yaml
+project:
+  jupyter:
+    binder:
+      repo: https://github.com/executablebooks/thebe-binder-base # default repo
+```
 
-Note this is equivalent to:
+````
+
+## Jupyter Configuration Options
+
+The following "cases" show different configuration options, aimed at different use cases. Look through these to find one that suits you purpose.
+
+### Case connect to binder with my own repo
+
+_`jupyter: true` and the `github` key is present_
 
 ```yaml
 project:
-  github: https://github.com/executablebooks/thebe-binder-base
-  thebe:
+  github: https://github.com/username/my-myst-article
+  jupyter: 'binder'
+```
+
+When `jupyter: true` and the `github` key is present, MyST will attempt to connect to the public `mybinder.org` service using the repository information and a the default `ref: HEAD`. See [](#connecting-to-a-binder) to point to a different binder service or changing repository details.
+
+````{tip} Equivalent Syntax
+:class: dropdown
+The following cases are all equivalent:
+
+```yaml
+project:
+  github: https://github.com/username/my-myst-article
+  jupyter: 'binder'
+```
+
+```yaml
+project:
+  github: https://github.com/username/my-myst-article
+  jupyter: true
+```
+
+```yaml
+project:
+  github: https://github.com/username/my-myst-article
+  jupyter:
     binder: true
 ```
 
-### Case - `thebe: true` and the `binder` key is present
-
-```yaml
-project:
-  binder: https://mybinder.org/v2/gh/executablebooks/thebe-binder-base/HEAD
-  thebe: true
-```
-
-When `thebe: true` and the `binder` key is present, MyST will use the binder information to establish a connection, the `github` field will be ignored.
-
-Note this is also equivalent to:
-
-```yaml
-project:
-  binder: https://mybinder.org/v2/gh/executablebooks/thebe-binder-base/HEAD
-  thebe:
-    binder: true
-```
+````
 
 ### 🚧 Case - Using Pyodide & JupyterLite
 
@@ -100,17 +124,29 @@ The JupyterLite server and `pyodide` kernels can be activated using:
 
 ```{code} yaml
 project:
-  thebe:
+  jupyter:
     lite: true
 ```
 
 This will load the server using the default options, to learn more about how using JupyterLite can affect site deployment and how environment setup works with pyodide see [](#jupyterlite)
 
+````{tip} Equivalent Syntax
+:class: dropdown
+The following cases are all equivalent:
+
+```{code} yaml
+project:
+  jupyter:
+    lite: true
+```
+
+````
+
 ### Disabling integrated compute
 
-Easily disable integrated compute on your project by either setting `thebe: false` or removing the key altogether.
+Easily disable integrated compute on your project by either setting `jupyter: false` or removing the key altogether.
 
-Disable integrated compute on a specific page in your website by adding `thebe: false` to the page frontmatter section.
+Disable integrated compute on a specific page in your website by adding `jupyter: false` to the page frontmatter section.
 
 (connecting-to-a-binder)=
 
@@ -123,9 +159,9 @@ When a the `thebe.binder` key contains a set of options, binder connections are 
 caption: A minimal `thebe.binder` configuration with the required `repo` field
 ---
 project:
-  thebe:
+  jupyter:
     binder:
-      repo: executablebooks/thebe-binder-base
+      repo: username/my-myst-article
 ```
 
 This allows the repository information for integrated compute to be different to that used for the `github` badge on the website, for useful for example if the github badge is pointing to a organization or other repo.
@@ -135,7 +171,7 @@ This allows the repository information for integrated compute to be different to
 caption: A complete `thebe.binder` configuration
 ---
 project:
-  thebe:
+  jupyter:
     binder:
       url: https://binder.myorganisation.com/services/binder/
       repo: executablebooks/thebe-binder-base
@@ -184,7 +220,7 @@ When a user presses the "launch binder" badge they will connect to a new indepen
 
 (directly-connecting-to-a-jupyter-server)=
 
-## Directly connecting to a Jupyter server
+## Directly connecting to a (local) Jupyter server
 
 The `thebe.server` key is used to provide options for direct connections to Jupyter, use the provided (and default) settings, the most minimal form of configuration is:
 
@@ -193,12 +229,13 @@ The `thebe.server` key is used to provide options for direct connections to Jupy
 caption: A unque connection token must be supplied to connect to a local server
 ---
 project:
-  thebe:
+  jupyter:
     server:
+      url: http://localhost:8888/
       token: <your-secret-token>
 ```
 
-By default, thebe will try to connect to a server on `http://localhost:8888`, to override this specify the url to connect to:
+Both `url` and `token` must be provided to enable a server connection.
 
 ```{list-table}
 :header-rows: 1
@@ -233,7 +270,7 @@ The [JupyterLite](https://jupyterlite.readthedocs.io/en/latest/) server and `pyo
 caption: Minimal configuration for enabling JupyterLite
 ---
 project:
-  thebe:
+  jupyter:
     lite: true
 ```
 
@@ -261,7 +298,7 @@ When starting a local Jupyter server for use with MyST it's also important to un
 
 ```{code-block} yaml
 project:
-  thebe: undefined(false) | boolean | object
+  jupyter: undefined(false) | boolean | object | 'lite' | 'binder'
     lite: boolean
     binder: undefined(false) | boolean | object
       url: string (url)

--- a/docs/integrating-jupyter.md
+++ b/docs/integrating-jupyter.md
@@ -44,21 +44,21 @@ project:
   thebe: true
 ```
 
-When `thebe: true` and no `github` or `binder` keys are present MyST will try to connect to a server using the default (local settings). To make this work you'll need to [](#start-a-local-jupyter-server) with the correct defaults or [provide alternative direct connection options](#directly-connecting-to-a-jupyter-server).
+When `thebe: true` and no `github` or `binder` keys are present MyST will try to connect to a binder using the default settings. The default settings will attempt to connect to [mybinder.org](https://mybinder.org) using the [thebe-binder-base](https://github.com/executablebooks/thebe-binder-base) repository for python environment configuration.
 
 Note this is equivalent to:
 
 ```yaml
 project:
   thebe:
-    server: true
+    binder: true
 ```
 
 ### Case - `thebe: true` and the `github` key is present
 
 ```yaml
 project:
-  github: executablebooks/thebe-binder-base
+  github: https://github.com/executablebooks/thebe-binder-base
   thebe: true
 ```
 
@@ -68,7 +68,7 @@ Note this is equivalent to:
 
 ```yaml
 project:
-  github: executablebooks/thebe-binder-base
+  github: https://github.com/executablebooks/thebe-binder-base
   thebe:
     binder: true
 ```
@@ -186,18 +186,19 @@ When a user presses the "launch binder" badge they will connect to a new indepen
 
 ## Directly connecting to a Jupyter server
 
-When the `thebe.server` key contains a set of options, direct connections to Jupyter use the provided (and default) settings, the most minimal form of configuration is:
+The `thebe.server` key is used to provide options for direct connections to Jupyter, use the provided (and default) settings, the most minimal form of configuration is:
 
 ```{code-block} yaml
 ---
-caption: Minimal configuration for connecting to a local server using default settings
+caption: A unque connection token must be supplied to connect to a local server
 ---
 project:
   thebe:
-    server: true
+    server:
+      token: <your-secret-token>
 ```
 
-Override the default settings using the following keys:
+By default, thebe will try to connect to a server on `http://localhost:8888`, to override this specify the url to connect to:
 
 ```{list-table}
 :header-rows: 1
@@ -208,12 +209,9 @@ Override the default settings using the following keys:
 * - `url`
   - The base url of the Jupyter server you want to connect to
   - `http://localhost:8888`
-* - `token`
-  - The token needed to establish a connection
-  - `test-secret`
 ```
 
-This allows you to connect to local servers on a different port, or across a private network and provide specific tokens to establish the connection, it is also useful in cases where this information is provided dynamically (for example after a JupyterHub server has been provisioned, however this requires additional infrastructure to deploy).
+This allows you to connect to local servers on a different port, or across a private network and provide specific tokens to establish the connection, it is also useful in cases where this information is provided dynamically (for example after a JupyterHub server has been provisioned).
 
 For more on working locally see [](#start-a-local-jupyter-server).
 
@@ -221,7 +219,7 @@ For more on working locally see [](#start-a-local-jupyter-server).
 :class: dropdown
 If you intend to run a dedicate single user Jupyter server accessible over a network please carefully read and follow [the advice provided by the Jupyter server team here](https://jupyter-notebook.readthedocs.io/en/stable/public_server.html).
 
-MyST Websites will work best, be safer and be more robust when backed by Jupyter services such as Binder or JupyterHub.
+MyST Websites will work best, be safer and be more robust when backed by Jupyter services such as BinderHub or JupyterHub.
 ```
 
 (jupyterlite)=
@@ -243,50 +241,17 @@ project:
 Add the specific list options for custom wheel paths, etc.
 ```
 
-## 🚧 Local Development Mode
-
-When working on a MyST Site using `mystmd`, using a local Jupyter server connection makes a lot of sense and speeds up development. The `local` key allows you to enable and configure a local environment without having to change the other (remote) settings in your `myst.yml` file that will be used in your final deployment.
-
-Local development using can be enabled by simply adding the `local` key, which will use default server options.
-
-```yaml
-project:
-  github: https://github.com/executablebooks/thebe-binder-base
-    thebe:
-      binder: true
-      local: true
-```
-
-Further configure the `local` connection using the following options.
-
-```{list-table}
-:header-rows: 1
-
-* - `key`
-  - description
-  - default
-* - `url`
-  - The base url of the Jupyter server you want to connect to
-  - `http://localhost:8888`
-* - `token`
-  - The token needed to establish a connection
-  - `test-secret`
-* - `kernelName`
-  - The name of the kernel to request when stating a session
-  - `python`
-```
-
 (start-a-local-jupyter-server)=
 
-### Start a local Jupyter server
+### Start a local Jupyter server for development purposes
 
 In addition to how you might normally start a JupyterLab session, it's necessary to provide two additional command line options, as follows.
 
 ```{code} bash
-jupyter lab --NotebookApp.token=test-secret --NotebookApp.allow_origin='*'
+jupyter lab --NotebookApp.token=<your-secret-token> --NotebookApp.allow_origin='https://localhost:3000'
 ```
 
-The command above is fine for local development and the `token` used should align with that provided in the `project.thebe.token` key.
+The command above is fine for local development. The `token` used should align with that provided in the `project.thebe.token` key and `allow_origin` should allow connections from your myst site preview, usually running on `https://localhost:3000`.
 
 When starting a local Jupyter server for use with MyST it's also important to understand your computational environment and ensure that the Jupyter instance has access to that with the dependencies it needs to run. This is achieved by following normal best practices for reproducible environment configuration, if you're not familiar with these see [REES](https://repo2docker.readthedocs.io/en/latest/specification.html).
 
@@ -303,17 +268,13 @@ project:
       repo: string (org-name/repo-name)
       ref: string (valid git refs only?)
       provider: string (git | gitlab | github)
-    server:  undefined(false) | boolean | object
+    server:  undefined | object
       url: string (url)
       token: string (any)
     kernelName: string (any)
     disableSessionSaving: boolean (default: false)
     mathjaxUrl: string (url)
     mathjaxConfig: string (any)
-    local: undefined(false) | boolean | object
-      url: string (url)
-      token: string (any)
-      kernelName: string (any)
 ```
 
 ### Additional options

--- a/docs/integrating-jupyter.md
+++ b/docs/integrating-jupyter.md
@@ -246,6 +246,8 @@ Both `url` and `token` must be provided to enable a server connection.
 * - `url`
   - The base url of the Jupyter server you want to connect to
   - `http://localhost:8888`
+* - `token`
+  - The secret token string required by your jupyter server
 ```
 
 This allows you to connect to local servers on a different port, or across a private network and provide specific tokens to establish the connection, it is also useful in cases where this information is provided dynamically (for example after a JupyterHub server has been provisioned).

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -10,7 +10,6 @@ import type {
   PageFrontmatter,
   ProjectFrontmatter,
   SiteFrontmatter,
-  Thebe,
 } from './types';
 import {
   fillPageFrontmatter,
@@ -26,7 +25,6 @@ import {
   validatePageFrontmatter,
   validateProjectFrontmatter,
   validateSiteFrontmatterKeys,
-  validateThebe,
   validateVenue,
 } from './validators';
 
@@ -68,31 +66,6 @@ const TEST_BIBLIO: Biblio = {
   issue: 'example',
   first_page: 1,
   last_page: 2,
-};
-
-const TEST_THEBE: Thebe = {
-  lite: false,
-  binder: {
-    url: 'https://my.binder.org/blah',
-    ref: 'HEAD',
-    repo: 'my-org/my-repo',
-    provider: 'github',
-  },
-  server: {
-    url: 'https://my.server.org',
-    token: 'legit-secret',
-  },
-  kernelName: 'python3',
-  sessionName: 'some-path',
-  disableSessionSaving: true,
-  mathjaxConfig: 'TeX-AMS_CHTML-full,Safe',
-  mathjaxUrl: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js',
-  local: {
-    url: 'http://localhost:8888',
-    token: 'test-secret',
-    kernelName: 'python27',
-    sessionName: 'another-path',
-  },
 };
 
 const TEST_NUMBERING: Numbering = {
@@ -332,59 +305,6 @@ describe('validateBiblio', () => {
   });
   it('full object returns self', async () => {
     expect(validateBiblio(TEST_BIBLIO, opts)).toEqual(TEST_BIBLIO);
-  });
-});
-
-describe('validateThebe', () => {
-  it('empty object returns self', async () => {
-    expect(validateThebe({}, opts)).toEqual({});
-  });
-  it('extra keys removed', async () => {
-    expect(validateThebe({ extra: '' }, opts)).toEqual({});
-  });
-  it('full object returns self', async () => {
-    expect(validateThebe(TEST_THEBE, opts)).toEqual(TEST_THEBE);
-  });
-  it('custom provider accepts url as repo value', async () => {
-    const output = validateThebe(
-      {
-        ...TEST_THEBE,
-        binder: {
-          url: 'https://binder.curvenote.com/services/binder/',
-          repo: 'https://curvenote.com/sub/bundle.zip',
-          provider: 'custom',
-        },
-      },
-      opts,
-    );
-    expect(output?.binder).toEqual({
-      url: 'https://binder.curvenote.com/services/binder/',
-      repo: 'https://curvenote.com/sub/bundle.zip',
-      provider: 'custom',
-    });
-  });
-  it('errors if no repo with custom provider', async () => {
-    expect(opts.messages).toEqual({});
-    expect(
-      validateThebe(
-        {
-          ...TEST_THEBE,
-          binder: {
-            url: 'https://binder.curvenote.com/services/binder/',
-            provider: 'custom',
-          },
-        },
-        opts,
-      ),
-    ).toEqual({
-      ...TEST_THEBE,
-      binder: {
-        url: 'https://binder.curvenote.com/services/binder/',
-        provider: 'custom',
-      },
-    });
-    expect(opts.messages.errors?.length).toEqual(1);
-    expect(opts.messages.errors?.[0].property).toEqual('repo');
   });
 });
 

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.thebe.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.thebe.spec.ts
@@ -75,7 +75,7 @@ describe('validateThebe', () => {
         url: 'https://mybinder.org/',
       },
     });
-    expect(opts.messages.errors?.length).toEqual(1);
+    expect(opts.messages.errors?.length).toBeGreaterThanOrEqual(1);
     expect(opts.messages.errors?.[0].property).toEqual('repo');
   });
   test('thebe: "server" is not valid', async () => {

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.thebe.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.thebe.spec.ts
@@ -54,6 +54,7 @@ describe('validateThebe', () => {
       url: 'https://binder.curvenote.com/services/binder/',
       repo: 'https://curvenote.com/sub/bundle.zip',
       provider: 'custom',
+      ref: '',
     });
   });
   test('errors if no repo with custom provider', async () => {
@@ -61,19 +62,17 @@ describe('validateThebe', () => {
     expect(
       validateThebe(
         {
-          ...TEST_THEBE,
           binder: {
-            url: 'https://binder.curvenote.com/services/binder/',
             provider: 'custom',
           },
         },
         opts,
       ),
     ).toEqual({
-      ...TEST_THEBE,
       binder: {
-        url: 'https://binder.curvenote.com/services/binder/',
         provider: 'custom',
+        ref: '',
+        url: 'https://mybinder.org/',
       },
     });
     expect(opts.messages.errors?.length).toEqual(1);
@@ -122,5 +121,19 @@ describe('validateThebe', () => {
     });
     expect(opts.messages.errors?.length).toEqual(1);
     expect(opts.messages.errors?.[0].property).toEqual('server');
+  });
+  test('thebe.binder - extra fields wil be stripped', async () => {
+    expect(opts.messages).toEqual({});
+    expect(
+      validateThebe({ binder: { url: 'http://localhost:9090', extra: 'field' } }, opts),
+    ).toEqual({
+      binder: {
+        url: 'http://localhost:9090',
+        repo: 'executablebooks/thebe-binder-base',
+        ref: 'HEAD',
+        provider: 'github',
+      },
+    });
+    expect(opts.messages.errors).toBeUndefined();
   });
 });

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.thebe.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.thebe.spec.ts
@@ -86,7 +86,7 @@ describe('validateThebe', () => {
   });
   test('thebe.server must be an object', async () => {
     expect(opts.messages).toEqual({});
-    expect(validateThebe({ server: true }, opts)).toEqual({ server: undefined });
+    expect(validateThebe({ server: true }, opts)).toEqual(undefined);
     expect(opts.messages.errors?.length).toEqual(1);
     expect(opts.messages.errors?.[0].property).toEqual('server');
   });

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.thebe.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.thebe.spec.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import type { Thebe } from './types';
+import { validateThebe } from './validators';
+import type { ValidationOptions } from 'simple-validators';
+
+const TEST_THEBE: Thebe = {
+  lite: false,
+  binder: {
+    url: 'https://my.binder.org/blah',
+    ref: 'HEAD',
+    repo: 'my-org/my-repo',
+    provider: 'github',
+  },
+  server: {
+    url: 'https://my.server.org',
+    token: 'legit-secret',
+  },
+  kernelName: 'python3',
+  sessionName: 'some-path',
+  disableSessionSaving: true,
+  mathjaxConfig: 'TeX-AMS_CHTML-full,Safe',
+  mathjaxUrl: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js',
+};
+
+let opts: ValidationOptions;
+
+beforeEach(() => {
+  opts = { property: 'test', messages: {} };
+});
+
+describe('validateThebe', () => {
+  test('empty object returns self', async () => {
+    expect(validateThebe({}, opts)).toEqual({});
+  });
+  test('extra keys removed', async () => {
+    expect(validateThebe({ extra: '' }, opts)).toEqual({});
+  });
+  test('full object returns self', async () => {
+    expect(validateThebe(TEST_THEBE, opts)).toEqual(TEST_THEBE);
+  });
+  test('custom provider accepts url as repo value', async () => {
+    const output = validateThebe(
+      {
+        ...TEST_THEBE,
+        binder: {
+          url: 'https://binder.curvenote.com/services/binder/',
+          repo: 'https://curvenote.com/sub/bundle.zip',
+          provider: 'custom',
+        },
+      },
+      opts,
+    );
+    expect(output?.binder).toEqual({
+      url: 'https://binder.curvenote.com/services/binder/',
+      repo: 'https://curvenote.com/sub/bundle.zip',
+      provider: 'custom',
+    });
+  });
+  test('errors if no repo with custom provider', async () => {
+    expect(opts.messages).toEqual({});
+    expect(
+      validateThebe(
+        {
+          ...TEST_THEBE,
+          binder: {
+            url: 'https://binder.curvenote.com/services/binder/',
+            provider: 'custom',
+          },
+        },
+        opts,
+      ),
+    ).toEqual({
+      ...TEST_THEBE,
+      binder: {
+        url: 'https://binder.curvenote.com/services/binder/',
+        provider: 'custom',
+      },
+    });
+    expect(opts.messages.errors?.length).toEqual(1);
+    expect(opts.messages.errors?.[0].property).toEqual('repo');
+  });
+  test('thebe: "server" is not valid', async () => {
+    expect(opts.messages).toEqual({});
+    expect(validateThebe('server', opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+    expect(opts.messages.errors?.[0].property).toEqual('test');
+  });
+  test('thebe.server must be an object', async () => {
+    expect(opts.messages).toEqual({});
+    expect(validateThebe({ server: true }, opts)).toEqual({ server: undefined });
+    expect(opts.messages.errors?.length).toEqual(1);
+    expect(opts.messages.errors?.[0].property).toEqual('server');
+  });
+  test('thebe.server must have url and token fields - empty', async () => {
+    expect(opts.messages).toEqual({});
+    expect(validateThebe({ server: {} }, opts)).toEqual({ server: undefined });
+    expect(opts.messages.errors?.length).toEqual(1);
+    expect(opts.messages.errors?.[0].property).toEqual('server');
+  });
+  test('thebe.server must have url and token fields - no url', async () => {
+    expect(opts.messages).toEqual({});
+    expect(validateThebe({ server: { token: 'my-secret-secret' } }, opts)).toEqual({
+      server: undefined,
+    });
+    expect(opts.messages.errors?.length).toEqual(1);
+    expect(opts.messages.errors?.[0].property).toEqual('server');
+  });
+  test('thebe.server must have url and token fields - not a url string', async () => {
+    expect(opts.messages).toEqual({});
+    expect(
+      validateThebe({ server: { url: 'not-a-url', token: 'my-secret-secret' } }, opts),
+    ).toEqual({
+      server: undefined,
+    });
+    expect(opts.messages.errors?.length).toEqual(1);
+    expect(opts.messages.errors?.[0].property).toEqual('url');
+  });
+  test('thebe.server must have url and token fields - no token', async () => {
+    expect(opts.messages).toEqual({});
+    expect(validateThebe({ server: { url: 'http://localhost:9090' } }, opts)).toEqual({
+      server: undefined,
+    });
+    expect(opts.messages.errors?.length).toEqual(1);
+    expect(opts.messages.errors?.[0].property).toEqual('server');
+  });
+});

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -77,13 +77,12 @@ export type Biblio = {
 export type Thebe = {
   lite?: boolean;
   binder?: boolean | BinderHubOptions;
-  server?: boolean | JupyterServerOptions;
+  server?: JupyterServerOptions;
   kernelName?: string;
   sessionName?: string;
   disableSessionSaving?: boolean;
   mathjaxUrl?: string;
   mathjaxConfig?: string;
-  local?: boolean | JupyterLocalOptions;
 };
 
 export type WellKnownRepoProviders = 'github' | 'gitlab' | 'git' | 'gist';

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -728,7 +728,11 @@ export function validateThebe(input: any, opts: ValidationOptions): Thebe | unde
   if (value.binder) {
     output.binder = validateBinderHubOptions(
       value.binder === true ? {} : (value.binder as BinderHubOptions),
-      incrementOptions('binder', opts),
+      {
+        ...incrementOptions('binder', opts),
+        errorLogFn: (msg) =>
+          validationError(msg.split('object').join('an object or boolean'), opts),
+      },
     );
   }
   if (defined(value.server)) {

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -742,7 +742,7 @@ export function validateThebe(input: any, opts: ValidationOptions): Thebe | unde
     if (server) {
       output.server = validateJupyterServerOptions(server, serverOpts);
     } else {
-      output.server = server;
+      return undefined;
     }
   }
   if (defined(value.kernelName)) {

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -726,7 +726,7 @@ export function validateThebe(input: any, opts: ValidationOptions): Thebe | unde
     output.lite = validateBoolean(value.lite, incrementOptions('lite', opts));
   }
   if (defined(value.binder)) {
-    const isBoolean = validateBoolean(value.binder, {
+    const asBoolean = validateBoolean(value.binder, {
       ...incrementOptions('binder', opts),
       suppressErrors: true,
       suppressWarnings: true,

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -705,25 +705,35 @@ export function validateBiblio(input: any, opts: ValidationOptions) {
 export function validateThebe(input: any, opts: ValidationOptions): Thebe | undefined {
   if (input === false) return undefined;
   if (input === 'lite') return { lite: true };
-  if (input === true || input === 'binder') return { binder: true };
-  if (typeof input === 'string') {
+  if (typeof input === 'string' && input !== 'binder') {
     return validationError(
       `thebe must be a boolean, an object, "lite" or "binder", not a string: ${input}`,
       opts,
     );
   }
 
-  const value: Thebe | undefined = validateObjectKeys(input, { optional: THEBE_KEYS }, opts);
+  let inputObject: Record<string, any> = input;
+  if (input === true || input === 'binder') {
+    // expand boolean methods to object
+    inputObject = { binder: true };
+  }
+
+  const value: Thebe | undefined = validateObjectKeys(inputObject, { optional: THEBE_KEYS }, opts);
+
   if (value === undefined) return undefined;
   const output: Thebe = {};
   if (defined(value.lite)) {
     output.lite = validateBoolean(value.lite, incrementOptions('lite', opts));
   }
   if (defined(value.binder)) {
-    output.binder = validateBooleanOrObject(
-      value.binder,
+    const isBoolean = validateBoolean(value.binder, {
+      ...incrementOptions('binder', opts),
+      suppressErrors: true,
+      suppressWarnings: true,
+    });
+    output.binder = validateBinderHubOptions(
+      isBoolean ? {} : (value.binder as BinderHubOptions),
       incrementOptions('binder', opts),
-      validateBinderHubOptions,
     );
   }
   if (defined(value.server)) {
@@ -759,36 +769,59 @@ export function validateThebe(input: any, opts: ValidationOptions): Thebe | unde
   return output;
 }
 
-export function validateBinderHubOptions(input: any, opts: ValidationOptions) {
+export function validateBinderHubOptions(input: BinderHubOptions, opts: ValidationOptions) {
+  // input expected to be resolved to an object at this stage.
+  // missing fields should be replaced by defaults
   const value = validateObjectKeys(input, { optional: BINDER_HUB_OPTIONS_KEYS }, opts);
   if (value === undefined) return undefined;
+
   const output: BinderHubOptions = {};
-  if (defined(value.url)) {
-    output.url = validateUrl(value.url, incrementOptions('url', opts));
-  }
-  if (defined(value.provider)) {
-    output.provider = validateString(value.provider, {
-      ...incrementOptions('provider', opts),
-      regex: /.+/,
-    });
-  }
-  if (defined(value.provider) && !output.provider?.match(/^(git|github|gitlab|gist)$/i)) {
-    // repo can be any value, but must be present -> validate as any non empty string
+
+  output.url = validateUrl(value.url ?? 'https://mybinder.org/', incrementOptions('url', opts));
+
+  // if there  is no provider, set it to github
+  // if there is a provider, validate it as a non empty string
+  output.provider = value.provider
+    ? validateString(value.provider, {
+        ...incrementOptions('provider', opts),
+        regex: /.+/,
+      })
+    : 'github';
+
+  // if our resolved provider is a git-like repo, we should validate repo and ref if
+  // provided, otherwise we supply defaults
+  if (output.provider?.match(/^(git|github|gitlab|gist)$/i)) {
+    // first try to validate repo as a github username/repo string
+    output.repo = value.repo
+      ? validateString(value.repo, {
+          ...incrementOptions('repo', opts),
+          regex: GITHUB_USERNAME_REPO_REGEX,
+          suppressErrors: true,
+          suppressWarnings: true,
+        })
+      : 'executablebooks/thebe-binder-base';
+
+    // then if not, validate as a url and report errors based on url validation
+    // this will encourage use of fully qualified urls
+    if (!output.repo) {
+      output.repo = validateUrl(value.repo, incrementOptions('repo', opts));
+    }
+
+    // validate ref as a string
+    output.ref = value.ref ? validateString(value.ref, incrementOptions('ref', opts)) : 'HEAD';
+  } else {
+    // we are in a custom provider and repo can be any string value, but must be present
+    // -> validate as any non empty string
+    // do not validate ref but ensure that is at least an empty string, to prevent thebe
+    // from setting it to 'HEAD'
+
+    // this ensures a non empty string
     output.repo = validateString(value.repo, {
       ...incrementOptions('repo', opts),
       regex: /.+/,
     });
-  } else {
-    // otherwise repo is optional, but must be a valid GitHub username/repo is defined
-    if (defined(value.repo)) {
-      output.repo = validateString(value.repo, {
-        ...incrementOptions('repo', opts),
-        regex: GITHUB_USERNAME_REPO_REGEX,
-      });
-    }
-  }
-  if (defined(value.ref)) {
-    output.ref = validateString(value.ref, incrementOptions('ref', opts));
+
+    output.ref = value.ref ? validateString(value.ref, incrementOptions('ref', opts)) : '';
   }
 
   return output;

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -765,6 +765,7 @@ export function validateThebe(input: any, opts: ValidationOptions): Thebe | unde
       incrementOptions('mathjaxConfig', opts),
     );
   }
+
   return output;
 }
 
@@ -1289,7 +1290,8 @@ export function validateProjectFrontmatterKeys(
 
   if (defined(value.thebe)) {
     const result = validateThebe(value.thebe, incrementOptions('thebe', opts));
-    if (result) output.thebe = result;
+    if (result && Object.keys(result).length > 0) output.thebe = result;
+    else delete output.thebe;
   }
 
   if (defined(value.requirements)) {

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -725,14 +725,9 @@ export function validateThebe(input: any, opts: ValidationOptions): Thebe | unde
   if (defined(value.lite)) {
     output.lite = validateBoolean(value.lite, incrementOptions('lite', opts));
   }
-  if (defined(value.binder)) {
-    const asBoolean = validateBoolean(value.binder, {
-      ...incrementOptions('binder', opts),
-      suppressErrors: true,
-      suppressWarnings: true,
-    });
+  if (value.binder) {
     output.binder = validateBinderHubOptions(
-      isBoolean ? {} : (value.binder as BinderHubOptions),
+      value.binder === true ? {} : (value.binder as BinderHubOptions),
       incrementOptions('binder', opts),
     );
   }

--- a/packages/myst-frontmatter/tests/thebe.yml
+++ b/packages/myst-frontmatter/tests/thebe.yml
@@ -71,6 +71,23 @@ cases:
           ref: 'HEAD'
           repo: 'executablebooks/thebe-binder-base'
           provider: 'github'
+  - title: jupyter.binder = false
+    raw:
+      jupyter:
+        binder: false
+    normalized: {}
+  - title: jupyter.binder = false, with server
+    raw:
+      jupyter:
+        binder: false
+        server:
+          url: https://my.server.com
+          token: test-secret
+    normalized:
+      thebe:
+        server:
+          url: https://my.server.com
+          token: test-secret
   - title: jupyter.binder repo only
     raw:
       jupyter:

--- a/packages/myst-frontmatter/tests/thebe.yml
+++ b/packages/myst-frontmatter/tests/thebe.yml
@@ -40,9 +40,71 @@ cases:
     normalized:
       thebe:
         lite: true
+  - title: jupyter true
+    raw:
+      jupyter: true
+    normalized:
+      thebe:
+        binder:
+          url: 'https://mybinder.org/'
+          ref: 'HEAD'
+          repo: 'executablebooks/thebe-binder-base'
+          provider: 'github'
   - title: jupyter binder
     raw:
       jupyter: 'binder'
     normalized:
       thebe:
+        binder:
+          url: 'https://mybinder.org/'
+          ref: 'HEAD'
+          repo: 'executablebooks/thebe-binder-base'
+          provider: 'github'
+  - title: jupyter.binder = true
+    raw:
+      jupyter:
         binder: true
+    normalized:
+      thebe:
+        binder:
+          url: 'https://mybinder.org/'
+          ref: 'HEAD'
+          repo: 'executablebooks/thebe-binder-base'
+          provider: 'github'
+  - title: jupyter.binder repo only
+    raw:
+      jupyter:
+        binder:
+          repo: 'username/my-repo'
+    normalized:
+      thebe:
+        binder:
+          repo: 'username/my-repo'
+          url: 'https://mybinder.org/'
+          ref: 'HEAD'
+          provider: 'github'
+  - title: jupyter.binder repo as url
+    raw:
+      jupyter:
+        binder:
+          repo: 'https://github.com/username/my-repo'
+    normalized:
+      thebe:
+        binder:
+          repo: 'https://github.com/username/my-repo'
+          url: 'https://mybinder.org/'
+          ref: 'HEAD'
+          provider: 'github'
+  - title: jupyter.binder custom (non-git) provider
+    raw:
+      jupyter:
+        binder:
+          provider: 'custom'
+          repo: 'doi:/10292.131k2'
+    normalized:
+      thebe:
+        binder:
+          url: 'https://mybinder.org/'
+          provider: 'custom'
+          repo: 'doi:/10292.131k2'
+          ref: ''

--- a/packages/myst-frontmatter/tests/thebe.yml
+++ b/packages/myst-frontmatter/tests/thebe.yml
@@ -18,11 +18,6 @@ cases:
         disableSessionSaving: true
         mathjaxConfig: TeX-AMS_CHTML-full,Safe
         mathjaxUrl: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js
-        local:
-          url: http://localhost:8888
-          token: local-secret
-          kernelName: local-kernel
-          sessionName: local-session
     normalized:
       thebe:
         lite: false
@@ -39,20 +34,15 @@ cases:
         disableSessionSaving: true
         mathjaxConfig: TeX-AMS_CHTML-full,Safe
         mathjaxUrl: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js
-        local:
-          url: http://localhost:8888
-          token: local-secret
-          kernelName: local-kernel
-          sessionName: local-session
   - title: jupyter lite
     raw:
       jupyter: 'lite'
     normalized:
       thebe:
         lite: true
-  - title: jupyter server
+  - title: jupyter binder
     raw:
-      jupyter: 'server'
+      jupyter: 'binder'
     normalized:
       thebe:
-        server: true
+        binder: true


### PR DESCRIPTION
These changes remove the `local` options for now and change the `server` and default `thebe: true` behaviour to remove the possibility of inadvertently connecting to a local server. 

We can discuss the frontmatter layout here, and once we are happy with that we can implement changes in the `myst-theme`'s and upstream in `thebe` to support it.

## summary of changes in this PR

* `local` section was removed
* `jupyter.server` can no longer be a boolean, it must be an object and must contain a `url` and `token` -- purpose here is to make connecting to a `localhost` server a more deliberate action
* doc changes
  * tried to make the docs simpler (based on feedback)
  * docs now promote use of the `jupyter` property name instead of `thebe` - `jupyter` has been added as an alias

### TODO

* [x] issue #557 
