### PR TITLE
🐍 Add pypi deploy for myst

### DIFF
--- a/.changeset/tiny-spoons-itch.md
+++ b/.changeset/tiny-spoons-itch.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Add pypi install instructions to update message

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -23,21 +23,23 @@ export function logUpdateAvailable({
   current,
   latest,
   upgradeCommand,
+  pypiUpgradeCommand,
   twitter,
 }: {
   current: string;
   latest: string;
   upgradeCommand: string;
+  pypiUpgradeCommand?: string;
   twitter: string;
 }) {
   return boxen(
     `Update available! ${chalk.dim(`v${current}`)} ≫ ${chalk.green.bold(
       `v${latest}`,
-    )}\n\nRun \`${chalk.cyanBright.bold(
-      upgradeCommand,
-    )}\` to update.\n\nFollow ${chalk.yellowBright(
-      `@${twitter}`,
-    )} for updates!\nhttps://twitter.com/${twitter}`,
+    )}\n\nRun \`${chalk.cyanBright.bold(upgradeCommand)}\` to update.\n\n${
+      pypiUpgradeCommand
+        ? `(Or if using PyPI, \`${chalk.cyanBright.bold(pypiUpgradeCommand)}\`) \n\n`
+        : ``
+    }Follow ${chalk.yellowBright(`@${twitter}`)} for updates!\nhttps://twitter.com/${twitter}`,
     {
       padding: 1,
       margin: 1,
@@ -82,6 +84,7 @@ export class Session implements ISession {
         current: version,
         latest: this._latestVersion,
         upgradeCommand: 'npm i -g mystmd@latest',
+        pypiUpgradeCommand: 'pip install -U mystmd',
         twitter: 'MystMarkdown',
       }),
     );

--- a/packages/mystmd-py/.gitignore
+++ b/packages/mystmd-py/.gitignore
@@ -1,0 +1,5 @@
+src/version.ts
+*.egg-info
+dist
+mystmd_py/myst.cjs
+README.md

--- a/packages/mystmd-py/LICENSE
+++ b/packages/mystmd-py/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2023 ExecutableBookProject
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mystmd-py/MANIFEST.in
+++ b/packages/mystmd-py/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE
+include mystmd_py/myst.cjs

--- a/packages/mystmd-py/mystmd_py/main.py
+++ b/packages/mystmd-py/mystmd_py/main.py
@@ -19,16 +19,30 @@ PATH_TO_BIN_JS = str(
 def main():
     if not NODE_LOCATION:
         sys.exit(
-            'You must install node to run myst\n\n'
+            'You must install node >=16 to run MyST\n\n'
             'We recommend installing the latest LTS release, using your preferred package manager\n'
             'or following instructions here: https://nodejs.org/en/download'
         )
     node = str(pathlib.Path(NODE_LOCATION).resolve())
-    p = subprocess.Popen(
+    version_proc = subprocess.Popen(
+        [node, '-v'], 
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE
+    )
+    version_proc.wait()
+    version = version_proc.communicate()[0].decode()
+    try:
+        ['16', '18', '20'].index(version[1:3])
+    except:
+        sys.exit(
+            f'MyST requires node 16, 18, or 20; you are running node {version[1:3]}.\n\n'
+            'Please update to the latest LTS release, using your preferred package manager\n'
+            'or following instructions here: https://nodejs.org/en/download'
+        )
+    myst_proc = subprocess.Popen(
         [node, PATH_TO_BIN_JS, *sys.argv[1:]],
         stdin=sys.stdin, stdout=sys.stdout
     )
-    sys.exit(p.wait())
+    sys.exit(myst_proc.wait())
 
 
 if __name__ == "__main__":

--- a/packages/mystmd-py/mystmd_py/main.py
+++ b/packages/mystmd-py/mystmd_py/main.py
@@ -1,0 +1,35 @@
+import pathlib
+import shutil
+import subprocess
+import sys
+
+
+NODE_LOCATION = (
+    shutil.which("node") or
+    shutil.which("node.exe") or
+    shutil.which("node.cmd")
+)
+PATH_TO_BIN_JS = str(
+    (
+        pathlib.Path(__file__).parent / 'myst.cjs'
+    ).resolve()
+)
+
+
+def main():
+    if not NODE_LOCATION:
+        sys.exit(
+            'You must install node to run myst\n\n'
+            'We recommend installing the latest LTS release, using your preferred package manager\n'
+            'or following instructions here: https://nodejs.org/en/download'
+        )
+    node = str(pathlib.Path(NODE_LOCATION).resolve())
+    p = subprocess.Popen(
+        [node, PATH_TO_BIN_JS, *sys.argv[1:]],
+        stdin=sys.stdin, stdout=sys.stdout
+    )
+    sys.exit(p.wait())
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/mystmd-py/scripts/pypi-deploy.sh
+++ b/packages/mystmd-py/scripts/pypi-deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cp ../mystmd/README.md .
+cp ../mystmd/dist/myst.cjs mystmd_py
+CURRENT=`awk -F'"' '/"version": ".+"/{ print $4; exit; }' ../mystmd/package.json`
+PREVIOUS=`awk -F' ' '/version = .+/{ print $3; exit; }' setup.cfg`
+sed -i "" "s/$PREVIOUS/$CURRENT/" setup.cfg
+rm -rf dist
+python -m build
+python -m twine upload dist/*

--- a/packages/mystmd-py/setup.cfg
+++ b/packages/mystmd-py/setup.cfg
@@ -5,7 +5,7 @@ description = Command line tools for MyST Markdown
 author = Franklin Koch
 url = https://github.com/executablebooks/mystmd
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Intended Audience :: Science/Research
     License :: OSI Approved :: MIT License

--- a/packages/mystmd-py/setup.cfg
+++ b/packages/mystmd-py/setup.cfg
@@ -1,0 +1,29 @@
+[metadata]
+name = mystmd
+version = 0.0.6
+description = Command line tools for MyST Markdown
+author = Franklin Koch
+url = https://github.com/executablebooks/mystmd
+license = MIT
+license_file = LICENSE
+classifiers =
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: JavaScript
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Topic :: Scientific/Engineering
+keywords = markdown, latex, writing-software, scientific-visualization, pdf-generation, science-research
+
+[options]
+packages = find:
+python_requires = >=3.6
+include_package_data = True
+
+[options.entry_points]
+console_scripts =
+    myst = mystmd_py.main:main

--- a/packages/mystmd-py/setup.py
+++ b/packages/mystmd-py/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
This introduces a new package that allows deploying `myst` to PyPI, so we can install with:

```
pip install mystmd
```

In order for this to work, users must have node installed. If they do not, they get a warning, like:
![image](https://github.com/executablebooks/mystmd/assets/9453731/39a471a3-3b91-4318-aa14-6f65627a4f42)

If node is installed, the `myst` python library passes all commands/arguments directly through to the JS CLI:
![image](https://github.com/executablebooks/mystmd/assets/9453731/68ec6f8a-ba69-4719-9846-a5b3b32593f3)


