### PR TITLE
🧹 Fix myst-to-tex legend and output node errors

### DIFF
--- a/.changeset/dry-poems-repeat.md
+++ b/.changeset/dry-poems-repeat.md
@@ -1,0 +1,6 @@
+---
+'myst-to-tex': patch
+'myst-cli': patch
+---
+
+Clean up tex errors associated with legends and empty outputs

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -4,6 +4,7 @@ import { computeHash } from 'myst-cli-utils';
 import { SourceFileKind } from 'myst-common';
 import type { GenericNode } from 'myst-common';
 import stripAnsi from 'strip-ansi';
+import { remove } from 'unist-util-remove';
 import { selectAll } from 'unist-util-select';
 import type { IOutput } from '@jupyterlab/nbformat';
 import { extFromMimeType, minifyCellOutput, walkOutputs } from 'nbtx';
@@ -66,6 +67,10 @@ export async function transformOutputs(
 export function reduceOutputs(mdast: Root, writeFolder: string) {
   const outputs = selectAll('output', mdast) as GenericNode[];
   outputs.forEach((node) => {
+    if (!node.data?.length) {
+      node.type = '__delete__';
+      return;
+    }
     let selectedOutput: { content_type: string; path: string; hash: string } | undefined;
     walkOutputs(node.data, (obj: any) => {
       if (selectedOutput || !obj.path || !obj.hash) return;
@@ -94,4 +99,5 @@ export function reduceOutputs(mdast: Root, writeFolder: string) {
       delete node.id;
     }
   });
+  remove(mdast, '__delete__');
 }

--- a/packages/myst-to-tex/src/container.ts
+++ b/packages/myst-to-tex/src/container.ts
@@ -123,7 +123,11 @@ export const captionHandler: Handler = (node, state) => {
   }
   state.ensureNewLine(true);
   const { nextCaptionNumbered: numbered, nextCaptionId: id } = state.data;
-  const command = numbered === false ? 'caption*' : 'caption';
+  // The square brackets here hold the "listoffigures" alternative figure description.
+  // This field is present because multi-paragraph captions will fail without
+  // this single paragraph alternative. For now, since we do not use "listoffigures"
+  // the square brackets are simply left empty. See https://tex.stackexchange.com/a/48313
+  const command = numbered === false ? 'caption[]*' : 'caption[]';
   const after = numbered && id ? `\\label{${id}}` : '';
   state.renderInlineEnvironment(node, command, { after });
 };

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -16,6 +16,7 @@ import {
 import MATH_HANDLERS, { withRecursiveCommands } from './math.js';
 import { selectAll } from 'unist-util-select';
 import type { FootnoteDefinition } from 'myst-spec-ext';
+import { transformLegends } from './legends.js';
 
 export type { LatexResult } from './types.js';
 
@@ -397,6 +398,7 @@ class TexSerializer implements ITexSerializer {
 
 const plugin: Plugin<[Options?], Root, VFile> = function (opts) {
   this.Compiler = (node, file) => {
+    transformLegends(node);
     const state = new TexSerializer(file, node, opts ?? { handlers });
     const tex = (file.result as string).trim();
     const result: LatexResult = {

--- a/packages/myst-to-tex/src/legends.ts
+++ b/packages/myst-to-tex/src/legends.ts
@@ -1,0 +1,25 @@
+import type { GenericNode } from 'myst-common';
+import type { Root } from 'myst-spec';
+import { remove } from 'unist-util-remove';
+import { selectAll } from 'unist-util-select';
+
+/**
+ * Consolidate all caption/legend nodes on a container to a single caption
+ */
+export function transformLegends(mdast: Root) {
+  const containers = selectAll('container', mdast) as GenericNode[];
+  containers.forEach((container: GenericNode) => {
+    const captionsAndLegends = container.children?.filter((child: GenericNode) => {
+      return child.type === 'caption' || child.type === 'legend';
+    });
+    if (!captionsAndLegends?.length) return;
+    captionsAndLegends[0].type = 'caption';
+    captionsAndLegends.slice(1).forEach((node) => {
+      if (captionsAndLegends[0].children && node.children) {
+        captionsAndLegends[0].children?.push(...node.children);
+      }
+      node.type = '__delete__';
+    });
+  });
+  remove(mdast, '__delete__');
+}

--- a/packages/myst-to-tex/tests/basic.yml
+++ b/packages/myst-to-tex/tests/basic.yml
@@ -98,7 +98,7 @@ cases:
       \begin{figure}[!htbp]
       \centering
       \includegraphics[width=0.625\linewidth]{https://example.com}
-      \caption{Some \% \textit{markdown}}
+      \caption[]{Some \% \textit{markdown}}
       \label{My-Fig}
       \end{figure}
   - title: list-table
@@ -229,7 +229,7 @@ cases:
     latex: |-
       \begin{table}
       \centering
-      \caption{My table!}
+      \caption[]{My table!}
       \label{ABC}
       \begin{tabular}{p{\dimexpr 0.250\linewidth-2\tabcolsep}p{\dimexpr 0.250\linewidth-2\tabcolsep}p{\dimexpr 0.250\linewidth-2\tabcolsep}p{\dimexpr 0.250\linewidth-2\tabcolsep}}
       \toprule


### PR DESCRIPTION
This PR resolves `unknown node type` errors during tex export for `legend` and `output`:

- For `output` - we usually simplify these nodes to other types renderable to tex (e.g. `text`, `image`). However, if the output has no `data`, it was left unchanged. Now, when we encounter these empty output nodes, they are simply removed during the simplification step.
- For `legend` - we now combine this with the corresponding `caption` node and pass it to tex as a multi-paragraph caption