### PR TITLE
🤐 Use adm-zip to unzip templates, not unzipper

### DIFF
--- a/.changeset/five-years-collect.md
+++ b/.changeset/five-years-collect.md
@@ -1,0 +1,5 @@
+---
+'myst-templates': patch
+---
+
+Download and unzip site templates, do not clone

--- a/.changeset/tall-bobcats-worry.md
+++ b/.changeset/tall-bobcats-worry.md
@@ -1,0 +1,7 @@
+---
+'myst-templates': patch
+'jats-to-myst': patch
+'jtex': patch
+---
+
+Use adm-zip to unzip templates, not unzipper

--- a/package-lock.json
+++ b/package-lock.json
@@ -1549,15 +1549,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
-    "node_modules/@types/unzipper": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/unzipper/-/unzipper-0.10.6.tgz",
-      "integrity": "sha512-zcBj329AHgKLQyz209N/S9R0GZqXSkUQO4tJSYE3x02qg4JuDFpgKMj50r82Erk1natCWQDIvSccDddt7jPzjA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/which": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.0.tgz",
@@ -2488,26 +2479,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -2538,11 +2509,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
     },
     "node_modules/blueimp-md5": {
       "version": "2.19.0",
@@ -2692,6 +2658,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2749,22 +2716,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-      "engines": {
-        "node": ">=0.2.0"
       }
     },
     "node_modules/bytes": {
@@ -2881,17 +2832,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-      "dependencies": {
-        "traverse": ">=0.3.0 <0.4"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -3271,7 +3211,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/concordance": {
       "version": "5.0.4",
@@ -3914,14 +3855,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
       }
     },
     "node_modules/eastasianwidth": {
@@ -5290,7 +5223,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -5303,31 +5237,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/fstream/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/function-bind": {
@@ -5436,6 +5345,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6078,6 +5988,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6930,11 +6841,6 @@
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
-    },
-    "node_modules/listenercount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -8019,6 +7925,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -8063,17 +7970,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mlly": {
@@ -8599,6 +8495,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8904,6 +8801,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10854,14 +10752,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "node_modules/traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -11465,23 +11355,6 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/unzipper": {
-      "version": "0.10.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
-      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
-      "dependencies": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
-        "graceful-fs": "^4.2.2",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "~1.0.4"
       }
     },
     "node_modules/uri-js": {
@@ -12120,7 +11993,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/ws": {
       "version": "8.13.0",
@@ -12253,7 +12127,7 @@
       "dependencies": {
         "doi-utils": "^2.0.0",
         "jats-tags": "^1.0.0",
-        "jats-xml": "^1.0.1",
+        "jats-xml": "^1.0.3",
         "myst-common": "^1.0.3",
         "myst-frontmatter": "^1.0.3",
         "myst-spec": "^0.0.4",
@@ -12276,19 +12150,19 @@
       }
     },
     "packages/jats-to-myst/node_modules/jats-xml": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jats-xml/-/jats-xml-1.0.2.tgz",
-      "integrity": "sha512-0Ed21q6fWW6KjBYmJwcVQTrLBapgFtx1wzNAmiaUnhNRgpg2M6sEFVJSPJ3/iOy/jToH9PSLaP7ks9sownN9EA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/jats-xml/-/jats-xml-1.0.3.tgz",
+      "integrity": "sha512-dtRjzMP04shbEuz8Wesn7zg3Oyq1Sco1Tw1D8/HBwAaul5x5K2xtcm8RTn3MN0PBFABCWKsZj4SBD5CwYSU64w==",
       "dependencies": {
+        "adm-zip": "^0.5.10",
         "doi-utils": "^2.0.0",
         "fair-principles": "^2.0.0",
-        "jats-tags": "^1.0.2",
+        "jats-tags": "^1.0.3",
         "js-yaml": "^4.1.0",
         "node-fetch": "^3.3.1",
         "unist-util-is": "^5.2.1",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.0",
-        "unzipper": "^0.10.14",
         "which": "^3.0.1",
         "xml-js": "^1.6.11"
       },
@@ -12304,6 +12178,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
+        "adm-zip": "^0.5.10",
         "chalk": "^5.2.0",
         "commander": "^10.0.1",
         "js-yaml": "^4.1.0",
@@ -12313,16 +12188,15 @@
         "node-fetch": "^3.3.1",
         "nunjucks": "^3.2.4",
         "pretty-hrtime": "^1.0.3",
