### PR TITLE
📂 Do not log errors on copying folders in meca bundle

### DIFF
--- a/.changeset/short-mugs-bathe.md
+++ b/.changeset/short-mugs-bathe.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Do not log errors on copying folders in meca bundle

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -128,15 +128,17 @@ async function copyFilesFromConfig(
       entries.map(async ({ itemType, entry }) => {
         const resolvedEntry = [...projectPath.split(path.sep), entry].join('/');
         const matches = await glob(resolvedEntry);
-        matches.forEach((match) => {
-          const destination = copyFileMaintainPath(
-            session,
-            match,
-            projectPath,
-            bundleFolder(mecaFolder),
-          );
-          addManifestItem(manifestItems, itemType, mecaFolder, destination);
-        });
+        matches
+          .filter((match) => !isDirectory(match))
+          .forEach((match) => {
+            const destination = copyFileMaintainPath(
+              session,
+              match,
+              projectPath,
+              bundleFolder(mecaFolder),
+            );
+            addManifestItem(manifestItems, itemType, mecaFolder, destination);
+          });
       }),
     );
   }


### PR DESCRIPTION
This simple filter on the glob matches should resolve #465 - all files are copied with recursive paths anyway, so there is no need to copy folders.