### PR TITLE
🎑 Add thumbnail to project manifest

### DIFF
--- a/.changeset/clean-toys-occur.md
+++ b/.changeset/clean-toys-occur.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Expose thumbnail on project if set on the index page

--- a/.changeset/nasty-foxes-jog.md
+++ b/.changeset/nasty-foxes-jog.md
@@ -1,0 +1,6 @@
+---
+'myst-frontmatter': patch
+'myst-cli': patch
+---
+
+Allow thumbnail to be set on project or site

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -36,8 +36,8 @@ export async function localToManifestProject(
   if (!proj) return null;
   // Update all of the page title to the frontmatter title
   const { index } = proj;
-  const projectTitle =
-    projConfig?.title || selectors.selectFileInfo(state, proj.file).title || proj.index;
+  const projectFileInfo = selectors.selectFileInfo(state, proj.file);
+  const projectTitle = projConfig?.title || projectFileInfo.title || proj.index;
   const pages = await Promise.all(
     proj.pages.map(async (page) => {
       if ('file' in page) {
@@ -87,8 +87,11 @@ export async function localToManifestProject(
   );
   return {
     ...projFrontmatter,
-    banner: banner?.url,
-    bannerOptimized: banner?.urlOptimized,
+    // TODO: a null in the project frontmatter should not fall back to index page
+    thumbnail: projFrontmatter.thumbnail || projectFileInfo.thumbnail,
+    thumbnailOptimized: projFrontmatter.thumbnailOptimized || projectFileInfo.thumbnailOptimized,
+    banner: banner?.url || projectFileInfo.banner,
+    bannerOptimized: banner?.urlOptimized || projectFileInfo.bannerOptimized || undefined,
     exports,
     bibliography: projFrontmatter.bibliography || [],
     title: projectTitle || 'Untitled',

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -11,7 +11,7 @@ import type { ISession } from '../../session/types.js';
 import type { RootState } from '../../store/index.js';
 import { selectors } from '../../store/index.js';
 import { getMystTemplate } from './template.js';
-import { transformBanner } from '../../transforms/images.js';
+import { transformBanner, transformThumbnail } from '../../transforms/images.js';
 
 type ManifestProject = Required<SiteManifest>['projects'][0];
 
@@ -85,11 +85,19 @@ export async function localToManifestProject(
     session.publicPath(),
     { altOutputFolder: '/' },
   );
+  const thumbnail = await transformThumbnail(
+    session,
+    null,
+    path.join(projectPath, 'myst.yml'),
+    projFrontmatter,
+    session.publicPath(),
+    { altOutputFolder: '/' },
+  );
   return {
     ...projFrontmatter,
     // TODO: a null in the project frontmatter should not fall back to index page
-    thumbnail: projFrontmatter.thumbnail || projectFileInfo.thumbnail,
-    thumbnailOptimized: projFrontmatter.thumbnailOptimized || projectFileInfo.thumbnailOptimized,
+    thumbnail: thumbnail?.url || projectFileInfo.thumbnail,
+    thumbnailOptimized: thumbnail?.urlOptimized || projectFileInfo.thumbnailOptimized || undefined,
     banner: banner?.url || projectFileInfo.banner,
     bannerOptimized: banner?.urlOptimized || projectFileInfo.bannerOptimized || undefined,
     exports,

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -504,7 +504,7 @@ export async function transformThumbnail(
 export async function transformBanner(
   session: ISession,
   file: string,
-  frontmatter: PageFrontmatter,
+  frontmatter: { banner?: string | null; bannerOptimized?: string },
   writeFolder: string,
   opts?: { altOutputFolder?: string },
 ): Promise<{ url: string; urlOptimized?: string } | undefined> {

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -467,19 +467,19 @@ export async function transformImageFormats(
 
 export async function transformThumbnail(
   session: ISession,
-  mdast: Root,
+  mdast: Root | null,
   file: string,
   frontmatter: PageFrontmatter,
   writeFolder: string,
   opts?: { altOutputFolder?: string },
-) {
+): Promise<{ url: string; urlOptimized?: string } | undefined> {
   let thumbnail = frontmatter.thumbnail;
   // If the thumbnail is explicitly null, don't add an image
   if (thumbnail === null) {
     session.log.debug(`${file}#frontmatter.thumbnail is explicitly null, not searching content.`);
     return;
   }
-  if (!thumbnail) {
+  if (!thumbnail && mdast) {
     // The thumbnail isn't found, grab it from the mdast, excluding videos
     const [image] = (selectAll('image', mdast) as Image[]).filter((n) => !n.url.endsWith('.mp4'));
     if (!image) {
@@ -494,11 +494,21 @@ export async function transformThumbnail(
   const result = await saveImageInStaticFolder(session, thumbnail, file, writeFolder, {
     altOutputFolder: opts?.altOutputFolder,
   });
-  if (result) {
-    // Update frontmatter with new file name
-    const { url } = result;
-    frontmatter.thumbnail = url;
+  if (!result) return;
+  // Update frontmatter with new file name
+  const { url } = result;
+  frontmatter.thumbnail = url;
+  const fileMatch = path.basename(result.url);
+  const optimized = await imagemagick.convertImageToWebp(
+    session,
+    path.join(writeFolder, fileMatch),
+  );
+  if (optimized) {
+    const urlOptimized = url.replace(fileMatch, optimized);
+    frontmatter.thumbnailOptimized = urlOptimized;
+    return { url, urlOptimized };
   }
+  return { url };
 }
 
 export async function transformBanner(

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -124,6 +124,8 @@ export type SiteFrontmatter = {
   description?: string;
   subtitle?: string;
   short_title?: string;
+  thumbnail?: string | null;
+  thumbnailOptimized?: string;
   banner?: string | null;
   bannerOptimized?: string;
   authors?: Author[];
@@ -163,8 +165,4 @@ export type PageFrontmatter = Omit<ProjectFrontmatter, 'references'> & {
   kernelspec?: KernelSpec;
   jupytext?: Jupytext;
   tags?: string[];
-  thumbnail?: string | null;
-  thumbnailOptimized?: string;
-  banner?: string | null;
-  bannerOptimized?: string;
 };

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -45,6 +45,8 @@ export const SITE_FRONTMATTER_KEYS = [
   'subtitle',
   'short_title',
   'description',
+  'thumbnail',
+  'thumbnailOptimized',
   'banner',
   'bannerOptimized',
   'authors',
@@ -71,15 +73,10 @@ export const PROJECT_FRONTMATTER_KEYS = [
   'exports',
   // Do not add any project specific keys here!
 ].concat(SITE_FRONTMATTER_KEYS);
-export const PAGE_FRONTMATTER_KEYS = [
-  'kernelspec',
-  'jupytext',
-  'tags',
-  'thumbnail',
-  'thumbnailOptimized',
-  'banner',
-  'bannerOptimized',
-].concat(PROJECT_FRONTMATTER_KEYS);
+
+export const PAGE_FRONTMATTER_KEYS = ['kernelspec', 'jupytext', 'tags'].concat(
+  PROJECT_FRONTMATTER_KEYS,
+);
 
 // These keys only exist on the project.
 PROJECT_FRONTMATTER_KEYS.push('references', 'requirements', 'resources', 'thebe');
@@ -815,6 +812,28 @@ export function validateSharedProjectFrontmatterKeys(
     const exports = validateExportsList(value.exports, opts);
     if (exports) output.exports = exports;
   }
+  if (value.thumbnail === null) {
+    // It is possible for the thumbnail to explicitly be null.
+    // This means not to look to the images in a page.
+    output.thumbnail = null;
+  } else if (defined(value.thumbnail)) {
+    output.thumbnail = validateString(value.thumbnail, incrementOptions('thumbnail', opts));
+  }
+  if (defined(value.thumbnailOptimized)) {
+    // No validation, this is expected to be set programmatically
+    output.thumbnailOptimized = value.thumbnailOptimized;
+  }
+  if (value.banner === null) {
+    // It is possible for the banner to explicitly be null.
+    // This means not to look to the images in a page.
+    output.banner = null;
+  } else if (defined(value.banner)) {
+    output.banner = validateString(value.banner, incrementOptions('banner', opts));
+  }
+  if (defined(value.bannerOptimized)) {
+    // No validation, this is expected to be set programmatically
+    output.bannerOptimized = value.bannerOptimized;
+  }
   return output;
 }
 
@@ -882,28 +901,6 @@ export function validatePageFrontmatterKeys(value: Record<string, any>, opts: Va
         return validateString(file, incrementOptions(`tags.${index}`, opts));
       },
     );
-  }
-  if (value.thumbnail === null) {
-    // It is possible for the thumbnail to explicitly be null.
-    // This means not to look to the images in a page.
-    output.thumbnail = null;
-  } else if (defined(value.thumbnail)) {
-    output.thumbnail = validateString(value.thumbnail, incrementOptions('thumbnail', opts));
-  }
-  if (defined(value.thumbnailOptimized)) {
-    // No validation, this is expected to be set programmatically
-    output.thumbnailOptimized = value.thumbnailOptimized;
-  }
-  if (value.banner === null) {
-    // It is possible for the banner to explicitly be null.
-    // This means not to look to the images in a page.
-    output.banner = null;
-  } else if (defined(value.banner)) {
-    output.banner = validateString(value.banner, incrementOptions('banner', opts));
-  }
-  if (defined(value.bannerOptimized)) {
-    // No validation, this is expected to be set programmatically
-    output.bannerOptimized = value.bannerOptimized;
   }
   return output;
 }


### PR DESCRIPTION
This adds a thumbnail to the project manifest (if it doesn't already exist) using the index page thumbnail.