### PR TITLE
🔍 allow myst to build in larger parent monorepos

### DIFF
--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -23,7 +23,8 @@
       "./types",
       "./node_modules/@types",
       "../../node_modules/@types",
-      "../../../node_modules/@types"
+      "../../../node_modules/@types",
+      "../../../../node_modules/@types"
     ]
   },
   "exclude": ["node_modules"]


### PR DESCRIPTION
This is a pretty simple change that enables the packages (esp `myst-cli-utils`) to build when part of a larger (deeper) monorepo