### PR TITLE
🛠 Allow jupyter as alias for thebe

### DIFF
--- a/.changeset/empty-days-invent.md
+++ b/.changeset/empty-days-invent.md
@@ -1,0 +1,8 @@
+---
+'myst-common': minor
+'myst-config': minor
+'myst-frontmatter': minor
+'myst-spec-ext': minor
+---
+
+Rearrange package imports and fix versions

--- a/.changeset/lazy-seas-begin.md
+++ b/.changeset/lazy-seas-begin.md
@@ -1,0 +1,6 @@
+---
+'myst-frontmatter': patch
+'myst-config': patch
+---
+
+Add jupyter alias in frontmatter for thebe

--- a/packages/myst-config/src/project/validators.ts
+++ b/packages/myst-config/src/project/validators.ts
@@ -11,6 +11,12 @@ import type { ProjectConfig } from './types.js';
 
 const PROJECT_CONFIG_KEYS = {
   optional: ['remote', 'index', 'exclude'].concat(PROJECT_FRONTMATTER_KEYS),
+  alias: {
+    jupyter: 'thebe',
+    author: 'authors',
+    affiliation: 'affiliations',
+    export: 'exports',
+  },
 };
 
 function validateProjectConfigKeys(value: Record<string, any>, opts: ValidationOptions) {

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -150,6 +150,7 @@ const TEST_PROJECT_FRONTMATTER: ProjectFrontmatter = {
   requirements: ['requirements.txt'],
   resources: ['my-script.sh'],
 };
+
 const TEST_PAGE_FRONTMATTER: PageFrontmatter = {
   title: 'frontmatter',
   description: 'page frontmatter',
@@ -175,7 +176,6 @@ const TEST_PAGE_FRONTMATTER: PageFrontmatter = {
   jupytext: {},
   keywords: ['example', 'test'],
   exports: [{ format: 'pdf' as any, template: 'default', output: 'out.tex', a: 1 }],
-  thebe: false,
 };
 
 let opts: ValidationOptions;
@@ -420,7 +420,7 @@ describe('validatePageFrontmatter', () => {
     });
     expect(opts.messages.warnings).toEqual(undefined);
   });
-  it('valid jupyter.kernelspec with extra key wawrns', async () => {
+  it('valid jupyter.kernelspec with extra key warns', async () => {
     const frontmatter = {
       jupyter: { kernelspec: TEST_KERNELSPEC, extra: true },
     };

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -27,14 +27,14 @@ export type Biblio = {
 
 export type Thebe = {
   lite?: boolean;
-  binder?: boolean | ThebeBinderOptions;
-  server?: boolean | ThebeServerOptions;
+  binder?: boolean | BinderHubOptions;
+  server?: boolean | JupyterServerOptions;
   kernelName?: string;
   sessionName?: string;
   disableSessionSaving?: boolean;
   mathjaxUrl?: string;
   mathjaxConfig?: string;
-  local?: boolean | ThebeLocalOptions;
+  local?: boolean | JupyterLocalOptions;
 };
 
 export enum BinderProviders {
@@ -43,19 +43,19 @@ export enum BinderProviders {
   gitlab = 'gitlab',
 }
 
-export type ThebeBinderOptions = {
+export type BinderHubOptions = {
   url?: string;
   ref?: string; // org-name/repo-name
   repo?: string; // valid git refs only?
   provider?: BinderProviders;
 };
 
-export type ThebeServerOptions = {
+export type JupyterServerOptions = {
   url?: string;
   token?: string;
 };
 
-export type ThebeLocalOptions = ThebeServerOptions & {
+export type JupyterLocalOptions = JupyterServerOptions & {
   kernelName?: string;
   sessionName?: string;
 };
@@ -154,7 +154,7 @@ export type ProjectFrontmatter = SiteFrontmatter & {
   /** Abbreviations used throughout the project */
   abbreviations?: Record<string, string>;
   exports?: Export[];
-  thebe?: boolean | Thebe;
+  thebe?: Thebe;
   requirements?: string[];
   resources?: string[];
 };

--- a/packages/myst-frontmatter/tests/examples.spec.ts
+++ b/packages/myst-frontmatter/tests/examples.spec.ts
@@ -2,11 +2,12 @@ import { describe, expect, test } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
-import { validatePageFrontmatter } from '../src';
+import { validatePageFrontmatter, validateProjectFrontmatter } from '../src';
 import type { ValidationOptions } from 'simple-validators';
 
 type TestFile = {
   title: string;
+  frontmatter?: 'project' | 'page';
   cases: TestCase[];
 };
 
@@ -40,7 +41,7 @@ const casesList = files
     return tests;
   });
 
-casesList.forEach(({ title, cases }) => {
+casesList.forEach(({ title, frontmatter, cases }) => {
   describe(title, () => {
     const casesToUse = cases.filter((c) => !only || c.title === only);
     if (casesToUse.length === 0) return;
@@ -48,7 +49,9 @@ casesList.forEach(({ title, cases }) => {
       '%s',
       (_, { raw, normalized, warnings, errors }) => {
         const opts: ValidationOptions = { property: '', messages: {} };
-        const result = validatePageFrontmatter(raw, opts);
+        const validator =
+          frontmatter === 'project' ? validateProjectFrontmatter : validatePageFrontmatter;
+        const result = validator(raw, opts);
         if (only) {
           // This runs in "only" mode
           console.log(raw);

--- a/packages/myst-frontmatter/tests/thebe.yml
+++ b/packages/myst-frontmatter/tests/thebe.yml
@@ -1,8 +1,9 @@
-title: THEBE
+title: Jupyter & Thebe Options
+frontmatter: 'project'
 cases:
   - title: Valid and Exhaustive Options
     raw:
-      thebe:
+      jupyter:
         lite: false
         binder:
           url: 'https://my.binder.org/blah'
@@ -43,3 +44,15 @@ cases:
           token: local-secret
           kernelName: local-kernel
           sessionName: local-session
+  - title: jupyter lite
+    raw:
+      jupyter: 'lite'
+    normalized:
+      thebe:
+        lite: true
+  - title: jupyter server
+    raw:
+      jupyter: 'server'
+    normalized:
+      thebe:
+        server: true


### PR DESCRIPTION
- Alias for option `thebe` of `jupyter` #473
- Allows for { jupyter: lite }

This is a start at #463.

**Future work:**
- remove the `boolean | Object` from the binder and server options. We should be explicit in the CLI.
- Update the docs should happen in #463