-        "simple-validators": "^1.0.1",
-        "unzipper": "^0.10.14"
+        "simple-validators": "^1.0.1"
       },
       "bin": {
         "jtex": "dist/jtex.cjs"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.0",
         "@types/nunjucks": "^3.2.2",
         "@types/sanitize-html": "^2.9.0",
-        "@types/unzipper": "^0.10.6",
         "memfs": "^3.5.3"
       },
       "engines": {
@@ -12797,13 +12671,11 @@
         "myst-frontmatter": "^1.0.3",
         "node-fetch": "^3.3.1",
         "pretty-hrtime": "^1.0.3",
-        "simple-validators": "^1.0.1",
-        "unzipper": "^0.10.14"
+        "simple-validators": "^1.0.1"
       },
       "devDependencies": {
         "@types/nunjucks": "^3.2.2",
         "@types/sanitize-html": "^2.9.0",
-        "@types/unzipper": "^0.10.6",
         "memfs": "^3.5.3"
       }
     },

--- a/packages/jats-to-myst/package.json
+++ b/packages/jats-to-myst/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "doi-utils": "^2.0.0",
     "jats-tags": "^1.0.0",
-    "jats-xml": "^1.0.1",
+    "jats-xml": "^1.0.3",
     "myst-common": "^1.0.3",
     "myst-frontmatter": "^1.0.3",
     "myst-spec": "^0.0.4",

--- a/packages/jtex/package.json
+++ b/packages/jtex/package.json
@@ -44,6 +44,7 @@
     "npm": ">=6"
   },
   "dependencies": {
+    "adm-zip": "^0.5.10",
     "chalk": "^5.2.0",
     "commander": "^10.0.1",
     "js-yaml": "^4.1.0",
@@ -53,13 +54,12 @@
     "node-fetch": "^3.3.1",
     "nunjucks": "^3.2.4",
     "pretty-hrtime": "^1.0.3",
-    "simple-validators": "^1.0.1",
-    "unzipper": "^0.10.14"
+    "simple-validators": "^1.0.1"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.0",
     "@types/nunjucks": "^3.2.2",
     "@types/sanitize-html": "^2.9.0",
-    "@types/unzipper": "^0.10.6",
     "memfs": "^3.5.3"
   }
 }

--- a/packages/myst-templates/package.json
+++ b/packages/myst-templates/package.json
@@ -45,13 +45,11 @@
     "myst-frontmatter": "^1.0.3",
     "node-fetch": "^3.3.1",
     "pretty-hrtime": "^1.0.3",
-    "simple-validators": "^1.0.1",
-    "unzipper": "^0.10.14"
+    "simple-validators": "^1.0.1"
   },
   "devDependencies": {
     "@types/nunjucks": "^3.2.2",
     "@types/sanitize-html": "^2.9.0",
-    "@types/unzipper": "^0.10.6",
     "memfs": "^3.5.3"
   }
 }

--- a/packages/myst-templates/src/download.ts
+++ b/packages/myst-templates/src/download.ts
@@ -1,12 +1,12 @@
-import fs, { createReadStream, createWriteStream, mkdirSync } from 'node:fs';
+import fs, { createWriteStream, mkdirSync } from 'node:fs';
 import { dirname, join, parse } from 'node:path';
 import { createHash } from 'node:crypto';
+import AdmZip from 'adm-zip';
 import yaml from 'js-yaml';
 import { TemplateKind } from 'myst-common';
 import { createGitLogger, makeExecutable } from 'myst-cli-utils';
 import fetch from 'node-fetch';
 import { validateUrl } from 'simple-validators';
-import unzipper from 'unzipper';
 import type { TemplateYmlListResponse, TemplateYmlResponse, ISession } from './types.js';
 
 export const TEMPLATE_FILENAME = 'template.tex';
@@ -196,9 +196,9 @@ export async function downloadAndUnzipTemplate(
     fileStream.on('finish', resolve);
   });
   session.log.debug(`Unzipping template on disk ${zipFile}`);
-  await createReadStream(zipFile)
-    .pipe(unzipper.Extract({ path: templatePath }))
-    .promise();
+
+  const zip = new AdmZip(zipFile);
+  zip.extractAllTo(templatePath);
   unnestTemplate(templatePath);
 }
 


### PR DESCRIPTION
This should address https://github.com/myst-templates/docx_default/issues/1

Same change we made here: https://github.com/curvenote/jats/pull/19 

---

Also this switches site template download from `git clone` to admzip. Before we needed a clone in order to pick up submodules. Now, though, the templates are bundled nicely and can simply be downloaded. Hopefully fixes: https://github.com/executablebooks/mystmd/issues/209

Note - it would be good to update the myst-templates API to have zip urls for site templates, not git, but for now, we construct zip from git.