### PR TITLE
🚀 Typst export

### DIFF
--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -83,6 +83,7 @@
     "myst-to-jats": "^1.0.6",
     "myst-to-md": "^1.0.4",
     "myst-to-tex": "^1.0.3",
+    "myst-to-typst": "^0.0.1",
     "myst-transforms": "^1.0.4",
     "nanoid": "^4.0.0",
     "nbtx": "^0.2.3",

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -15,6 +15,7 @@ export type BuildOpts = {
   docx?: boolean;
   pdf?: boolean;
   tex?: boolean;
+  typst?: boolean;
   xml?: boolean;
   md?: boolean;
   meca?: boolean;
@@ -26,18 +27,19 @@ export type BuildOpts = {
 };
 
 export function hasAnyExplicitExportFormat(opts: BuildOpts): boolean {
-  const { docx, pdf, tex, xml, md, meca } = opts;
-  return docx || pdf || tex || xml || md || meca || false;
+  const { docx, pdf, tex, typst, xml, md, meca } = opts;
+  return docx || pdf || tex || typst || xml || md || meca || false;
 }
 
 export function getExportFormats(opts: BuildOpts & { explicit?: boolean; extension?: string }) {
-  const { docx, pdf, tex, xml, md, meca, all, explicit, extension } = opts;
+  const { docx, pdf, tex, typst, xml, md, meca, all, explicit, extension } = opts;
   const formats = [];
   const any = hasAnyExplicitExportFormat(opts);
   const override = all || (!any && explicit && !extension);
   if (docx || override || extension === '.docx') formats.push(ExportFormats.docx);
   if (pdf || override || extension === '.pdf') formats.push(ExportFormats.pdf);
   if (tex || override || extension === '.tex') formats.push(ExportFormats.tex);
+  if (typst || override || extension === '.typ') formats.push(ExportFormats.typst);
   if (xml || override || extension === '.xml') formats.push(ExportFormats.xml);
   if (md || override || extension === '.md') formats.push(ExportFormats.md);
   if (meca || override) formats.push(ExportFormats.meca);
@@ -45,10 +47,13 @@ export function getExportFormats(opts: BuildOpts & { explicit?: boolean; extensi
 }
 
 export function exportSite(session: ISession, opts: BuildOpts) {
-  const { docx, pdf, tex, xml, md, meca, force, site, html, all } = opts;
+  const { docx, pdf, tex, typst, xml, md, meca, force, site, html, all } = opts;
   const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());
   return (
-    site || html || all || (siteConfig && !force && !docx && !pdf && !tex && !xml && !md && !meca)
+    site ||
+    html ||
+    all ||
+    (siteConfig && !force && !docx && !pdf && !tex && !typst && !xml && !md && !meca)
   );
 }
 

--- a/packages/myst-cli/src/build/typst/index.ts
+++ b/packages/myst-cli/src/build/typst/index.ts
@@ -1,0 +1,1 @@
+export { localArticleToTypst } from './single.js';

--- a/packages/myst-cli/src/build/typst/single.ts
+++ b/packages/myst-cli/src/build/typst/single.ts
@@ -1,0 +1,303 @@
+import AdmZip from 'adm-zip';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { TemplateImports } from 'jtex';
+import { mergeTemplateImports } from 'jtex';
+import type { Root } from 'mdast';
+import { tic, writeFileToFolder } from 'myst-cli-utils';
+import type { References } from 'myst-common';
+import { extractPart, TemplateKind } from 'myst-common';
+import type { PageFrontmatter } from 'myst-frontmatter';
+import { ExportFormats } from 'myst-frontmatter';
+import type { TemplatePartDefinition, TemplateYml } from 'myst-templates';
+import MystTemplate from 'myst-templates';
+import mystToTypst from 'myst-to-typst';
+import type { TypstResult } from 'myst-to-typst';
+import type { LinkTransformer } from 'myst-transforms';
+import { unified } from 'unified';
+import { findCurrentProjectAndLoad } from '../../config.js';
+import { loadProjectFromDisk } from '../../project/index.js';
+import { castSession } from '../../session/index.js';
+import type { ISession } from '../../session/types.js';
+import { createTempFolder, ImageExtensions, logMessagesFromVFile } from '../../utils/index.js';
+import type { ExportWithOutput, ExportOptions, ExportResults } from '../types.js';
+import {
+  cleanOutput,
+  collectTexExportOptions,
+  getFileContent,
+  resolveAndLogErrors,
+} from '../utils/index.js';
+import version from '../../version.js';
+
+export const DEFAULT_BIB_FILENAME = 'main.bib';
+const TYPST_IMAGE_EXTENSIONS = [
+  ImageExtensions.pdf,
+  ImageExtensions.png,
+  ImageExtensions.jpg,
+  ImageExtensions.jpeg,
+];
+
+export function mdastToTypst(
+  session: ISession,
+  mdast: Root,
+  references: References,
+  frontmatter: PageFrontmatter,
+  templateYml: TemplateYml | null,
+) {
+  const pipe = unified().use(mystToTypst, {
+    math: frontmatter?.math,
+    citestyle: templateYml?.style?.citation,
+    bibliography: templateYml?.style?.bibliography,
+    references,
+  });
+  const result = pipe.runSync(mdast as any);
+  const tex = pipe.stringify(result);
+  logMessagesFromVFile(session, tex);
+  return tex.result as TypstResult;
+}
+
+export function extractTexPart(
+  session: ISession,
+  mdast: Root,
+  references: References,
+  partDefinition: TemplatePartDefinition,
+  frontmatter: PageFrontmatter,
+  templateYml: TemplateYml,
+): TypstResult | undefined {
+  const part = extractPart(mdast, partDefinition.id);
+  if (!part) return undefined;
+  const partContent = mdastToTypst(session, part, references, frontmatter, templateYml);
+  return partContent;
+}
+
+export async function localArticleToTexRaw(
+  session: ISession,
+  templateOptions: ExportWithOutput,
+  projectPath?: string,
+  extraLinkTransformers?: LinkTransformer[],
+): Promise<ExportResults> {
+  const { article, output } = templateOptions;
+  const [{ mdast, frontmatter, references }] = await getFileContent(
+    session,
+    [article],
+    path.join(path.dirname(output), 'files'),
+    {
+      projectPath,
+      imageAltOutputFolder: 'files/',
+      imageExtensions: TYPST_IMAGE_EXTENSIONS,
+      extraLinkTransformers,
+      simplifyFigures: true,
+    },
+  );
+  const toc = tic();
+  const result = mdastToTypst(session, mdast, references, frontmatter, null);
+  session.log.info(toc(`📑 Exported TeX in %s, copying to ${output}`));
+  // TODO: add imports and macros?
+  writeFileToFolder(output, result.value);
+  return { tempFolders: [] };
+}
+
+function writeBibtexFromCitationRenderers(session: ISession, output: string) {
+  const cache = castSession(session);
+  const allBibtexContent = Object.values(cache.$citationRenderers)
+    .map((renderers) => {
+      return Object.values(renderers).map((renderer) => {
+        const bibtexContent = (renderer.cite._graph as any[]).find((item) => {
+          return item.type === '@biblatex/text';
+        });
+        return bibtexContent?.data;
+      });
+    })
+    .flat()
+    .filter((item) => !!item);
+  const bibtexContent = [...new Set(allBibtexContent)].join('\n');
+  if (!fs.existsSync(output)) fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, bibtexContent);
+}
+
+export async function localArticleToTexTemplated(
+  session: ISession,
+  file: string,
+  templateOptions: ExportWithOutput,
+  projectPath?: string,
+  force?: boolean,
+  extraLinkTransformers?: LinkTransformer[],
+): Promise<ExportResults> {
+  const filesPath = path.join(path.dirname(templateOptions.output), 'files');
+  const [{ frontmatter, mdast, references }] = await getFileContent(
+    session,
+    [templateOptions.article],
+    filesPath,
+    {
+      projectPath,
+      imageAltOutputFolder: 'files/',
+      imageExtensions: TYPST_IMAGE_EXTENSIONS,
+      extraLinkTransformers,
+      simplifyFigures: true,
+    },
+  );
+  writeBibtexFromCitationRenderers(
+    session,
+    path.join(path.dirname(templateOptions.output), DEFAULT_BIB_FILENAME),
+  );
+
+  const mystTemplate = new MystTemplate(session, {
+    kind: TemplateKind.tex,
+    template: templateOptions.template || undefined,
+    buildDir: session.buildPath(),
+  });
+  await mystTemplate.ensureTemplateExistsOnPath();
+  const toc = tic();
+  const templateYml = mystTemplate.getValidatedTemplateYml();
+
+  const partDefinitions = templateYml?.parts || [];
+  const parts: Record<string, string> = {};
+  let collectedImports: TemplateImports = { imports: [], commands: {} };
+  partDefinitions.forEach((def) => {
+    const result = extractTexPart(session, mdast, references, def, frontmatter, templateYml);
+    if (result != null) {
+      collectedImports = mergeTemplateImports(collectedImports, result);
+      parts[def.id] = result?.value ?? '';
+    }
+  });
+
+  // prune mdast based on tags, if required by template, eg abstract, acknowledgements
+  // Need to load up template yaml - returned from jtex, with 'parts' dict
+  // This probably means we need to store tags alongside oxa link for blocks
+  // This will need opts eventually --v
+  const result = mdastToTypst(session, mdast, references, frontmatter, templateYml);
+  // Fill in template
+  session.log.info(toc(`📑 Exported typst in %s, copying to ${templateOptions.output}`));
+  // Have a better template!
+  const importStatements: string[] = [];
+  if (result.macros.length > 0) {
+    const mystTypst = path.join(path.dirname(templateOptions.output), 'myst.typ');
+    importStatements.push('#import "myst.typ": *');
+    writeFileToFolder(mystTypst, result.macros.join('\n\n'));
+  }
+  importStatements.push('#set math.equation(numbering: "(1)")');
+  if (Object.keys(result.commands).length > 0) {
+    importStatements.push('', '/* Math Macros */');
+    Object.entries(result.commands).forEach(([k, v]) => {
+      // Won't work for math with args
+      importStatements.push(`#let ${k} = $${v.trim()}$`);
+    });
+  }
+  const bib = `
+
+
+#show bibliography: set text(8pt)
+#bibliography("${DEFAULT_BIB_FILENAME}", title: text(10pt)[References], style: "ieee")`;
+  const typst = `/* Written by MyST v${version} */\n\n${importStatements.join('\n')}\n\n${
+    result.value
+  }${bib}`;
+  writeFileToFolder(templateOptions.output, typst);
+  // renderTex(mystTemplate, {
+  //   contentOrPath: result.value,
+  //   outputPath: templateOptions.output,
+  //   frontmatter,
+  //   parts,
+  //   options: templateOptions,
+  //   bibliography: [DEFAULT_BIB_FILENAME],
+  //   sourceFile: file,
+  //   imports: mergeTemplateImports(collectedImports, result),
+  //   force,
+  //   packages: templateYml.packages,
+  //   filesPath,
+  // });
+  return { tempFolders: [] };
+}
+
+export async function runTypstExport(
+  session: ISession,
+  file: string,
+  exportOptions: ExportWithOutput,
+  projectPath?: string,
+  clean?: boolean,
+  extraLinkTransformers?: LinkTransformer[],
+): Promise<ExportResults> {
+  if (clean) cleanOutput(session, exportOptions.output);
+  let result: ExportResults;
+  if (exportOptions.template === null) {
+    result = await localArticleToTexRaw(session, exportOptions, projectPath, extraLinkTransformers);
+  } else {
+    result = await localArticleToTexTemplated(
+      session,
+      file,
+      exportOptions,
+      projectPath,
+      clean,
+      extraLinkTransformers,
+    );
+  }
+  return result;
+}
+
+export async function runTypstZipExport(
+  session: ISession,
+  file: string,
+  exportOptions: ExportWithOutput,
+  projectPath?: string,
+  clean?: boolean,
+  extraLinkTransformers?: LinkTransformer[],
+): Promise<ExportResults> {
+  if (clean) cleanOutput(session, exportOptions.output);
+  const zipOutput = exportOptions.output;
+  const texFolder = createTempFolder(session);
+  exportOptions.output = path.join(
+    texFolder,
+    `${path.basename(zipOutput, path.extname(zipOutput))}.tex`,
+  );
+  await runTypstExport(session, file, exportOptions, projectPath, false, extraLinkTransformers);
+  session.log.info(`🤐 Zipping tex outputs to ${zipOutput}`);
+  const zip = new AdmZip();
+  zip.addLocalFolder(texFolder);
+  zip.writeZip(zipOutput);
+  return { tempFolders: [texFolder] };
+}
+
+export async function localArticleToTypst(
+  session: ISession,
+  file: string,
+  opts: ExportOptions,
+  templateOptions?: Record<string, any>,
+  extraLinkTransformers?: LinkTransformer[],
+): Promise<ExportResults> {
+  let { projectPath } = opts;
+  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
+  if (projectPath) await loadProjectFromDisk(session, projectPath);
+  const exportOptionsList = (
+    await collectTexExportOptions(session, file, 'typ', [ExportFormats.typst], projectPath, opts)
+  ).map((exportOptions) => {
+    return { ...exportOptions, ...templateOptions };
+  });
+  const results: ExportResults = { tempFolders: [] };
+  await resolveAndLogErrors(
+    session,
+    exportOptionsList.map(async (exportOptions) => {
+      let exportResults: ExportResults;
+      if (path.extname(exportOptions.output) === '.zip') {
+        exportResults = await runTypstZipExport(
+          session,
+          file,
+          exportOptions,
+          projectPath,
+          opts.clean,
+          extraLinkTransformers,
+        );
+      } else {
+        exportResults = await runTypstExport(
+          session,
+          file,
+          exportOptions,
+          projectPath,
+          opts.clean,
+          extraLinkTransformers,
+        );
+      }
+      results.tempFolders.push(...exportResults.tempFolders);
+    }),
+    opts.throwOnFailure,
+  );
+  return results;
+}

--- a/packages/myst-cli/src/build/utils/collectExportOptions.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.ts
@@ -119,7 +119,11 @@ function getOutput(
       session,
       sourceFile,
       projectPath,
-      formats.includes(ExportFormats.tex) ? 'tex' : undefined,
+      formats.includes(ExportFormats.tex)
+        ? 'tex'
+        : formats.includes(ExportFormats.typst)
+        ? 'typ'
+        : undefined,
     );
   }
   if (!path.extname(output)) {
@@ -151,7 +155,8 @@ export async function collectTexExportOptions(
   const resolvedExportOptions: ExportWithOutput[] = filterAndMakeUnique(
     exportOptions.map((exp): ExportWithOutput | undefined => {
       const rawOutput = filename || exp.output || '';
-      const useZip = extension === 'tex' && (zip || path.extname(rawOutput) === '.zip');
+      const useZip =
+        (extension === 'tex' || extension === 'typ') && (zip || path.extname(rawOutput) === '.zip');
       const expExtension = useZip ? 'zip' : extension;
       const output = getOutput(
         session,
@@ -296,6 +301,18 @@ export async function collectExportOptions(
             file,
             'tex',
             [ExportFormats.tex],
+            fileProjectPath,
+            opts,
+          )),
+        );
+      }
+      if (formats.includes(ExportFormats.typst)) {
+        fileExportOptionsList.push(
+          ...(await collectTexExportOptions(
+            session,
+            file,
+            'typ',
+            [ExportFormats.typst],
             fileProjectPath,
             opts,
           )),

--- a/packages/myst-cli/src/build/utils/defaultNames.ts
+++ b/packages/myst-cli/src/build/utils/defaultNames.ts
@@ -30,10 +30,11 @@ export function getDefaultExportFolder(
   session: ISession,
   file: string,
   projectPath?: string,
-  ext?: 'tex',
+  ext?: 'tex' | 'typ',
 ) {
   const subpaths = [projectPath || path.parse(file).dir, '_build', 'exports'];
   // Extra folder for tex export content
   if (ext === 'tex') subpaths.push(`${getDefaultExportFilename(session, file, projectPath)}_tex`);
+  if (ext === 'typ') subpaths.push(`${getDefaultExportFilename(session, file, projectPath)}_typst`);
   return path.join(...subpaths);
 }

--- a/packages/myst-cli/src/build/utils/localArticleExport.ts
+++ b/packages/myst-cli/src/build/utils/localArticleExport.ts
@@ -12,6 +12,7 @@ import { texExportOptionsFromPdf } from '../pdf/single.js';
 import { createPdfGivenTexExport } from '../pdf/create.js';
 import { runMecaExport } from '../meca/index.js';
 import { runMdExport } from '../md/index.js';
+import { runTypstExport, runTypstZipExport } from '../typst/single.js';
 
 async function _localArticleExport(
   session: ISession,
@@ -37,6 +38,12 @@ async function _localArticleExport(
           await runTexZipExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
         } else {
           await runTexExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
+        }
+      } else if (format === ExportFormats.typst) {
+        if (path.extname(output) === '.zip') {
+          await runTypstZipExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
+        } else {
+          await runTypstExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
         }
       } else if (format === ExportFormats.docx) {
         await runWordExport(sessionClone, $file, exportOptions, fileProjectPath, clean);

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -102,6 +102,7 @@ export type KernelSpec = {
 export enum ExportFormats {
   pdf = 'pdf',
   tex = 'tex',
+  typst = 'typst',
   pdftex = 'pdf+tex',
   docx = 'docx',
   xml = 'xml',

--- a/packages/myst-to-typst/.eslintrc.cjs
+++ b/packages/myst-to-typst/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['curvenote'],
+};

--- a/packages/myst-to-typst/CHANGELOG.md
+++ b/packages/myst-to-typst/CHANGELOG.md
@@ -1,0 +1,1 @@
+# myst-to-typst

--- a/packages/myst-to-typst/README.md
+++ b/packages/myst-to-typst/README.md
@@ -1,0 +1,3 @@
+# myst-to-Typst
+
+Convert a MyST AST to Typst.

--- a/packages/myst-to-typst/package.json
+++ b/packages/myst-to-typst/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "myst-to-typst",
+  "version": "0.0.1",
+  "description": "Export from MyST mdast to Typst",
+  "author": "Rowan Cockett <rowan@curvenote.com>",
+  "homepage": "https://github.com/executablebooks/mystmd/tree/main/packages/myst-to-tex",
+  "license": "MIT",
+  "type": "module",
+  "exports": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "keywords": [
+    "myst-plugin",
+    "tex",
+    "latex"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/executablebooks/mystmd.git"
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "lint": "eslint \"src/**/*.ts\" -c .eslintrc.cjs --max-warnings 1",
+    "lint:format": "prettier --check src/*.ts src/**/*.ts",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "build:esm": "tsc --project ./tsconfig.json --module es2015 --outDir dist --declaration",
+    "build": "npm-run-all -l clean -p build:esm"
+  },
+  "bugs": {
+    "url": "https://github.com/executablebooks/mystmd/issues"
+  },
+  "dependencies": {
+    "myst-common": "^1.0.2",
+    "myst-frontmatter": "^1.0.2",
+    "myst-spec-ext": "^1.0.2",
+    "tex-to-typst": "^0.0.1",
+    "unist-util-select": "^4.0.3",
+    "vfile-reporter": "^7.0.4"
+  }
+}

--- a/packages/myst-to-typst/src/container.spec.ts
+++ b/packages/myst-to-typst/src/container.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { CaptionKind, determineCaptionKind } from './container';
+
+describe('determineCaptionKind', () => {
+  it('iframe -> figure', () => {
+    const node = {
+      type: 'iframe',
+    };
+    expect(determineCaptionKind(node)).toEqual(CaptionKind.fig);
+  });
+  it('container[table] -> table', () => {
+    const node = {
+      type: 'container',
+      children: [{ type: 'table' }],
+    };
+    expect(determineCaptionKind(node)).toEqual(CaptionKind.table);
+  });
+  it('container[embed[block[text]]] -> null', () => {
+    const node = {
+      type: 'container',
+      children: [{ type: 'embed', children: [{ type: 'block', children: [{ type: 'text' }] }] }],
+    };
+    expect(determineCaptionKind(node)).toEqual(null);
+  });
+});

--- a/packages/myst-to-typst/src/container.ts
+++ b/packages/myst-to-typst/src/container.ts
@@ -1,0 +1,70 @@
+import { fileError, type GenericNode } from 'myst-common';
+import type { Image, Table, Code, Math } from 'myst-spec';
+import { select } from 'unist-util-select';
+import { getColumnWidths } from './tables.js';
+import type { Handler } from './types.js';
+
+export enum CaptionKind {
+  fig = 'fig',
+  eq = 'eq',
+  code = 'code',
+  table = 'table',
+}
+
+function switchKind(node: Image | Table | Code | Math) {
+  switch (node.type as string) {
+    case 'iframe':
+    case 'image':
+      return CaptionKind.fig;
+    case 'table':
+      return CaptionKind.table;
+    case 'code':
+      return CaptionKind.code;
+    case 'math':
+      return CaptionKind.eq;
+    default:
+      return null;
+  }
+}
+
+export function determineCaptionKind(node: GenericNode): CaptionKind | null {
+  let kind = switchKind(node as any);
+  node.children?.forEach((n) => {
+    if (!kind) kind = determineCaptionKind(n);
+  });
+  return kind;
+}
+
+export const containerHandler: Handler = (node, state) => {
+  state.ensureNewLine();
+  const prevState = state.data.isInFigure;
+  state.data.isInFigure = true;
+  const { label } = node;
+  const caption = select('caption', node);
+  const image = select('image', node);
+  if (!image) {
+    fileError(state.file, `Figure only supports image children at the moment!`, {
+      node,
+      source: 'myst-to-typst',
+    });
+    return;
+  }
+  state.write('#figure(\n  ');
+  state.renderChildren({ children: [image] }, true);
+  state.trimEnd();
+  state.write(',');
+  if (caption) {
+    state.write('\n  caption: [');
+    state.renderChildren(caption, true);
+    state.trimEnd();
+    state.write('],');
+  }
+  state.write('\n)');
+  if (label) state.write(` <${label}>`);
+  state.closeBlock(node);
+  state.data.isInFigure = prevState;
+};
+
+export const captionHandler: Handler = () => {
+  // blank
+};

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -1,0 +1,405 @@
+import type { Root, Parent, Code } from 'myst-spec';
+import type { Plugin } from 'unified';
+import type { VFile } from 'vfile';
+import type { References } from 'myst-common';
+import { fileError, toText } from 'myst-common';
+import { captionHandler, containerHandler } from './container.js';
+import { renderNodeToLatex } from './tables.js';
+import type { Handler, ITexSerializer, TypstResult, Options, StateData } from './types.js';
+import {
+  getLatexImageWidth,
+  hrefToLatexText,
+  nodeOnlyHasTextChildren,
+  stringToLatexMath,
+  stringToLatexText,
+} from './utils.js';
+import MATH_HANDLERS, { withRecursiveCommands } from './math.js';
+import { select, selectAll } from 'unist-util-select';
+import type { Admonition, FootnoteDefinition } from 'myst-spec-ext';
+
+export type { TypstResult } from './types.js';
+
+const admonition = `#let admonition(body, heading: none, color: blue) = {
+  let stroke = (left: 2pt + color.darken(20%))
+  let fill = color.lighten(80%)
+  let title
+  if heading != none {
+    title = block(width: 100%, inset: (x: 8pt, y: 4pt), fill: fill, below: 0pt, radius: (top-right: 2pt))[#text(11pt, weight: "bold")[#heading]]
+  }
+  block(width: 100%, stroke: stroke, [
+    #title
+  #block(fill: luma(240), width: 100%, inset: 8pt, radius: (bottom-right: 2pt))[#body]
+])
+}`;
+const admonitionMacros = {
+  attention:
+    '#let attentionBlock(body, heading: [Attention]) = admonition(body, heading: heading, color: yellow)',
+  caution:
+    '#let cautionBlock(body, heading: [Caution]) = admonition(body, heading: heading, color: yellow)',
+  danger:
+    '#let dangerBlock(body, heading: [Danger]) = admonition(body, heading: heading, color: red)',
+  error: '#let errorBlock(body, heading: [Error]) = admonition(body, heading: heading, color: red)',
+  hint: '#let hintBlock(body, heading: [Hint]) = admonition(body, heading: heading, color: green)',
+  important:
+    '#let importantBlock(body, heading: [Important]) = admonition(body, heading: heading, color: blue)',
+  note: '#let noteBlock(body, heading: [Note]) = admonition(body, heading: heading, color: blue)',
+  seealso:
+    '#let seealsoBlock(body, heading: [See Also]) = admonition(body, heading: heading, color: green)',
+  tip: '#let tipBlock(body, heading: [Tip]) = admonition(body, heading: heading, color: green)',
+  warning:
+    '#let warningBlock(body, heading: [Warning]) = admonition(body, heading: heading, color: yellow)',
+};
+
+const blockquote = `#let blockquote(node, color: gray) = {
+  let stroke = (left: 2pt + color.darken(20%))
+  set text(fill: black.lighten(40%), style: "oblique")
+  block(width: 100%, inset: 8pt, stroke: stroke)[#node]
+}`;
+
+const INDENT = '  ';
+
+const handlers: Record<string, Handler> = {
+  text(node, state) {
+    state.text(node.value);
+  },
+  paragraph(node, state) {
+    state.renderChildren(node);
+  },
+  heading(node, state) {
+    const { depth, identifier, enumerated } = node;
+    state.write(`${Array(depth).fill('=').join('')} `);
+    state.renderChildren(node, true);
+    if (enumerated !== false && identifier) {
+      state.write(` <${identifier}>`);
+    }
+    state.closeBlock(node);
+  },
+  block(node, state) {
+    state.renderChildren(node, false);
+  },
+  blockquote(node, state) {
+    state.useMacro(blockquote);
+    state.renderEnvironment(node, 'blockquote');
+  },
+  definitionList(node, state) {
+    state.renderChildren(node, true);
+    state.closeBlock(node);
+  },
+  definitionTerm(node, state) {
+    state.ensureNewLine();
+    state.write('/ ');
+    state.renderChildren(node, true);
+    state.trimEnd();
+    state.write(': ');
+  },
+  definitionDescription(node, state) {
+    state.renderChildren(node, true);
+    state.trimEnd();
+  },
+  code(node: Code, state) {
+    const start = `\`\`\`${node.lang ?? ''}\n`;
+    const end = '\n```';
+    state.write(start);
+    state.text(node.value, true);
+    state.write(end);
+    state.closeBlock(node);
+  },
+  list(node, state) {
+    state.data.list ??= { env: [] };
+    state.data.list.env.push(node.ordered ? '+' : '-');
+    state.renderChildren(node);
+    state.data.list.env.pop();
+  },
+  listItem(node, state) {
+    const listEnv = state.data.list?.env ?? [];
+    const tabs = Array(Math.max(listEnv.length - 1, 0))
+      .fill(INDENT)
+      .join('');
+    const env = listEnv.slice(-1)[0] ?? '-';
+    state.ensureNewLine();
+    state.write(`${tabs}${env} `);
+    state.renderChildren(node, true);
+    state.write('\n');
+  },
+  thematicBreak(node, state) {
+    state.write('\n\\bigskip\n\\centerline{\\rule{13cm}{0.4pt}}\n\\bigskip');
+    state.closeBlock(node);
+  },
+  ...MATH_HANDLERS,
+  mystRole(node, state) {
+    state.renderChildren(node, true);
+  },
+  mystDirective(node, state) {
+    state.renderChildren(node, false);
+  },
+  comment(node, state) {
+    state.ensureNewLine();
+    if (node.value?.includes('\n')) {
+      state.write(`/*\n${node.value}\n*/`);
+    } else {
+      state.write(`// ${node.value ?? ''}`);
+    }
+    state.closeBlock(node);
+  },
+  strong(node, state) {
+    if (nodeOnlyHasTextChildren(node)) {
+      state.write('*');
+      state.renderChildren(node, true);
+      state.write('*');
+    } else {
+      state.renderInlineEnvironment(node, 'strong');
+    }
+  },
+  emphasis(node, state) {
+    if (nodeOnlyHasTextChildren(node)) {
+      state.write('_');
+      state.renderChildren(node, true);
+      state.write('_');
+    } else {
+      state.renderInlineEnvironment(node, 'emph');
+    }
+  },
+  underline(node, state) {
+    state.renderInlineEnvironment(node, 'underline');
+  },
+  inlineCode(node, state) {
+    state.write('`');
+    state.text(node.value, false);
+    state.write('`');
+  },
+  subscript(node, state) {
+    state.renderInlineEnvironment(node, 'sub');
+  },
+  superscript(node, state) {
+    state.renderInlineEnvironment(node, 'super');
+  },
+  delete(node, state) {
+    state.renderInlineEnvironment(node, 'strike');
+  },
+  break(node, state) {
+    state.write(' \\');
+    state.ensureNewLine();
+  },
+  abbreviation(node, state) {
+    // TODO: \newacronym{gcd}{GCD}{Greatest Common Divisor}
+    // https://www.overleaf.com/learn/latex/glossaries
+    state.renderChildren(node, true);
+  },
+  link(node, state) {
+    const href = node.url;
+    state.write('#link("');
+    state.write(hrefToLatexText(href));
+    state.write('")');
+    if (node.children[0]?.value !== href) {
+      state.write('[');
+      state.renderChildren(node, true);
+      state.write(']');
+    }
+  },
+  admonition(node: Admonition, state) {
+    state.useMacro(admonition);
+    state.ensureNewLine();
+    const title = select('admonitionTitle', node);
+    if (!node.kind) {
+      fileError(state.file, `Unknown admonition kind`, {
+        node,
+        source: 'myst-to-typst',
+      });
+      return;
+    }
+    state.useMacro(admonitionMacros[node.kind]);
+    state.write(`#${node.kind}Block`);
+    if (title && toText(title).toLowerCase().replace(' ', '') !== node.kind) {
+      state.write('(heading: [');
+      state.renderChildren(title);
+      state.trimEnd();
+      state.write('])');
+    }
+    state.write('[\n');
+    state.renderChildren(node);
+    state.trimEnd();
+    state.write('\n]');
+    state.closeBlock(node);
+  },
+  admonitionTitle() {
+    return;
+  },
+  table: renderNodeToLatex,
+  image(node, state) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { width: nodeWidth, url: nodeSrc, align } = node;
+    const src = nodeSrc;
+    const width = getLatexImageWidth(nodeWidth);
+    const command = state.data.isInFigure ? 'image' : '#image';
+    state.write(`${command}("${src}", width: ${width})`);
+    state.closeBlock(node);
+  },
+  container: containerHandler,
+  caption: captionHandler,
+  captionNumber: () => undefined,
+  crossReference(node, state) {
+    // Look up reference and add the text
+    // const usedTemplate = node.template?.includes('%s') ? node.template : undefined;
+    // const text = (usedTemplate ?? toText(node))?.replace(/\s/g, '~') || '%s';
+    const id = node.identifier;
+    // state.write(text.replace(/%s/g, `@${id}`));
+    state.write(`@${id}`);
+  },
+  citeGroup(node, state) {
+    state.write('#cite(');
+    state.renderChildren(node, true, ', ');
+    state.write(')');
+  },
+  cite(node, state, parent) {
+    if (parent.type === 'citeGroup') {
+      state.write(`"${node.label}"`);
+    } else {
+      state.write(`@${node.label}`);
+    }
+  },
+  embed(node, state) {
+    state.renderChildren(node, true);
+  },
+  include(node, state) {
+    state.renderChildren(node, true);
+  },
+  footnoteReference(node, state) {
+    if (!node.identifier) return;
+    const footnote = state.footnotes[node.identifier];
+    if (!footnote) {
+      fileError(state.file, `Unknown footnote identifier "${node.identifier}"`, {
+        node,
+        source: 'myst-to-typst',
+      });
+      return;
+    }
+    state.write('#footnote[');
+    state.renderChildren(footnote, true);
+    state.trimEnd();
+    state.write(']');
+  },
+  si(node, state) {
+    // state.useMacro('siunitx');
+    if (node.number == null) {
+      state.write(`\\unit{${node.units?.map((u: string) => `\\${u}`).join('') ?? ''}}`);
+    } else {
+      state.write(
+        `\\qty{${node.number}}{${node.units?.map((u: string) => `\\${u}`).join('') ?? ''}}`,
+      );
+    }
+  },
+};
+
+class TexSerializer implements ITexSerializer {
+  file: VFile;
+  data: StateData;
+  options: Options;
+  handlers: Record<string, Handler>;
+  references: References;
+  footnotes: Record<string, FootnoteDefinition>;
+
+  constructor(file: VFile, tree: Root, opts?: Options) {
+    file.result = '';
+    this.file = file;
+    this.options = opts ?? {};
+    this.data = { mathPlugins: {}, macros: new Set() };
+    this.handlers = opts?.handlers ?? handlers;
+    this.references = opts?.references ?? {};
+    this.footnotes = Object.fromEntries(
+      selectAll('footnoteDefinition', tree).map((node) => {
+        const fn = node as FootnoteDefinition;
+        return [fn.identifier, fn];
+      }),
+    );
+    this.renderChildren(tree);
+  }
+
+  get out(): string {
+    return this.file.result as string;
+  }
+
+  useMacro(macro: string) {
+    this.data.macros.add(macro);
+  }
+
+  write(value: string) {
+    this.file.result += value;
+  }
+
+  text(value: string, mathMode = false) {
+    const escaped = mathMode ? stringToLatexMath(value) : stringToLatexText(value);
+    this.write(escaped);
+  }
+
+  trimEnd() {
+    this.file.result = this.out.trimEnd();
+  }
+
+  ensureNewLine(trim = false) {
+    if (trim) this.trimEnd();
+    if (this.out.endsWith('\n')) return;
+    this.write('\n');
+  }
+
+  renderChildren(node: Partial<Parent>, inline = false, delim = '') {
+    const numChildren = node.children?.length ?? 0;
+    node.children?.forEach((child, index) => {
+      if (!child) return;
+      const handler = this.handlers[child?.type];
+      if (handler) {
+        handler(child, this, node);
+      } else {
+        fileError(this.file, `Unhandled Typst conversion for node of "${child?.type}"`, {
+          node: child,
+          source: 'myst-to-typst',
+        });
+      }
+      if (delim && index + 1 < numChildren) this.write(delim);
+    });
+    if (!inline) this.closeBlock(node);
+  }
+
+  renderEnvironment(node: any, env: string, opts?: { parameters?: string; arguments?: string[] }) {
+    // const optsInBrackets = opts?.parameters ? `[${opts.parameters}]` : '';
+    // const optsInBraces = opts?.arguments ? `{${opts.arguments.join('}{')}}` : '';
+    this.file.result += `#${env}[\n`;
+    this.renderChildren(node, true);
+    this.trimEnd();
+    this.file.result += `\n]`;
+    this.closeBlock(node);
+  }
+
+  renderInlineEnvironment(node: any, env: string) {
+    this.file.result += `#${env}[`;
+    this.renderChildren(node, true);
+    this.trimEnd();
+    this.file.result += ']';
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  closeBlock(node: any) {
+    this.ensureNewLine(true);
+    this.file.result += '\n';
+  }
+}
+
+const plugin: Plugin<[Options?], Root, VFile> = function (opts) {
+  this.Compiler = (node, file) => {
+    const state = new TexSerializer(file, node, opts ?? { handlers });
+    const tex = (file.result as string).trim();
+    const result: TypstResult = {
+      macros: [...state.data.macros],
+      commands: withRecursiveCommands(state),
+      value: tex,
+    };
+    file.result = result;
+    return file;
+  };
+
+  return (node: Root) => {
+    // Preprocess
+    return node;
+  };
+};
+
+export default plugin;

--- a/packages/myst-to-typst/src/math.ts
+++ b/packages/myst-to-typst/src/math.ts
@@ -1,0 +1,61 @@
+import { texToTypst } from 'tex-to-typst';
+import type { Handler, ITexSerializer } from './types.js';
+
+function addMacrosToState(value: string, state: ITexSerializer) {
+  if (!state.options.math) return;
+  Object.entries(state.options.math).forEach(([k, v]) => {
+    const key = texToTypst(k);
+    if (value.includes(key)) state.data.mathPlugins[key] = texToTypst(v);
+  });
+}
+
+type MathPlugins = ITexSerializer['data']['mathPlugins'];
+
+/**
+ * Add any required recursive commands found, for example,
+ * if only `\aMat` was included in the content, but sill requires other commands:
+ *
+ * ```javascript
+ * {
+ *    '\aNrm': "a",
+ *    '\aMat': '[\mathrm{\aNrm}]',
+ * }
+ * ```
+ */
+export function withRecursiveCommands(
+  state: ITexSerializer,
+  plugins = state.data.mathPlugins,
+): MathPlugins {
+  if (!state.options.math) return plugins;
+  const pluginsList = Object.entries(plugins);
+  const addedPlugins: MathPlugins = {};
+  Object.entries(state.options.math).forEach(([k, v]) => {
+    const key = texToTypst(k);
+    if (plugins[key]) return;
+    pluginsList.forEach(([, value]) => {
+      if (value.includes(key)) addedPlugins[key] = texToTypst(v);
+    });
+  });
+  const newPlugins = { ...addedPlugins, ...plugins };
+  if (Object.keys(addedPlugins).length === 0) return newPlugins;
+  return withRecursiveCommands(state, newPlugins);
+}
+
+const math: Handler = (node, state) => {
+  const value = texToTypst(node.value);
+  addMacrosToState(value, state);
+  state.ensureNewLine();
+  // Note: must have spaces $ math $ for the block!
+  state.write(`$ ${value} $${node.label ? ` <${node.label}>` : ''}\n\n`);
+  state.closeBlock(node);
+};
+
+const inlineMath: Handler = (node, state) => {
+  const value = texToTypst(node.value);
+  addMacrosToState(value, state);
+  state.write(`$${value}$`);
+};
+
+const MATH_HANDLERS = { math, inlineMath };
+
+export default MATH_HANDLERS;

--- a/packages/myst-to-typst/src/tables.ts
+++ b/packages/myst-to-typst/src/tables.ts
@@ -1,0 +1,196 @@
+import type { Table, TableRow, TableCell as SpecTableCell } from 'myst-spec';
+import type { ITexSerializer } from './types.js';
+
+export const TOTAL_TABLE_WIDTH = 886;
+
+type TableCell = SpecTableCell & { colspan?: number; width?: number };
+
+export function renderPColumn(width: number) {
+  if (width === 1) return `p{\\dimexpr \\linewidth-2\\tabcolsep}`;
+  return `p{\\dimexpr ${width.toFixed(3)}\\linewidth-2\\tabcolsep}`;
+}
+
+/**
+ * given a table node, return the column widths
+ *
+ * @param node  - node.type.name === 'table'
+ * @returns
+ */
+export function getColumnWidths(node: Table) {
+  // TODO: unsure about rowspans
+  let bestMaybeWidths: number[] = [];
+  let mostNonNulls = 0;
+  for (let i = 0; i < node.children.length; i += 1) {
+    const row = node.children[i] as TableRow;
+    const maybeWidths = row.children.reduce((acc: number[], cell: TableCell) => {
+      const colwidth = new Array(cell.colspan ?? 1).fill(
+        cell.width ? cell.width / (cell.colspan ?? 1) : null,
+      );
+      return [...acc, ...colwidth];
+    }, []);
+    const nonNulls = maybeWidths.filter((maybeWidth: number) => maybeWidth > 0).length;
+    if (i === 0 || nonNulls >= mostNonNulls) {
+      mostNonNulls = nonNulls;
+      bestMaybeWidths = maybeWidths;
+      if (mostNonNulls === maybeWidths.length) {
+        break;
+      }
+    }
+  }
+
+  let widths;
+  if (mostNonNulls === bestMaybeWidths.length) {
+    widths = bestMaybeWidths;
+  } else {
+    // need to fill in the null colwidths
+    const totalDefinedWidths = bestMaybeWidths.reduce(
+      (acc: number, cur: number | null) => (cur == null ? acc : acc + cur),
+      0,
+    );
+    const remainingSpace = TOTAL_TABLE_WIDTH - totalDefinedWidths;
+    const nullCells = bestMaybeWidths.length - mostNonNulls;
+    const defaultWidth = Math.floor(remainingSpace / nullCells);
+    widths = bestMaybeWidths.map((w: number) => (w == null || w === 0 ? defaultWidth : w));
+  }
+  const total = widths.reduce((acc: number, cur: number) => acc + cur, 0);
+  const fractionalWidths = widths.map((w: number) => w / total);
+  const columnSpec = fractionalWidths.map((w: number) => renderPColumn(w)).join('');
+
+  const numColumns = widths.length > 0 ? widths.length : node?.children[0]?.children?.length ?? 0;
+
+  return { widths: fractionalWidths, columnSpec, numColumns };
+}
+
+function renderTableCell(
+  state: ITexSerializer,
+  cell: TableCell,
+  i: number,
+  spanIdx: number,
+  widths: number[],
+  childCount: number,
+) {
+  let renderedSpan = 1;
+  const colspan = cell.colspan ?? 1;
+  if (colspan > 1) {
+    let width = 0;
+    for (let j = 0; j < colspan; j += 1) {
+      width += widths[spanIdx + j];
+    }
+    state.write(`\\multicolumn{${colspan}}{${renderPColumn(width)}}{`);
+    renderedSpan = colspan;
+  }
+  if (cell.children.length === 1 && (cell.children[0].type as string) === 'paragraph') {
+    // Render simple things inline, otherwise render a block
+    state.renderChildren(cell.children[0], true);
+  } else {
+    state.renderChildren(cell, true);
+  }
+  if (colspan > 1) state.write('}');
+  if (i < childCount - 1) {
+    state.write(' & ');
+  }
+  return renderedSpan;
+}
+
+/**
+ * convert prosemirror table node into latex table
+ */
+export function renderNodeToLatex(node: Table, state: ITexSerializer) {
+  // state.useMacro('booktabs');
+  const { widths, columnSpec, numColumns } = getColumnWidths(node);
+  if (!numColumns) {
+    throw new Error('invalid table format, no columns');
+  }
+  state.data.isInTable = true; // this is cleared at the end of this function
+  state.ensureNewLine();
+
+  // if not in a longtable environment already (these replace the figure environment)
+  // let dedent;
+  // handle initial headers first
+  let numHeaderRowsFound = 0;
+  if (state.data.longFigure) {
+    state.ensureNewLine();
+    state.write('\\hline');
+    state.ensureNewLine();
+    let endHeader = false;
+    // write the first header section
+    node.children.forEach(({ children: rowContent }) => {
+      if (endHeader) return;
+      if (rowContent[0]?.header) {
+        numHeaderRowsFound += 1;
+        let spanIdx = 0;
+        rowContent.forEach((cell, i) => {
+          spanIdx += renderTableCell(state, cell, i, spanIdx, widths, rowContent.length);
+        });
+        state.write(' \\\\');
+        state.ensureNewLine();
+      }
+      if (!rowContent[0]?.header) {
+        endHeader = true;
+      }
+    });
+
+    if (numHeaderRowsFound > 0) {
+      state.ensureNewLine();
+      state.write('\\hline');
+      state.ensureNewLine();
+      state.write('\\endfirsthead');
+      state.ensureNewLine();
+
+      state.write('\\hline');
+      state.ensureNewLine();
+      // write the continuation header section
+      state.write(
+        `\\multicolumn{${numColumns}}{c}{\\tablename\\ \\thetable\\ -- \\textit{Continued from previous page}}\\\\`,
+      );
+      state.ensureNewLine();
+      node.children.forEach(({ children: rowContent }, index) => {
+        if (index >= numHeaderRowsFound) return;
+        let spanIdx = 0;
+        rowContent.forEach((cell, i) => {
+          spanIdx += renderTableCell(state, cell, i, spanIdx, widths, rowContent.length);
+        });
+        state.write(' \\\\');
+        state.ensureNewLine();
+      });
+      state.ensureNewLine();
+      state.write('\\hline');
+      state.ensureNewLine();
+      state.write('\\endhead');
+      state.ensureNewLine();
+    }
+  } else {
+    state.write(`\\begin{tabular}{${columnSpec}}`);
+    state.ensureNewLine();
+    // dedent = indent(state);
+    state.write(`\\toprule`);
+    state.ensureNewLine();
+  }
+
+  // todo: can we use offset and index to better handle row and column spans?
+  node.children.forEach(({ children: rowContent }, index) => {
+    if (index < numHeaderRowsFound) return; // skip the header rows
+    let spanIdx = 0;
+    rowContent.forEach((cell, i) => {
+      spanIdx += renderTableCell(state, cell, i, spanIdx, widths, rowContent.length);
+    });
+    state.write(' \\\\');
+    state.ensureNewLine();
+    // If the first cell in this row is a table header, make a line
+    if (rowContent[0]?.header) {
+      state.write('\\hline');
+      state.ensureNewLine();
+    }
+  });
+
+  if (state.data.longFigure) {
+    state.write('\\hline');
+  } else {
+    state.write('\\bottomrule');
+    state.ensureNewLine();
+    // dedent?.();
+    state.write('\\end{tabular}');
+  }
+  state.closeBlock(node);
+  state.data.isInTable = false;
+}

--- a/packages/myst-to-typst/src/types.ts
+++ b/packages/myst-to-typst/src/types.ts
@@ -1,0 +1,61 @@
+import type { References } from 'myst-common';
+import type { PageFrontmatter } from 'myst-frontmatter';
+import type { FootnoteDefinition } from 'myst-spec-ext';
+import type { VFile } from 'vfile';
+
+export const DEFAULT_IMAGE_WIDTH = 0.7;
+export const DEFAULT_PAGE_WIDTH_PIXELS = 800;
+
+export type Handler = (node: any, state: ITexSerializer, parent: any) => void;
+
+export type TypstResult = {
+  value: string;
+  macros: string[];
+  commands: Record<string, string>;
+};
+
+export type MathPlugins = Required<PageFrontmatter>['math'];
+
+export type Options = {
+  handlers?: Record<string, Handler>;
+  beamer?: boolean;
+  math?: MathPlugins;
+  bibliography?: 'natbib' | 'biblatex';
+  citestyle?: 'numerical-only';
+  references?: References;
+};
+
+export type StateData = {
+  isInTable?: boolean;
+  isInFigure?: boolean;
+  longFigure?: boolean;
+  nextCaptionNumbered?: boolean;
+  nextHeadingIsFrameTitle?: boolean;
+  nextCaptionId?: string;
+  mathPlugins: Required<PageFrontmatter>['math'];
+  macros: Set<string>;
+  list?: {
+    env: string[];
+  };
+};
+
+export interface ITexSerializer<D extends Record<string, any> = StateData> {
+  file: VFile;
+  data: D;
+  options: Options;
+  references: References;
+  footnotes: Record<string, FootnoteDefinition>;
+  useMacro: (macro: string) => void;
+  write: (value: string) => void;
+  text: (value: string, mathMode?: boolean) => void;
+  trimEnd: () => void;
+  ensureNewLine: (trim?: boolean) => void;
+  renderChildren: (node: any, inline?: boolean, delim?: string) => void;
+  renderInlineEnvironment: (node: any, env: string, opts?: { after?: string }) => void;
+  renderEnvironment: (
+    node: any,
+    env: string,
+    opts?: { parameters?: string; arguments?: string[] },
+  ) => void;
+  closeBlock: (node: any) => void;
+}

--- a/packages/myst-to-typst/src/utils.ts
+++ b/packages/myst-to-typst/src/utils.ts
@@ -1,0 +1,257 @@
+import type { GenericNode } from 'myst-common';
+import { DEFAULT_IMAGE_WIDTH, DEFAULT_PAGE_WIDTH_PIXELS } from './types.js';
+
+/** Removes nobreak and zero-width spaces */
+export function cleanWhitespaceChars(text: string, nbsp = ' '): string {
+  return text.replace(/\u00A0/g, nbsp).replace(/[\u200B-\u200D\uFEFF]/g, '');
+}
+
+// Funky placeholders (unlikely to be written ...?!)
+const BACKSLASH_SPACE = '💥🎯BACKSLASHSPACE🎯💥';
+const BACKSLASH = '💥🎯BACKSLASH🎯💥';
+const TILDE = '💥🎯TILDE🎯💥';
+
+const hrefOnlyReplacements: Record<string, string> = {
+  // Not allowed characters
+  // Latex escaped characters are: \ & % $ # _ { } ~ ^
+  '&': '\\&',
+  '%': '\\%',
+  $: '\\$',
+  '#': '\\#',
+  _: '\\_',
+  '{': '\\{',
+  '}': '\\}',
+  '[': '\\[',
+  ']': '\\]',
+  '^': '\\^',
+};
+
+const textOnlyReplacements: Record<string, string> = {
+  ...hrefOnlyReplacements,
+  // quotes
+  '’': "'",
+  '‘': "'",
+  '”': '"',
+  '“': '"',
+  // guillemots
+  // '»': '>>', // These could be improved
+  // '«': '<<',
+  // '…': '\\dots',
+  // '–': '--',
+  // '—': '---',
+  // Commands gobble fhttps://texfaq.org/FAQ-xspaceollowing space
+  // See: https://texfaq.org/FAQ-xspace
+  '©': '#emoji.copyright ',
+  '®': '#emoji.reg ',
+  '™': '#emoji.tm ',
+  '<': '\\< ',
+  '>': '\\> ',
+  ' ': '~',
+  ' ': '~',
+  // eslint-disable-next-line no-irregular-whitespace
+  // ' ': '\\,',
+};
+
+const arrows: Record<string, string> = {
+  '↔': 'arrow.l.r',
+  '⇔': 'arrow.l.r.double',
+  '→': 'arrow.r',
+  '⇒': 'arrow.r.double',
+  '←': 'arrow.l',
+  '⇐': 'arrow.l.double',
+};
+
+const symbols: Record<string, string> = {
+  '−': '-', // minus
+  '-': '-', // hyphen minus
+  '﹣': '-', // Small hyphen minus
+  '－': '-', // Full-width Hyphen-minus
+  '＋': '+', // Full-width Plus
+};
+
+const textReplacements: Record<string, string> = {
+  ...textOnlyReplacements,
+  ...arrows,
+  ...symbols,
+};
+
+const mathReplacements: Record<string, string> = {
+  ...arrows,
+  ...symbols,
+  '½': '1/2',
+  '⅓': '1/3',
+  '⅔': '2/3',
+  '¼': '1/4',
+  '⅕': '1/5',
+  '⅖': '2/5',
+  '⅗': '3/5',
+  '⅘': '4/5',
+  '⅙': '1/6',
+  '⅚': '5/6',
+  '⅐': '1/7',
+  '⅛': '1/8',
+  '⅜': '3/8',
+  '⅝': '5/8',
+  '⅞': '7/8',
+  '⅑': '1/9',
+  '⅒': '1/10',
+  '±': 'plus.minus',
+  '×': 'times',
+  Α: 'A',
+  α: 'alpha',
+  Β: 'B',
+  β: 'beta',
+  ß: 'beta',
+  Γ: 'Gamma',
+  γ: 'gamma',
+  Δ: 'Delta',
+  '∆': 'Delta',
+  δ: 'delta',
+  Ε: 'E',
+  ε: 'epsilon',
+  Ζ: 'Z',
+  ζ: 'zeta',
+  Η: 'H',
+  η: 'eta',
+  Θ: 'Theta',
+  θ: 'theta',
+  ϑ: 'vartheta',
+  Ι: 'I',
+  ι: 'iota',
+  Κ: 'K',
+  κ: 'kappa',
+  Λ: 'Lambda',
+  λ: 'lambda',
+  Μ: 'M',
+  μ: 'mu',
+  Ν: 'N',
+  ν: 'nu',
+  Ξ: 'Xi',
+  ξ: 'xi',
+  Ο: 'O',
+  ο: 'o',
+  Π: 'Pi',
+  π: 'pi',
+  Ρ: 'P',
+  ρ: 'rho',
+  Σ: 'Sigma',
+  σ: 'sigma',
+  Τ: 'T',
+  τ: 'tau',
+  Υ: 'Upsilon',
+  υ: 'upsilon',
+  Φ: 'Phi',
+  ϕ: 'phi',
+  φ: 'phi.alt',
+  Χ: 'X',
+  χ: 'chi',
+  Ψ: 'Psi',
+  ψ: 'psi',
+  Ω: 'Omega',
+  ω: 'omega',
+  '∂': 'diff',
+  '∞': 'infty',
+  '≈': 'approx',
+  '≠': 'eq.not',
+  '•': 'dot.c',
+  // '‰': '\\permille',
+};
+
+type SimpleTokens = { kind: 'math' | 'text'; text: string };
+
+export function nodeOnlyHasTextChildren(node?: GenericNode) {
+  if (!node || !node.children || node.children.length === 0) return false;
+  return node.children.reduce((previous, { type }) => previous && type === 'text', true);
+}
+
+export function hrefToLatexText(text: string) {
+  const replacedArray: SimpleTokens[] = Array.from(text ?? '').map((char) => {
+    if (hrefOnlyReplacements[char]) return { kind: 'text', text: hrefOnlyReplacements[char] };
+    return { kind: 'text', text: char };
+  });
+
+  const replaced = replacedArray
+    .reduce((arr, next) => {
+      const prev = arr.slice(-1)[0];
+      if (prev?.kind === next.kind) prev.text += next.text;
+      else arr.push(next);
+      return arr;
+    }, [] as SimpleTokens[])
+    .reduce((s, next) => {
+      return s + next.text;
+    }, '');
+
+  return replaced;
+}
+
+export function stringToLatexText(text: string) {
+  const escaped = (text ?? '')
+    .replace(/\\ /g, BACKSLASH_SPACE)
+    .replace(/\\/g, BACKSLASH)
+    .replace(/~/g, TILDE);
+
+  const replacedArray: SimpleTokens[] = Array.from(escaped).map((char) => {
+    if (textReplacements[char]) return { kind: 'text', text: textReplacements[char] };
+    if (mathReplacements[char]) return { kind: 'math', text: mathReplacements[char] };
+    return { kind: 'text', text: char };
+  });
+
+  const replaced = replacedArray
+    .reduce((arr, next) => {
+      // Join any strings of math or text together (avoids $\delta$$\mu$ --> $\delta\mu$)
+      const prev = arr.slice(-1)[0];
+      if (prev?.kind === next.kind) prev.text += next.text;
+      else arr.push(next);
+      return arr;
+    }, [] as SimpleTokens[])
+    .reduce((s, next) => {
+      if (next.kind === 'math') return `${s}$${next.text}$`;
+      return s + next.text;
+    }, '');
+
+  const final = replaced
+    .replace(new RegExp(BACKSLASH_SPACE, 'g'), '{\\textbackslash}~')
+    .replace(new RegExp(BACKSLASH, 'g'), '{\\textbackslash}')
+    .replace(new RegExp(TILDE, 'g'), '{\\textasciitilde}');
+  return cleanWhitespaceChars(final, '~');
+}
+
+export function stringToLatexMath(text: string) {
+  const replaced = Array.from(text ?? '').reduce((s, char) => {
+    if (mathReplacements[char]) {
+      const space = s.slice(-1) === ' ' ? '' : ' ';
+      return `${s}${space}${mathReplacements[char]}`;
+    }
+    return s + char;
+  }, '');
+  const final = replaced.trim();
+  return cleanWhitespaceChars(final);
+}
+
+export function getLatexImageWidth(width?: number | string): string {
+  if (typeof width === 'number' && Number.isNaN(width)) {
+    // If it is nan, return with the default.
+    return getLatexImageWidth(DEFAULT_IMAGE_WIDTH);
+  }
+  if (typeof width === 'string') {
+    if (width.endsWith('%')) {
+      return getLatexImageWidth(Number(width.replace('%', '')));
+    } else if (width.endsWith('px')) {
+      return getLatexImageWidth(Number(width.replace('px', '')) / DEFAULT_PAGE_WIDTH_PIXELS);
+    }
+    console.log(`Unknown width ${width} in getLatexImageWidth`);
+    return getLatexImageWidth(DEFAULT_IMAGE_WIDTH);
+  }
+  let lineWidth = width ?? DEFAULT_IMAGE_WIDTH;
+  if (lineWidth < 1) lineWidth *= 100;
+  return `${lineWidth}%`;
+}
+
+export function getClasses(className?: string): string[] {
+  const classes =
+    className
+      ?.split(' ')
+      .map((s) => s.trim().toLowerCase())
+      .filter((s) => !!s) ?? [];
+  return Array.from(new Set(classes));
+}

--- a/packages/myst-to-typst/tests/admonitions.yml
+++ b/packages/myst-to-typst/tests/admonitions.yml
@@ -1,0 +1,40 @@
+title: myst-to-typst admonitions
+cases:
+  - title: important admonition
+    mdast:
+      type: root
+      children:
+        - type: admonition
+          kind: important
+          children:
+            - type: admonitionTitle
+              children:
+                - type: text
+                  value: Important
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'This is the admonition body!'
+    typst: |-
+      #importantBlock[
+      This is the admonition body!
+      ]
+  - title: important admonition - custom title
+    mdast:
+      type: root
+      children:
+        - type: admonition
+          kind: important
+          children:
+            - type: admonitionTitle
+              children:
+                - type: text
+                  value: NOTE
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'This is the admonition body!'
+    typst: |-
+      #importantBlock(heading: [NOTE])[
+      This is the admonition body!
+      ]

--- a/packages/myst-to-typst/tests/basic.yml
+++ b/packages/myst-to-typst/tests/basic.yml
@@ -1,0 +1,209 @@
+title: myst-to-typst basic features
+cases:
+  - title: text in paragraph
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'Some '
+            - type: emphasis
+              children:
+                - type: text
+                  value: markdown
+            - type: text
+              value: ' and '
+            - type: strong
+              children:
+                - type: text
+                  value: strong
+            - type: text
+              value: ' and '
+            - type: inlineCode
+              value: inlineCode
+            - type: text
+              value: ' and '
+            - type: link
+              url: https://example.com
+              children:
+                - type: text
+                  value: a link!
+            - type: text
+              value: ' and not a # comment'
+    typst: |-
+      Some _markdown_ and *strong* and `inlineCode` and #link("https://example.com")[a link!] and not a \# comment
+  - title: strong
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'This is '
+            - type: strong
+              children:
+                - type: text
+                  value: 'strong'
+            - type: text
+              value: '.'
+    typst: |-
+      This is *strong*.
+  - title: strong with children
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'This is a '
+            - type: strong
+              children:
+                - type: text
+                  value: 'strong '
+                - type: link
+                  url: https://example.com
+                  children:
+                    - type: text
+                      value: link
+            - type: text
+              value: '.'
+    typst: |-
+      This is a #strong[strong #link("https://example.com")[link]].
+  - title: emphasis
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'This is '
+            - type: emphasis
+              children:
+                - type: text
+                  value: 'emphasis'
+            - type: text
+              value: '.'
+    typst: |-
+      This is _emphasis_.
+  - title: emphasis with children
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'This is a '
+            - type: emphasis
+              children:
+                - type: text
+                  value: 'emphasis '
+                - type: link
+                  url: https://example.com
+                  children:
+                    - type: text
+                      value: link
+            - type: text
+              value: '.'
+    typst: |-
+      This is a #emph[emphasis #link("https://example.com")[link]].
+  - title: subscript
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'Revenue'
+            - type: subscript
+              children:
+                - type: text
+                  value: 'yearly'
+    typst: |-
+      Revenue#sub[yearly]
+  - title: superscript
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: '1'
+            - type: superscript
+              children:
+                - type: text
+                  value: 'st'
+            - type: text
+              value: ' try!'
+    typst: |-
+      1#super[st] try!
+  - title: strike
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'This is '
+            - type: delete
+              children:
+                - type: text
+                  value: 'not'
+            - type: text
+              value: ' relevant.'
+    typst: |-
+      This is #strike[not] relevant.
+  - title: underline
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'This is '
+            - type: underline
+              children:
+                - type: text
+                  value: 'important'
+            - type: text
+              value: '.'
+    typst: |-
+      This is #underline[important].
+  - title: escapes quotes
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: '“quote”'
+    typst: |-
+      "quote"
+  - title: escapes dollar sign
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: I got an ice cream for $1.50!
+    typst: |-
+      I got an ice cream for \$1.50!
+  - title: line break
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: Fleas
+            - type: break
+            - type: text
+              value: Adam
+            - type: break
+            - type: text
+              value: Had 'em.
+    typst: |-
+      Fleas \
+      Adam \
+      Had 'em.

--- a/packages/myst-to-typst/tests/cite.yml
+++ b/packages/myst-to-typst/tests/cite.yml
@@ -1,0 +1,26 @@
+title: myst-to-typst links
+cases:
+  - title: cite single
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: cite
+              label: cockett2015
+    typst: |-
+      @cockett2015
+  - title: cite multiple
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: citeGroup
+              children:
+                - type: cite
+                  label: cockett2015
+                - type: cite
+                  label: jon85
+    typst: |-
+      #cite("cockett2015", "jon85")

--- a/packages/myst-to-typst/tests/code.yml
+++ b/packages/myst-to-typst/tests/code.yml
@@ -1,0 +1,25 @@
+title: myst-to-typst code
+cases:
+  - title: code-block-default
+    mdast:
+      type: root
+      children:
+        - type: mystDirective
+          name: code-block
+          args: python
+          class: my-class
+          value: |-
+            # here is math
+            1+2
+          children:
+            - type: code
+              lang: python
+              class: my-class
+              value: |-
+                # here is math
+                1+2
+    typst: |-
+      ```python
+      # here is math
+      1+2
+      ```

--- a/packages/myst-to-typst/tests/comments.yml
+++ b/packages/myst-to-typst/tests/comments.yml
@@ -1,0 +1,23 @@
+title: myst-to-typst comments
+cases:
+  - title: comments
+    mdast:
+      type: root
+      children:
+        - type: comment
+          value: |-
+            hello
+            world
+    typst: |-
+      /*
+      hello
+      world
+      */
+  - title: comment - empty
+    mdast:
+      type: root
+      children:
+        - type: comment
+          value: null
+    typst: |-
+      //

--- a/packages/myst-to-typst/tests/cross-references.yml
+++ b/packages/myst-to-typst/tests/cross-references.yml
@@ -1,0 +1,24 @@
+title: myst-to-typst sections
+cases:
+  - title: sections
+    mdast:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          identifier: section-one
+          children:
+            - type: text
+              value: My Heading
+        - type: paragraph
+          children:
+            - type: text
+              value: 'Please see '
+            - type: crossReference
+              identifier: section-one
+            - type: text
+              value: ' for more information!'
+    typst: |-
+      = My Heading <section-one>
+
+      Please see @section-one for more information!

--- a/packages/myst-to-typst/tests/definitions.yml
+++ b/packages/myst-to-typst/tests/definitions.yml
@@ -1,0 +1,27 @@
+title: myst-to-typst definitions
+cases:
+  - title: definitionList
+    mdast:
+      type: root
+      children:
+        - type: definitionList
+          children:
+            - type: definitionTerm
+              children:
+                - type: text
+                  value: Term 1
+            - type: definitionDescription
+              children:
+                - type: text
+                  value: Definition
+            - type: definitionTerm
+              children:
+                - type: text
+                  value: Term 2
+            - type: definitionDescription
+              children:
+                - type: text
+                  value: Definition
+    typst: |-
+      / Term 1: Definition
+      / Term 2: Definition

--- a/packages/myst-to-typst/tests/figures.yml
+++ b/packages/myst-to-typst/tests/figures.yml
@@ -1,0 +1,48 @@
+title: myst-to-typst figures
+cases:
+  - title: image
+    mdast:
+      type: root
+      children:
+        - type: image
+          url: molecular.jpg
+          width: 500px
+    typst: |-
+      #image("molecular.jpg", width: 62.5%)
+  - title: figure directive - no caption/legend
+    mdast:
+      type: root
+      children:
+        - type: container
+          kind: figure
+          label: glacier
+          children:
+            - type: image
+              url: glacier.jpg
+              width: 500px
+    typst: |-
+      #figure(
+        image("glacier.jpg", width: 62.5%),
+      ) <glacier>
+  - title: figure directive - with caption
+    mdast:
+      type: root
+      children:
+        - type: container
+          kind: figure
+          label: glacier
+          children:
+            - type: image
+              url: glacier.jpg
+              width: 500px
+            - type: caption
+              children:
+                - type: paragraph
+                  children:
+                    - type: text
+                      value: A curious figure.
+    typst: |-
+      #figure(
+        image("glacier.jpg", width: 62.5%),
+        caption: [A curious figure.],
+      ) <glacier>

--- a/packages/myst-to-typst/tests/footnotes.spec.ts
+++ b/packages/myst-to-typst/tests/footnotes.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { unified } from 'unified';
+import { u } from 'unist-builder';
+import type { TypstResult } from '../src';
+import mystToTex from '../src';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+describe('myst-to-tex footnotes', () => {
+  it('footnote reference/definition', () => {
+    const tree = u('root', [
+      u('paragraph', [
+        u('text', 'hello'),
+        u('footnoteReference', { identifier: 1 }),
+        u('text', 'world'),
+      ]),
+      u('footnoteDefinition', { identifier: '1' }, [u('paragraph', [u('text', 'tex')])]),
+    ]);
+    const pipe = unified().use(mystToTex, {
+      references: {},
+    });
+    pipe.runSync(tree as any);
+    const file = pipe.stringify(tree as any);
+    expect((file.result as TypstResult).value).toEqual('hello#footnote[tex]world');
+  });
+});

--- a/packages/myst-to-typst/tests/footnotes.yml
+++ b/packages/myst-to-typst/tests/footnotes.yml
@@ -1,0 +1,25 @@
+title: myst-to-typst comments
+cases:
+  - title: comments
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: A footnote reference
+            - type: footnoteReference
+              identifier: myref
+              label: myref
+            - type: text
+              value: ' with more text!'
+        - type: footnoteDefinition
+          identifier: myref
+          label: myref
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: Footnote definition!
+    typst: |-
+      A footnote reference#footnote[Footnote definition!] with more text!

--- a/packages/myst-to-typst/tests/links.yml
+++ b/packages/myst-to-typst/tests/links.yml
@@ -1,0 +1,17 @@
+title: myst-to-typst links
+cases:
+  - title: href
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'my link: '
+            - type: link
+              url: https://example.com#^my_example
+              children:
+                - type: text
+                  value: my-example
+    typst: |-
+      my link: #link("https://example.com\#\^my\_example")[my-example]

--- a/packages/myst-to-typst/tests/lists.yml
+++ b/packages/myst-to-typst/tests/lists.yml
@@ -1,0 +1,27 @@
+title: myst-to-typst admonitions
+cases:
+  - title: important admonition
+    mdast:
+      type: root
+      children:
+        - type: list
+          children:
+            - type: listItem
+              children:
+                - type: text
+                  value: This is a list
+                - type: list
+                  ordered: true
+                  children:
+                    - type: listItem
+                      children:
+                        - type: text
+                          value: My other, nested
+                    - type: listItem
+                      children:
+                        - type: text
+                          value: bullet point list!
+    typst: |-
+      - This is a list
+        + My other, nested
+        + bullet point list!

--- a/packages/myst-to-typst/tests/math.spec.ts
+++ b/packages/myst-to-typst/tests/math.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { unified } from 'unified';
+import { u } from 'unist-builder';
+import type { TypstResult } from '../src';
+import mystToTypst from '../src';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+describe('myst-to-tex math', () => {
+  it('includes recursive commands', () => {
+    const tree = u('root', [u('paragraph', [u('inlineMath', { value: '\\aRecursion' })])]);
+    const plugins = { '\\aNrm': 'a', '\\aMat': '[\\mathrm{\\aNrm}]', '\\aRecursion': '\\aMat' };
+    const pipe = unified().use(mystToTypst, {
+      references: {},
+      math: {
+        ...plugins,
+        '\\somethingElse': '\\blah',
+      },
+    });
+    pipe.runSync(tree as any);
+    const file = pipe.stringify(tree as any);
+    expect((file.result as TypstResult).value).toEqual('$aRecursion$');
+    expect((file.result as TypstResult).commands).toEqual({
+      aRecursion: 'aMat',
+      aMat: '[ upright(aNrm) ]',
+      aNrm: 'a',
+    });
+  });
+});

--- a/packages/myst-to-typst/tests/run.spec.ts
+++ b/packages/myst-to-typst/tests/run.spec.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { unified } from 'unified';
+import type { LatexResult } from '../src';
+import mystToTex from '../src';
+
+type TestCase = {
+  title: string;
+  typst: string;
+  mdast: Record<string, any>;
+};
+
+type TestCases = {
+  title: string;
+  cases: TestCase[];
+};
+
+const casesList: TestCases[] = fs
+  .readdirSync(__dirname)
+  .filter((file) => file.endsWith('.yml'))
+  .map((file) => {
+    const content = fs.readFileSync(path.join(__dirname, file), { encoding: 'utf-8' });
+    return yaml.load(content) as TestCases;
+  });
+
+casesList.forEach(({ title, cases }) => {
+  describe(title, () => {
+    test.each(cases.map((c): [string, TestCase] => [c.title, c]))('%s', (_, { typst, mdast }) => {
+      const pipe = unified().use(mystToTex);
+      pipe.runSync(mdast as any);
+      const file = pipe.stringify(mdast as any);
+      expect((file.result as LatexResult).value).toEqual(typst);
+    });
+  });
+});

--- a/packages/myst-to-typst/tests/sections.yml
+++ b/packages/myst-to-typst/tests/sections.yml
@@ -1,0 +1,25 @@
+title: myst-to-typst sections
+cases:
+  - title: sections
+    mdast:
+      type: root
+      children:
+        - type: heading
+          depth: 4
+          children:
+            - type: text
+              value: My Heading
+    typst: |-
+      ==== My Heading
+  - title: sections
+    mdast:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          identifier: section-one
+          children:
+            - type: text
+              value: My Heading
+    typst: |-
+      = My Heading <section-one>

--- a/packages/myst-to-typst/tests/siunit.spec.ts
+++ b/packages/myst-to-typst/tests/siunit.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { unified } from 'unified';
+import { u } from 'unist-builder';
+import type { LatexResult } from '../src';
+import mystToTex from '../src';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+describe('myst-to-tex siunitx', () => {
+  it('footnote reference/definition', () => {
+    const tree = u('root', [
+      u('paragraph', [
+        u('si', { units: ['milli', 'meter'], alt: 'mili meter', value: '1 mm', number: '1' }),
+      ]),
+    ]);
+    const pipe = unified().use(mystToTex, {
+      references: {},
+    });
+    pipe.runSync(tree as any);
+    const file = pipe.stringify(tree as any);
+    expect((file.result as LatexResult).value).toEqual('\\qty{1}{\\milli\\meter}');
+  });
+});

--- a/packages/myst-to-typst/tsconfig.json
+++ b/packages/myst-to-typst/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../tsconfig/base.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules", "src/**/*.spec.ts", "tests"]
+}

--- a/packages/mystmd/src/build.ts
+++ b/packages/mystmd/src/build.ts
@@ -15,6 +15,7 @@ import {
   makeHtmlOption,
   makeMecaOptions,
   makeMdOption,
+  makeTypstOption,
 } from './options.js';
 
 export function makeBuildCLI(program: Command) {
@@ -23,6 +24,7 @@ export function makeBuildCLI(program: Command) {
     .argument('[files...]', 'list of files to export')
     .addOption(makePdfOption('Build PDF output'))
     .addOption(makeTexOption('Build LaTeX outputs'))
+    .addOption(makeTypstOption('Build Typst outputs'))
     .addOption(makeDocxOption('Build Docx output'))
     .addOption(makeMdOption('Build MD output'))
     .addOption(makeJatsOption('Build JATS xml output'))

--- a/packages/mystmd/src/options.ts
+++ b/packages/mystmd/src/options.ts
@@ -8,6 +8,10 @@ export function makeTexOption(description: string) {
   return new Option('--tex', description).default(false);
 }
 
+export function makeTypstOption(description: string) {
+  return new Option('--typst', description).default(false);
+}
+
 export function makeDocxOption(description: string) {
   return new Option('--word, --docx', description).default(false);
 }


### PR DESCRIPTION
Convert markdown files into typst for PDF creation.

- [ ] Need better templating
- [ ] Remove unknown cross-references
- [ ] Tables
- [ ] Render