### PR TITLE
📤 Put url/filename on project exports in site config

### DIFF
--- a/.changeset/loud-weeks-jam.md
+++ b/.changeset/loud-weeks-jam.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Add URLs to project-level exports in site config

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -6,6 +6,7 @@ import type { SiteAction, SiteManifest, SiteTemplateOptions } from 'myst-config'
 import { PROJECT_FRONTMATTER_KEYS, SITE_FRONTMATTER_KEYS } from 'myst-frontmatter';
 import type MystTemplate from 'myst-templates';
 import { filterKeys } from 'simple-validators';
+import { resolvePageExports } from '../../process/site.js';
 import type { ISession } from '../../session/types.js';
 import type { RootState } from '../../store/index.js';
 import { selectors } from '../../store/index.js';
@@ -71,6 +72,12 @@ export async function localToManifestProject(
   );
 
   const projFrontmatter = projConfig ? filterKeys(projConfig, PROJECT_FRONTMATTER_KEYS) : {};
+  const projConfigFile = selectors.selectLocalConfigFile(state, projectPath);
+  const exports = (await resolvePageExports(session, projConfigFile)).map(
+    ({ format, filename, url }) => {
+      return { format, filename, url };
+    },
+  );
   const banner = await transformBanner(
     session,
     path.join(projectPath, 'myst.yml'),
@@ -82,6 +89,7 @@ export async function localToManifestProject(
     ...projFrontmatter,
     banner: banner?.url,
     bannerOptimized: banner?.urlOptimized,
+    exports,
     bibliography: projFrontmatter.bibliography || [],
     title: projectTitle || 'Untitled',
     slug: projectSlug,

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -145,7 +145,7 @@ async function resolvePageSource(session: ISession, file: string) {
   return { format: extname(file).substring(1), filename: basename(file), url: `/${fileHash}` };
 }
 
-async function resolvePageExports(session: ISession, file: string) {
+export async function resolvePageExports(session: ISession, file: string) {
   const exports = (
     await collectExportOptions(
       session,

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -150,7 +150,13 @@ export async function resolvePageExports(session: ISession, file: string) {
     await collectExportOptions(
       session,
       [file],
-      [ExportFormats.docx, ExportFormats.pdf, ExportFormats.tex, ExportFormats.xml],
+      [
+        ExportFormats.docx,
+        ExportFormats.pdf,
+        ExportFormats.tex,
+        ExportFormats.xml,
+        ExportFormats.meca,
+      ],
       {},
     )
   )


### PR DESCRIPTION
Previously exports in the `config.json` site file were just copied straight from the original frontmatter. This pr updates the exports to include filename/url, like we do for page-level exports:

![image](https://github.com/executablebooks/mystmd/assets/9453731/4a614df7-4a9e-4c6d-bc21-8d7a69f764e2)
