### PR TITLE
🔧 Fix supplementary material in jats export

### DIFF
--- a/.changeset/stupid-llamas-rest.md
+++ b/.changeset/stupid-llamas-rest.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Fix supplementary material in jats export for simpler embed figure structure

--- a/packages/myst-to-jats/src/transforms/containers.ts
+++ b/packages/myst-to-jats/src/transforms/containers.ts
@@ -1,8 +1,10 @@
 import type { Plugin } from 'unified';
 import type { Root } from 'mdast';
-import type { Container, Blockquote, Legend, Caption, FlowContent } from 'myst-spec';
+import type { Blockquote, Legend, Caption, FlowContent } from 'myst-spec';
+import type { Container } from 'myst-spec-ext';
 import { select, selectAll } from 'unist-util-select';
 import { remove } from 'unist-util-remove';
+import { normalizeLabel } from 'myst-common';
 
 export type SupplementaryMaterial = {
   type: 'supplementaryMaterial';
@@ -43,19 +45,16 @@ export function containerTransform(mdast: Root) {
       caption.children.push(...legendChildren);
       remove(container as any, 'legend');
     }
-    const embed = select('embed', container);
-    if (embed) {
-      const embedBlock = select('block', embed);
-      const embedOutputs = selectAll('output', embedBlock);
+    const { identifier } = normalizeLabel(container.source?.label) ?? {};
+    if (identifier && container.source) {
       caption.children.push({
         type: 'supplementaryMaterial',
         enumerator: container.enumerator,
         figIdentifier: container.identifier,
-        sourceUrl: (embed as any).source?.url,
-        sourceSlug: (embed as any).source?.slug,
-        embedIdentifier: (embedBlock as any)?.identifier,
+        sourceUrl: container.source.url,
+        sourceSlug: container.source.slug,
+        embedIdentifier: identifier,
       } as SupplementaryMaterial);
-      if (embedOutputs) container.children.push(...(embedOutputs as any[]));
     }
     if (caption.children?.length && !select('caption', container)) {
       container.children.push(caption);

--- a/packages/myst-to-jats/tests/basic.yml
+++ b/packages/myst-to-jats/tests/basic.yml
@@ -648,55 +648,45 @@ cases:
           kind: figure
           identifier: myfigure
           enumerator: 1
+          source:
+            label: nb-cell-0
+            url: /myst/nb-0
+            kind: Notebook
           children:
-            - type: embed
-              label: nb-cell-0
-              source:
-                url: /myst/nb-0
-                kind: Notebook
-              children:
-                - type: block
+            - type: code
+              lang: python
+              executable: true
+              value: print('abc')
+              identifier: nb-cell-0-code
+              enumerator: 1
+              html_id: nb-cell-0-code
+            - type: output
+              id: T7FMDqDm8dM2bOT1tKeeM
+              identifier: nb-cell-0-output
+              html_id: nb-cell-0-output
+              data:
+                - name: stdout
+                  output_type: stream
+                  text: abc\n...
+                  hash: a
+                  path: files/a.txt
+            - type: output
+              id: uE4mPgSow0oyo0dvEH9Lc
+              identifier: nb-cell-1-output
+              html_id: nb-cell-1-output
+              data:
+                - output_type: execute_result
+                  execution_count: 3
+                  metadata: {}
                   data:
-                    id: nb-cell-0
-                    type: notebook-code
-                  identifier: nb-cell-0
-                  label: nb-cell-0
-                  html_id: nb-cell-0
-                  children:
-                    - type: code
-                      lang: python
-                      executable: true
-                      value: print('abc')
-                      identifier: nb-cell-0-code
-                      enumerator: 1
-                      html_id: nb-cell-0-code
-                    - type: output
-                      id: T7FMDqDm8dM2bOT1tKeeM
-                      identifier: nb-cell-0-output
-                      html_id: nb-cell-0-output
-                      data:
-                        - name: stdout
-                          output_type: stream
-                          text: abc\n...
-                          hash: a
-                          path: files/a.txt
-                    - type: output
-                      id: uE4mPgSow0oyo0dvEH9Lc
-                      identifier: nb-cell-1-output
-                      html_id: nb-cell-1-output
-                      data:
-                        - output_type: execute_result
-                          execution_count: 3
-                          metadata: {}
-                          data:
-                            text/plain:
-                              content_type: text/plain
-                              hash: b
-                              path: files/b.txt
-                            text/html:
-                              content_type: text/html
-                              hash: b
-                              path: files/b.html
+                    text/plain:
+                      content_type: text/plain
+                      hash: b
+                      path: files/b.txt
+                    text/html:
+                      content_type: text/html
+                      hash: b
+                      path: files/b.html
             - type: caption
               children:
                 - type: paragraph
@@ -709,4 +699,4 @@ cases:
                   children:
                     - type: text
                       value: My Legend
-    jats: <fig id="myfigure"><caption><p>My Caption</p><p>My Legend</p><p><supplementary-material id="myfigure-source" specific-use="notebook"><label>Figure 1 - Notebook.</label><caption><title>Analysis for <xref ref-type="fig" rid="myfigure">Figure 1</xref>.</title><p>See methods from <xref ref-type="custom" custom-type="notebook-code" rid="nb-cell-0">cell</xref>.</p></caption></supplementary-material></p></caption><alternatives><media specific-use="stream" mimetype="text" mime-subtype="plain" xlink:href="files/a.txt"/></alternatives><alternatives><media specific-use="text" mimetype="text" mime-subtype="plain" xlink:href="files/b.txt"/><media specific-use="web" mimetype="text" mime-subtype="html" xlink:href="files/b.html"/></alternatives></fig>
+    jats: <fig id="myfigure"><caption><p>My Caption</p><p>My Legend</p><p><supplementary-material id="myfigure-source" specific-use="notebook"><label>Figure 1 - Notebook.</label><caption><title>Analysis for <xref ref-type="fig" rid="myfigure">Figure 1</xref>.</title><p>See methods from <xref ref-type="custom" custom-type="notebook-code" rid="nb-cell-0">cell</xref>.</p></caption></supplementary-material></p></caption><code id="nb-cell-0-code" language="python" executable="yes">print('abc')</code><alternatives><media specific-use="stream" mimetype="text" mime-subtype="plain" xlink:href="files/a.txt"/></alternatives><alternatives><media specific-use="text" mimetype="text" mime-subtype="plain" xlink:href="files/b.txt"/><media specific-use="web" mimetype="text" mime-subtype="html" xlink:href="files/b.html"/></alternatives></fig>


### PR DESCRIPTION
Simplifying the structure of embedded figures in #477 broke the transform to add `supplementary-material` in JATS export. However, it did fix the ordering of captions and content in figures to address #471...

This PR revives the `supplementary-material` in JATS and in turn resolves #471 I believe.