### PR TITLE
Copy site template files (using glob)

### DIFF
--- a/.changeset/calm-crews-sort.md
+++ b/.changeset/calm-crews-sort.md
@@ -1,0 +1,5 @@
+---
+'myst-templates': patch
+---
+
+Use glob to validate and copy template files

--- a/.changeset/wicked-beds-deliver.md
+++ b/.changeset/wicked-beds-deliver.md
@@ -1,0 +1,6 @@
+---
+'myst-cli-utils': patch
+'myst-cli': patch
+---
+
+Move isDirectory and copyFile functions from myst-cli to myst-cli-utils

--- a/package-lock.json
+++ b/package-lock.json
@@ -13644,6 +13644,7 @@
       "dependencies": {
         "chalk": "^5.2.0",
         "commander": "^10.0.1",
+        "glob": "^10.3.1",
         "js-yaml": "^4.1.0",
         "myst-cli-utils": "^2.0.1",
         "myst-common": "^1.0.3",

--- a/packages/myst-cli-utils/src/index.ts
+++ b/packages/myst-cli-utils/src/index.ts
@@ -11,4 +11,11 @@ export { exec, makeExecutable } from './exec.js';
 export { clirun, tic } from './utils.js';
 export { isUrl } from './isUrl.js';
 export { Session, getSession } from './session.js';
-export { computeHash, hashAndCopyStaticFile, writeFileToFolder } from './filesystem.js';
+export {
+  computeHash,
+  copyFileMaintainPath,
+  copyFileToFolder,
+  hashAndCopyStaticFile,
+  isDirectory,
+  writeFileToFolder,
+} from './filesystem.js';

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -83,6 +83,7 @@ async function copyFilesFromConfig(
         const resolvedEntry = [...projectPath.split(path.sep), entry].join('/');
         const matches = await glob(resolvedEntry);
         matches
+          .map((match) => match.split('/').join(path.sep))
           .filter((match) => !isDirectory(match))
           .forEach((match) => {
             const destination = copyFileMaintainPath(

--- a/packages/myst-cli/src/project/fromPath.ts
+++ b/packages/myst-cli/src/project/fromPath.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs';
 import { extname, join } from 'node:path';
+import { isDirectory } from 'myst-cli-utils';
 import type { ISession } from '../session/types.js';
 import {
   fileInfo,
-  isDirectory,
   isValidFile,
   nextLevel,
   shouldIgnoreFile,

--- a/packages/myst-cli/src/project/load.ts
+++ b/packages/myst-cli/src/project/load.ts
@@ -1,12 +1,12 @@
 import fs from 'node:fs';
 import { join, resolve } from 'node:path';
-import { isUrl } from 'myst-cli-utils';
+import { isDirectory, isUrl } from 'myst-cli-utils';
 import { loadConfigAndValidateOrThrow } from '../config.js';
 import { loadFile, combineProjectCitationRenderers } from '../process/index.js';
 import type { ISession } from '../session/types.js';
 import { selectors } from '../store/index.js';
 import { projects } from '../store/reducers.js';
-import { getAllBibTexFilesOnPath, isDirectory, validateTOC } from '../utils/index.js';
+import { getAllBibTexFilesOnPath, validateTOC } from '../utils/index.js';
 import { projectFromPath } from './fromPath.js';
 import { projectFromToc } from './fromToc.js';
 import { writeTocFromProject } from './toToc.js';

--- a/packages/myst-cli/src/utils/getAllBibtexFiles.ts
+++ b/packages/myst-cli/src/utils/getAllBibtexFiles.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { isDirectory } from 'myst-cli-utils';
 import type { ISession } from '../session/types.js';
-import { isDirectory } from './isDirectory.js';
 import { shouldIgnoreFile } from './shouldIgnoreFile.js';
 
 export function getAllBibTexFilesOnPath(session: ISession, dir: string) {

--- a/packages/myst-cli/src/utils/index.ts
+++ b/packages/myst-cli/src/utils/index.ts
@@ -4,7 +4,6 @@ export * from './createTempFolder.js';
 export * from './fileInfo.js';
 export * from './filterFilenamesByExtension.js';
 export * from './getAllBibtexFiles.js';
-export * from './isDirectory.js';
 export * from './logMessagesFromVFile.js';
 export * from './nextLevel.js';
 export * from './removeExtension.js';

--- a/packages/myst-cli/src/utils/isDirectory.ts
+++ b/packages/myst-cli/src/utils/isDirectory.ts
@@ -1,5 +1,0 @@
-import fs from 'node:fs';
-
-export function isDirectory(file: string): boolean {
-  return fs.lstatSync(file).isDirectory();
-}

--- a/packages/myst-cli/src/utils/resolveExtension.ts
+++ b/packages/myst-cli/src/utils/resolveExtension.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { isDirectory } from './isDirectory.js';
+import { isDirectory } from 'myst-cli-utils';
 
 export enum ImageExtensions {
   png = '.png',

--- a/packages/myst-templates/package.json
+++ b/packages/myst-templates/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "chalk": "^5.2.0",
     "commander": "^10.0.1",
+    "glob": "^10.3.1",
     "js-yaml": "^4.1.0",
     "myst-cli-utils": "^2.0.1",
     "myst-common": "^1.0.3",


### PR DESCRIPTION
We changed site template fetching from clone to download/unzip. However, the unzipping function wasn't copying required template files.

This PR updates the site template download to copy all `files` listed on the template yml (which may use glob patterns). This functionality requires updates to site templates here: https://github.com/executablebooks/myst-theme/pull/178