### PR TITLE
✅ Support for new GitHub admonitions

### DIFF
--- a/.changeset/tough-ghosts-raise.md
+++ b/.changeset/tough-ghosts-raise.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Expand to allow for new github admonitions [!NOTE] in a blockquote

--- a/docs/admonitions.md
+++ b/docs/admonitions.md
@@ -110,10 +110,23 @@ Here is an admonition!
 
 :::::::{tip} Compatibility with GitHub
 :class: dropdown
-GitHub markdown transforms blockquotes that start with a bold `Note` or `Warning` into a simple admonition (see [GitHub](https://github.com/community/community/discussions/16925)). MyST also transforms these blockquotes into the appropriate admonitions with a `simple` class.
+GitHub markdown transforms blockquotes that start with a bold `Note` or text with `[!NOTE]` into a simple admonition (see [GitHub](https://github.com/community/community/discussions/16925)). This syntax only works for `note`, `important` or `warning`. MyST transforms these blockquotes into the appropriate admonitions with a `simple` class.
 
 ```{myst}
-> **Note** This is a note!
+> [!NOTE]
+> Highlights information that users should take into account, even when skimming.
+
+> [!IMPORTANT]
+> Crucial information necessary for users to succeed.
+
+> [!WARNING]
+> Critical content demanding immediate user attention due to potential risks.
+
+> **Note**
+> This is a note
+
+> **Warning**
+> This is a warning
 ```
 
 :::::::

--- a/packages/myst-transforms/src/admonitions.spec.ts
+++ b/packages/myst-transforms/src/admonitions.spec.ts
@@ -4,13 +4,30 @@ import type { Root } from 'mdast';
 import { admonitionBlockquoteTransform, admonitionHeadersTransform } from './admonitions';
 
 describe('Test admonitionBlockquoteTransform', () => {
-  test('simple code block returns self', async () => {
+  test('blockquote bold admonition', async () => {
     const mdast = u('root', [
       u('blockquote', [
         u('paragraph', [
           u('strong', [u('text', 'note')]),
           u('text', 'We know what we are, but know not what we may be.'),
         ]),
+      ]),
+    ]);
+    admonitionBlockquoteTransform(mdast as Root);
+    admonitionHeadersTransform(mdast as Root);
+    expect(mdast).toEqual(
+      u('root', [
+        u('admonition', { kind: 'note', class: 'simple' }, [
+          u('admonitionTitle', [u('text', 'Note')]),
+          u('paragraph', [u('text', 'We know what we are, but know not what we may be.')]),
+        ]),
+      ]),
+    );
+  });
+  test('blockquote [!NOTE] admonition', async () => {
+    const mdast = u('root', [
+      u('blockquote', [
+        u('paragraph', [u('text', '[!NOTE] We know what we are, but know not what we may be.')]),
       ]),
     ]);
     admonitionBlockquoteTransform(mdast as Root);


### PR DESCRIPTION
See https://github.com/orgs/community/discussions/16925

Support for:

```
> [!NOTE]
> Highlights information that users should take into account, even when skimming.

> [!IMPORTANT]
> Crucial information necessary for users to succeed.

> [!WARNING]
> Critical content demanding immediate user attention due to potential risks.

> **Note**
> This is a note

> **Warning**
> This is a warning
```