### PR TITLE
🚴‍♀️ Refactor Root --> GenericParent

### DIFF
--- a/.changeset/giant-dingos-boil.md
+++ b/.changeset/giant-dingos-boil.md
@@ -1,0 +1,12 @@
+---
+'myst-transforms': patch
+'myst-to-docx': patch
+'myst-to-html': patch
+'myst-to-jats': patch
+'myst-common': patch
+'myst-parser': patch
+'myst-cli': patch
+'mystmd': patch
+---
+
+Move from Root in mdast to `GenericParent` to relax types

--- a/packages/myst-cli/src/build/tex/single.spec.ts
+++ b/packages/myst-cli/src/build/tex/single.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Root } from 'mdast';
+import type { GenericParent } from 'myst-common';
 import { Session } from '../../session';
 import { extractTexPart } from './single';
 
@@ -17,7 +17,7 @@ describe('extractPart', () => {
     ).toEqual(undefined);
   });
   it('tagged part removed from tree and returned', async () => {
-    const tree: Root = {
+    const tree: GenericParent = {
       type: 'root',
       children: [
         {
@@ -56,7 +56,7 @@ describe('extractPart', () => {
     });
   });
   it('tagged part meeting maximums passes', async () => {
-    const tree: Root = {
+    const tree: GenericParent = {
       type: 'root',
       children: [
         {
@@ -82,7 +82,7 @@ describe('extractPart', () => {
     });
   });
   it('exceeding max chars passes', async () => {
-    const tree: Root = {
+    const tree: GenericParent = {
       type: 'root',
       children: [
         {
@@ -101,7 +101,7 @@ describe('extractPart', () => {
     });
   });
   it('exceeding max words passes', async () => {
-    const tree: Root = {
+    const tree: GenericParent = {
       type: 'root',
       children: [
         {

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -3,9 +3,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { TemplateImports } from 'jtex';
 import { renderTex, mergeTemplateImports } from 'jtex';
-import type { Root } from 'mdast';
 import { tic, writeFileToFolder } from 'myst-cli-utils';
-import type { References } from 'myst-common';
+import type { References, GenericParent } from 'myst-common';
 import { extractPart, TemplateKind } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import { ExportFormats } from 'myst-frontmatter';
@@ -38,7 +37,7 @@ const TEX_IMAGE_EXTENSIONS = [
 
 export function mdastToTex(
   session: ISession,
-  mdast: Root,
+  mdast: GenericParent,
   references: References,
   frontmatter: PageFrontmatter,
   templateYml: TemplateYml | null,
@@ -57,7 +56,7 @@ export function mdastToTex(
 
 export function extractTexPart(
   session: ISession,
-  mdast: Root,
+  mdast: GenericParent,
   references: References,
   partDefinition: TemplatePartDefinition,
   frontmatter: PageFrontmatter,

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -1,4 +1,3 @@
-import type { Root } from 'mdast';
 import { getFrontmatter } from 'myst-transforms';
 import type { Export, ExportFormats, Licenses, PageFrontmatter } from 'myst-frontmatter';
 import {
@@ -8,6 +7,7 @@ import {
   unnestKernelSpec,
   validatePageFrontmatter,
 } from 'myst-frontmatter';
+import type { GenericParent } from 'myst-common';
 import { copyNode } from 'myst-common';
 import type { ValidationOptions } from 'simple-validators';
 import { VFile } from 'vfile';
@@ -28,7 +28,7 @@ import { logMessagesFromVFile } from './index.js';
  */
 export function getPageFrontmatter(
   session: ISession,
-  tree: Root,
+  tree: GenericParent,
   file: string,
   path?: string,
   removeNode = true,

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
-import type { Root } from 'mdast';
 import { tic } from 'myst-cli-utils';
-import type { References } from 'myst-common';
+import type { GenericParent, References } from 'myst-common';
 import { SourceFileKind } from 'myst-spec-ext';
 import type { LinkTransformer } from 'myst-transforms';
 import {
@@ -124,7 +123,7 @@ export async function transformMdast(
   if (!mdastPre) throw new Error(`Expected mdast to be parsed for ${file}`);
   log.debug(`Processing "${file}"`);
   // Use structuredClone in future (available in node 17)
-  const mdast = JSON.parse(JSON.stringify(mdastPre)) as Root;
+  const mdast = JSON.parse(JSON.stringify(mdastPre)) as GenericParent;
   const frontmatter = preFrontmatter
     ? processPageFrontmatter(session, preFrontmatter, projectPath)
     : getPageFrontmatter(session, mdast, file, projectPath);

--- a/packages/myst-cli/src/process/myst.ts
+++ b/packages/myst-cli/src/process/myst.ts
@@ -1,4 +1,3 @@
-import type { Root } from 'mdast';
 import { mystParse } from 'myst-parser';
 import { cardDirective } from 'myst-ext-card';
 import { gridDirective } from 'myst-ext-grid';
@@ -9,8 +8,9 @@ import { tabDirectives } from 'myst-ext-tabs';
 import { VFile } from 'vfile';
 import type { ISession } from '../session/index.js';
 import { logMessagesFromVFile } from '../utils/index.js';
+import type { GenericParent } from 'myst-common';
 
-export function parseMyst(session: ISession, content: string, file: string): Root {
+export function parseMyst(session: ISession, content: string, file: string): GenericParent {
   const vfile = new VFile();
   vfile.path = file;
   const parsed = mystParse(content, {

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -1,7 +1,6 @@
-import type { Root } from 'mdast';
 import { computeHash } from 'myst-cli-utils';
 import { NotebookCell } from 'myst-common';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 import { nanoid } from 'nanoid';
 import type { MinifiedOutput } from 'nbtx';
@@ -30,7 +29,7 @@ export async function processNotebook(
   file: string,
   content: string,
   opts?: { minifyMaxCharacters?: number },
-): Promise<Root> {
+): Promise<GenericParent> {
   const { log } = session;
   const { metadata, cells } = JSON.parse(content) as INotebookContent;
   // notebook will be empty, use generateNotebookChildren, generateNotebookOrder here if we want to populate those

--- a/packages/myst-cli/src/transforms/citations.ts
+++ b/packages/myst-cli/src/transforms/citations.ts
@@ -1,11 +1,10 @@
 import type { CitationRenderer } from 'citation-js-utils';
 import { InlineCite } from 'citation-js-utils';
 import type { Logger } from 'myst-cli-utils';
-import type { References } from 'myst-common';
+import type { GenericParent, References } from 'myst-common';
 import type { StaticPhrasingContent, Parent } from 'myst-spec';
 import type { Cite, CiteKind, CiteGroup } from 'myst-spec-ext';
 import { selectAll } from 'unist-util-select';
-import type { Root } from 'mdast';
 
 function pushCite(
   references: Pick<References, 'cite'>,
@@ -54,7 +53,7 @@ function hasChildren(node: Parent) {
 
 export function transformCitations(
   log: Logger,
-  mdast: Root,
+  mdast: GenericParent,
   renderer: CitationRenderer,
   references: Pick<References, 'cite'>,
   file: string,

--- a/packages/myst-cli/src/transforms/code.ts
+++ b/packages/myst-cli/src/transforms/code.ts
@@ -1,5 +1,4 @@
-import type { Root } from 'mdast';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { fileError, fileWarn } from 'myst-common';
 import { select, selectAll } from 'unist-util-select';
 import yaml from 'js-yaml';
@@ -65,7 +64,7 @@ export function metadataFromCode(
 /**
  * Traverse mdast, remove code cell metadata, and add it to parent block
  */
-export function liftCodeMetadataToBlock(session: ISession, filename: string, mdast: Root) {
+export function liftCodeMetadataToBlock(session: ISession, filename: string, mdast: GenericParent) {
   const blocks = selectAll('block', mdast) as GenericNode[];
   blocks.forEach((block) => {
     const codeNodes = selectAll('code', block) as GenericNode[];
@@ -138,7 +137,7 @@ export function checkMetaTags(
 /**
  * Traverse mdast, propagate block tags to code and output
  */
-export function propagateBlockDataToCode(session: ISession, vfile: VFile, mdast: Root) {
+export function propagateBlockDataToCode(session: ISession, vfile: VFile, mdast: GenericParent) {
   const blocks = selectAll('block', mdast) as GenericNode[];
   blocks.forEach((block) => {
     if (!block.data || !block.data.tags) return;

--- a/packages/myst-cli/src/transforms/dois.ts
+++ b/packages/myst-cli/src/transforms/dois.ts
@@ -2,12 +2,11 @@ import type { CitationRenderer } from 'citation-js-utils';
 import { getCitations } from 'citation-js-utils';
 import { doi } from 'doi-utils';
 import type { Link } from 'myst-spec';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 import fetch from 'node-fetch';
 import { tic } from 'myst-cli-utils';
 import type { Logger } from 'myst-cli-utils';
-import type { Root } from 'mdast';
 import { toText } from 'myst-common';
 import type { Cite } from 'myst-spec-ext';
 import type { SingleCitationRenderer } from './types.js';
@@ -50,7 +49,7 @@ async function getCitation(log: Logger, doiString: string): Promise<SingleCitati
  */
 export async function transformLinkedDOIs(
   log: Logger,
-  mdast: Root,
+  mdast: GenericParent,
   doiRenderer: Record<string, SingleCitationRenderer>,
   path: string,
 ): Promise<CitationRenderer> {

--- a/packages/myst-cli/src/transforms/embed.ts
+++ b/packages/myst-cli/src/transforms/embed.ts
@@ -1,8 +1,7 @@
-import type { Root } from 'mdast';
 import { filter } from 'unist-util-filter';
 import { selectAll } from 'unist-util-select';
 import type { IReferenceState, MultiPageReferenceState } from 'myst-transforms';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { copyNode, liftChildren, normalizeLabel } from 'myst-common';
 import type { Dependency, Embed, Container } from 'myst-spec-ext';
 import { selectFile } from '../process/index.js';
@@ -13,7 +12,7 @@ import type { ISession } from '../session/types.js';
  */
 export function embedTransform(
   session: ISession,
-  mdast: Root,
+  mdast: GenericParent,
   dependencies: Dependency[],
   state: IReferenceState,
 ) {

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
-import type { Root } from 'mdast';
 import mime from 'mime-types';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { computeHash, hashAndCopyStaticFile, isUrl } from 'myst-cli-utils';
 import { remove } from 'unist-util-remove';
 import { selectAll } from 'unist-util-select';
@@ -157,7 +156,7 @@ export async function saveImageInStaticFolder(
 
 export async function transformImages(
   session: ISession,
-  mdast: Root,
+  mdast: GenericParent,
   file: string,
   writeFolder: string,
   opts?: { altOutputFolder?: string; imageExtensions?: ImageExtensions[] },
@@ -363,7 +362,7 @@ export function getConversionFns(imageExt: string, validExts: ImageExtensions[])
  */
 export async function transformImageFormats(
   session: ISession,
-  mdast: Root,
+  mdast: GenericParent,
   file: string,
   writeFolder: string,
   opts?: { altOutputFolder?: string; imageExtensions?: ImageExtensions[] },
@@ -467,7 +466,7 @@ export async function transformImageFormats(
 
 export async function transformThumbnail(
   session: ISession,
-  mdast: Root | null,
+  mdast: GenericParent | null,
   file: string,
   frontmatter: PageFrontmatter,
   writeFolder: string,
@@ -625,7 +624,7 @@ function isValidImageNode(node: GenericNode, validExts: ImageExtensions[]) {
  * author a placeholder image is using a figure directive.
  */
 export function transformPlaceholderImages(
-  mdast: Root,
+  mdast: GenericParent,
   opts?: { imageExtensions?: ImageExtensions[] },
 ) {
   const validExts = opts?.imageExtensions ?? DEFAULT_IMAGE_EXTENSIONS;

--- a/packages/myst-cli/src/transforms/include.ts
+++ b/packages/myst-cli/src/transforms/include.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
-import type { Root } from 'mdast';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { parseMyst } from '../process/index.js';
 import { selectAll } from 'unist-util-select';
 import { join, dirname } from 'node:path';
@@ -12,7 +11,7 @@ import type { ISession } from '../session/types.js';
  * RST documentation:
  *  - https://docutils.sourceforge.io/docs/ref/rst/directives.html#including-an-external-document-fragment
  */
-export function includeFilesDirective(session: ISession, filename: string, mdast: Root) {
+export function includeFilesDirective(session: ISession, filename: string, mdast: GenericParent) {
   const includeNodes = selectAll('include', mdast) as GenericNode[];
   const dir = dirname(filename);
   includeNodes.forEach((node) => {

--- a/packages/myst-cli/src/transforms/inlineExpressions.ts
+++ b/packages/myst-cli/src/transforms/inlineExpressions.ts
@@ -1,7 +1,6 @@
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { fileWarn, NotebookCell } from 'myst-common';
 import { selectAll } from 'unist-util-select';
-import type { Root } from 'mdast';
 import type { InlineExpression } from 'myst-spec-ext';
 import type { StaticPhrasingContent } from 'myst-spec';
 import type { Plugin } from 'unified';
@@ -67,7 +66,7 @@ function renderExpression(node: InlineExpression, file: VFile): StaticPhrasingCo
   return [];
 }
 
-export function transformInlineExpressions(mdast: Root, file: VFile) {
+export function transformInlineExpressions(mdast: GenericParent, file: VFile) {
   const blocks = selectAll('block', mdast).filter(
     (node) => node.data?.type === NotebookCell.content && node.data?.[metadataSection],
   ) as GenericNode[];
@@ -88,6 +87,7 @@ export function transformInlineExpressions(mdast: Root, file: VFile) {
   });
 }
 
-export const inlineExpressionsPlugin: Plugin<[], Root, Root> = () => (tree, file) => {
-  transformInlineExpressions(tree, file);
-};
+export const inlineExpressionsPlugin: Plugin<[], GenericParent, GenericParent> =
+  () => (tree, file) => {
+    transformInlineExpressions(tree, file);
+  };

--- a/packages/myst-cli/src/transforms/links.ts
+++ b/packages/myst-cli/src/transforms/links.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import pLimit from 'p-limit';
 import fetch from 'node-fetch';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 import { updateLinkTextIfEmpty } from 'myst-transforms';
 import type { LinkTransformer, Link } from 'myst-transforms';
@@ -11,7 +11,6 @@ import { hashAndCopyStaticFile, tic } from 'myst-cli-utils';
 import type { VFile } from 'vfile';
 import type { ISession } from '../session/types.js';
 import { selectors } from '../store/index.js';
-import type { Root } from 'mdast';
 import { addWarningForFile } from '../utils/index.js';
 import { links } from '../store/reducers.js';
 import type { ExternalLinkResult } from '../store/types.js';
@@ -163,7 +162,7 @@ const limitOutgoingConnections = pLimit(25);
 export async function checkLinksTransform(
   session: ISession,
   file: string,
-  mdast: Root,
+  mdast: GenericParent,
 ): Promise<string[]> {
   const linkNodes = selectAll('link,linkBlock,card', mdast) as GenericNode[];
   const linkUrls = linkNodes

--- a/packages/myst-cli/src/transforms/mdast.ts
+++ b/packages/myst-cli/src/transforms/mdast.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
-import type { GenericNode } from 'myst-common';
-import type { Root } from 'mdast';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 import { join, dirname } from 'node:path';
 import type { ISession } from '../session/types.js';
@@ -9,7 +8,7 @@ import type { ISession } from '../session/types.js';
  * This is the {mdast} directive, that loads from disk
  * For example, tables that can't be represented in markdown.
  */
-export function importMdastFromJson(session: ISession, filename: string, mdast: Root) {
+export function importMdastFromJson(session: ISession, filename: string, mdast: GenericParent) {
   const mdastNodes = selectAll('mdast', mdast) as GenericNode[];
   const loadedData: Record<string, GenericNode> = {};
   const dir = dirname(filename);

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -2,20 +2,19 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { computeHash } from 'myst-cli-utils';
 import { SourceFileKind } from 'myst-spec-ext';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import stripAnsi from 'strip-ansi';
 import { remove } from 'unist-util-remove';
 import { selectAll } from 'unist-util-select';
 import type { IOutput } from '@jupyterlab/nbformat';
 import { extFromMimeType, minifyCellOutput, walkOutputs } from 'nbtx';
-import type { Root } from 'mdast';
 import { castSession } from '../session/index.js';
 import type { ISession } from '../session/types.js';
 import { resolveOutputPath } from './images.js';
 
 export async function transformOutputs(
   session: ISession,
-  mdast: Root,
+  mdast: GenericParent,
   kind: SourceFileKind,
   writeFolder: string,
   opts?: { altOutputFolder?: string; minifyMaxCharacters?: number },
@@ -64,7 +63,7 @@ export async function transformOutputs(
  * It also only supports minified images (i.e. images cannot be too small) or
  * non-minified text (i.e. text cannot be too large).
  */
-export function reduceOutputs(mdast: Root, writeFolder: string) {
+export function reduceOutputs(mdast: GenericParent, writeFolder: string) {
   const outputs = selectAll('output', mdast) as GenericNode[];
   outputs.forEach((node) => {
     if (!node.data?.length) {

--- a/packages/myst-cli/src/transforms/types.ts
+++ b/packages/myst-cli/src/transforms/types.ts
@@ -1,12 +1,11 @@
-import type { Root } from 'mdast';
-import type { References } from 'myst-common';
+import type { References, GenericParent } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import type { SourceFileKind, Dependency } from 'myst-spec-ext';
 import type { CitationRenderer } from 'citation-js-utils';
 
 export type PreRendererData = {
   file: string;
-  mdast: Root;
+  mdast: GenericParent;
   kind: SourceFileKind;
   frontmatter?: PageFrontmatter;
 };

--- a/packages/myst-common/src/extractParts.spec.ts
+++ b/packages/myst-common/src/extractParts.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Root } from 'mdast';
 import { extractPart } from './extractParts';
+import type { GenericParent } from '../dist';
 
 describe('extractPart', () => {
   it('no part returns undefined', async () => {
@@ -12,7 +12,7 @@ describe('extractPart', () => {
     ).toEqual(undefined);
   });
   it('part removed from tree and returned', async () => {
-    const tree: Root = {
+    const tree: GenericParent = {
       type: 'root',
       children: [
         {

--- a/packages/myst-common/src/extractParts.ts
+++ b/packages/myst-common/src/extractParts.ts
@@ -1,5 +1,5 @@
-import type { Root } from 'mdast';
 import type { Block } from 'myst-spec';
+import type { GenericParent } from './types.js';
 import { remove } from 'unist-util-remove';
 import { selectAll } from 'unist-util-select';
 import { copyNode } from './utils.js';
@@ -7,7 +7,7 @@ import { copyNode } from './utils.js';
 /**
  * Selects the block node(s) based on part (string) or tags (string[]).
  */
-export function selectBlockParts(tree: Root, part: string): Block[] | undefined {
+export function selectBlockParts(tree: GenericParent, part: string): Block[] | undefined {
   if (!part) {
     // Prevent an undefined, null or empty part comparison
     return;
@@ -25,7 +25,7 @@ export function selectBlockParts(tree: Root, part: string): Block[] | undefined 
 /**
  * Returns a copy of the block parts and removes them from the tree.
  */
-export function extractPart(tree: Root, part: string): Root | undefined {
+export function extractPart(tree: GenericParent, part: string): GenericParent | undefined {
   const blockParts = selectBlockParts(tree, part);
   if (!blockParts) return undefined;
   const children = copyNode(blockParts).map((block) => {
@@ -40,7 +40,7 @@ export function extractPart(tree: Root, part: string): Root | undefined {
     }
     return block;
   });
-  const partsTree = { type: 'root', children } as unknown as Root;
+  const partsTree = { type: 'root', children } as GenericParent;
   // Remove the block parts from the main document
   blockParts.forEach((block) => {
     (block as any).type = '__delete__';

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -1,4 +1,3 @@
-import type { Root } from 'mdast';
 import type { Node } from 'myst-spec';
 import type { VFile } from 'vfile';
 
@@ -28,7 +27,7 @@ export enum NotebookCell {
 
 export type References = {
   cite?: Citations;
-  article?: Root;
+  article?: GenericParent;
 };
 
 // Types for defining roles and directives

--- a/packages/myst-common/src/utils.ts
+++ b/packages/myst-common/src/utils.ts
@@ -2,8 +2,7 @@ import type { VFile } from 'vfile';
 import type { VFileMessage } from 'vfile-message';
 import { map } from 'unist-util-map';
 import { customAlphabet } from 'nanoid';
-import type { Root, PhrasingContent } from 'mdast';
-import type { Node, Parent } from 'myst-spec';
+import type { Node, Parent, PhrasingContent } from 'myst-spec';
 import type { GenericNode, GenericParent } from './types.js';
 
 export type MessageInfo = {
@@ -72,7 +71,7 @@ export function createHtmlId(identifier?: string): string | undefined {
     .replace(/(?:^[-]+)|(?:[-]+$)/g, ''); // Remove repeated `-`s at the start or the end
 }
 
-export function liftChildren(tree: Root, nodeType: string) {
+export function liftChildren(tree: GenericParent, nodeType: string) {
   map(tree, (node) => {
     const children = ((node as GenericParent).children as Parent[])
       ?.map((child) => {

--- a/packages/myst-parser/src/directives.ts
+++ b/packages/myst-parser/src/directives.ts
@@ -1,5 +1,10 @@
-import type { Root } from 'mdast';
-import type { GenericNode, DirectiveData, DirectiveSpec, ParseTypes } from 'myst-common';
+import type {
+  GenericNode,
+  DirectiveData,
+  DirectiveSpec,
+  ParseTypes,
+  GenericParent,
+} from 'myst-common';
 import { fileError, fileWarn } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 import type { VFile } from 'vfile';
@@ -9,7 +14,7 @@ type MystDirectiveNode = GenericNode & {
   name: string;
 };
 
-export function applyDirectives(tree: Root, specs: DirectiveSpec[], vfile: VFile) {
+export function applyDirectives(tree: GenericParent, specs: DirectiveSpec[], vfile: VFile) {
   const specLookup: Record<string, DirectiveSpec> = {};
   specs.forEach((spec) => {
     const names = [spec.name];

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -1,5 +1,4 @@
 import MarkdownIt from 'markdown-it';
-import type { Root } from 'mdast';
 import { defaultDirectives } from 'myst-directives';
 import { defaultRoles } from 'myst-roles';
 import type { Plugin } from 'unified';
@@ -20,6 +19,7 @@ import {
 import { applyDirectives } from './directives.js';
 import { applyRoles } from './roles.js';
 import type { AllOptions } from './types.js';
+import type { GenericParent } from 'myst-common';
 
 type Options = Partial<AllOptions>;
 
@@ -83,7 +83,7 @@ export function mystParse(content: string, opts?: Options) {
 /**
  * MyST Parser as a Unified Plugin
  */
-export const mystParser: Plugin<[Options?], string, Root> = function mystParser() {
+export const mystParser: Plugin<[Options?], string, GenericParent> = function mystParser() {
   this.Parser = (content: string, opts?: Options) => {
     return mystParse(content, opts);
   };

--- a/packages/myst-parser/src/roles.ts
+++ b/packages/myst-parser/src/roles.ts
@@ -1,5 +1,4 @@
-import type { Root } from 'mdast';
-import type { GenericNode, ArgDefinition, RoleData, RoleSpec } from 'myst-common';
+import type { GenericNode, ArgDefinition, RoleData, RoleSpec, GenericParent } from 'myst-common';
 import { fileError, fileWarn, ParseTypesEnum } from 'myst-common';
 import { select, selectAll } from 'unist-util-select';
 import type { VFile } from 'vfile';
@@ -61,7 +60,7 @@ export function contentFromNode(
   }
 }
 
-export function applyRoles(tree: Root, specs: RoleSpec[], vfile: VFile) {
+export function applyRoles(tree: GenericParent, specs: RoleSpec[], vfile: VFile) {
   const specLookup: Record<string, RoleSpec> = {};
   specs.forEach((spec) => {
     const names = [spec.name];

--- a/packages/myst-parser/src/tokensToMyst.ts
+++ b/packages/myst-parser/src/tokensToMyst.ts
@@ -1,7 +1,6 @@
 import he from 'he';
 import type Token from 'markdown-it/lib/token.js';
-import type { Root } from 'mdast';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { liftChildren, normalizeLabel, setTextAsChild } from 'myst-common';
 import { visit } from 'unist-util-visit';
 import { remove } from 'unist-util-remove';
@@ -445,9 +444,9 @@ const defaultMdast: Record<string, TokenHandlerSpec> = {
   },
 };
 
-function hoistSingleImagesOutofParagraphs(tree: Root) {
+function hoistSingleImagesOutofParagraphs(tree: GenericParent) {
   // Hoist up all paragraphs with a single image
-  visit(tree, 'paragraph', (node) => {
+  visit(tree, 'paragraph', (node: GenericParent) => {
     if (!(node.children?.length === 1 && node.children?.[0].type === 'image')) return;
     const child = node.children[0];
     Object.keys(node).forEach((k) => {
@@ -457,7 +456,7 @@ function hoistSingleImagesOutofParagraphs(tree: Root) {
   });
 }
 
-function nestSingleImagesIntoParagraphs(tree: Root) {
+function nestSingleImagesIntoParagraphs(tree: GenericParent) {
   tree.children = tree.children.map((node) => {
     if (node.type === 'image') {
       return { type: 'paragraph', children: [node] };
@@ -473,7 +472,7 @@ const defaultOptions: MdastOptions = {
   nestBlocks: true,
 };
 
-export function tokensToMyst(tokens: Token[], options = defaultOptions): Root {
+export function tokensToMyst(tokens: Token[], options = defaultOptions): GenericParent {
   const opts = {
     ...defaultOptions,
     ...options,
@@ -481,9 +480,9 @@ export function tokensToMyst(tokens: Token[], options = defaultOptions): Root {
   };
   const state = new MarkdownParseState(opts.handlers);
   state.parseTokens(tokens);
-  let tree: Root;
+  let tree: GenericParent;
   do {
-    tree = state.closeNode() as Root;
+    tree = state.closeNode() as GenericParent;
   } while (state.stack.length);
 
   // Remove all redundant nodes marked for removal
@@ -550,7 +549,7 @@ export function tokensToMyst(tokens: Token[], options = defaultOptions): Root {
       stack.children?.push(node);
     });
     pushBlock();
-    tree = newTree as Root;
+    tree = newTree as GenericParent;
   }
 
   // ensureCaptionIsParagraph(tree);

--- a/packages/myst-parser/tests/linkify.spec.ts
+++ b/packages/myst-parser/tests/linkify.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import type { Root } from 'mdast';
 import { visit } from 'unist-util-visit';
 import { mystParse } from '../src';
+import type { GenericParent } from 'myst-common';
 
-function stripPositions(tree: Root) {
+function stripPositions(tree: GenericParent) {
   visit(tree, (node) => {
     delete node.position;
   });

--- a/packages/myst-parser/tests/myst.spec.ts
+++ b/packages/myst-parser/tests/myst.spec.ts
@@ -3,10 +3,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
 import { visit } from 'unist-util-visit';
-import type { Root } from 'mdast';
 import { mystParse } from '../src';
 import { mystToHtml } from 'myst-to-html';
 import { selectAll } from 'unist-util-select';
+import type { GenericParent } from 'myst-common';
 
 type TestFile = {
   cases: TestCase[];
@@ -15,7 +15,7 @@ type TestCase = {
   title: string;
   description?: string;
   skip?: boolean;
-  mdast: Root;
+  mdast: GenericParent;
   myst?: string;
   html?: string;
 };
@@ -76,14 +76,14 @@ function normalize(html: string) {
   return html.replace(/\n[\s]*/g, '');
 }
 
-function stripPositions(tree: Root) {
+function stripPositions(tree: GenericParent) {
   visit(tree, (node) => {
     delete node.position;
   });
   return tree;
 }
 
-function replaceMystCommentNodes(tree: Root) {
+function replaceMystCommentNodes(tree: GenericParent) {
   selectAll('comment', tree).forEach((node) => {
     // In a future version of the spec, hopefully this is removed
     // There isn't anything myst-like about the comments
@@ -92,7 +92,7 @@ function replaceMystCommentNodes(tree: Root) {
   return tree;
 }
 
-function replaceCommentNodes(tree: Root) {
+function replaceCommentNodes(tree: GenericParent) {
   selectAll('mystComment', tree).forEach((node) => {
     // In a future version of the spec, hopefully this is removed
     // There isn't anything myst-like about the comments

--- a/packages/myst-to-docx/src/utils.ts
+++ b/packages/myst-to-docx/src/utils.ts
@@ -10,11 +10,11 @@ import {
   SectionType,
 } from 'docx';
 import { Buffer } from 'buffer'; // Important for frontend development!
-import type { Root } from 'mdast';
 import type { Image as MdastImage } from 'myst-spec';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import { selectAll } from 'unist-util-select';
 import type { IFootnotes, Options } from './types.js';
+import type { GenericParent } from 'myst-common';
 
 export function createShortId() {
   return Math.random().toString(36).slice(2);
@@ -110,7 +110,7 @@ async function getImageDimensions(file: Blob | Buffer): Promise<{ width: number;
  * @returns options for the serializer
  */
 export async function fetchImagesAsBuffers(
-  tree: Root,
+  tree: GenericParent,
 ): Promise<Required<Pick<Options, 'getImageBuffer' | 'getImageDimensions'>>> {
   const images = selectAll('image', tree) as MdastImage[];
   const buffers: Record<string, Buffer> = {};

--- a/packages/myst-to-html/src/format.ts
+++ b/packages/myst-to-html/src/format.ts
@@ -1,8 +1,8 @@
-import type { Root } from 'mdast';
+import type { GenericParent } from 'myst-common';
 import rehypeFormat from 'rehype-format';
 import type { Plugin } from 'unified';
 
-export const formatHtml: Plugin<[boolean?], string, Root> = function formatHtml(opt) {
+export const formatHtml: Plugin<[boolean?], string, GenericParent> = function formatHtml(opt) {
   if (!opt) return () => undefined;
   return rehypeFormat(typeof opt === 'boolean' ? {} : opt);
 };

--- a/packages/myst-to-html/src/renderMdast.ts
+++ b/packages/myst-to-html/src/renderMdast.ts
@@ -1,13 +1,13 @@
-import type { Root } from 'mdast';
 import rehypeStringify from 'rehype-stringify';
 import { unified } from 'unified';
 import { formatHtml } from './format.js';
 import { mystToHast } from './schema.js';
 import { State } from './state.js';
 import { transform } from './transforms.js';
+import type { GenericParent } from 'myst-common';
 
 export function mystToHtml(
-  tree: Root,
+  tree: GenericParent,
   opts?: {
     formatHtml?: boolean;
     hast?: {

--- a/packages/myst-to-html/src/schema.ts
+++ b/packages/myst-to-html/src/schema.ts
@@ -1,10 +1,10 @@
-import type { Root } from 'mdast';
 import type { Handler, Options } from 'mdast-util-to-hast';
 import { defaultHandlers, toHast, all } from 'mdast-util-to-hast';
 import { u } from 'unist-builder';
 import classNames from 'classnames';
 import type { Plugin } from 'unified';
 import type { ElementContent, Properties } from 'hast';
+import type { GenericParent } from 'myst-common';
 
 const abbreviation: Handler = (h, node) => h(node, 'abbr', { title: node.title }, all(h, node));
 
@@ -161,46 +161,47 @@ const mermaid: Handler = (h, node) => h(node, 'div', { class: 'margin' });
 const myst: Handler = (h, node) => h(node, 'div', { class: 'margin' });
 const output: Handler = (h, node) => h(node, 'div', { class: 'output' });
 
-export const mystToHast: Plugin<[Options?], string, Root> = (opts) => (tree: Root) => {
-  return toHast(tree, {
-    ...opts,
-    handlers: {
-      admonition,
-      admonitionTitle,
-      container,
-      image,
-      caption,
-      captionNumber,
-      legend,
-      abbreviation,
-      subscript,
-      superscript,
-      math,
-      inlineMath,
-      definitionList,
-      definitionTerm,
-      definitionDescription,
-      mystRole,
-      mystDirective,
-      block,
-      comment,
-      heading,
-      crossReference,
-      code,
-      table,
-      iframe,
-      bibliography,
-      details,
-      summary,
-      embed,
-      include,
-      linkBlock,
-      margin,
-      mdast,
-      mermaid,
-      myst,
-      output,
-      ...opts?.handlers,
-    },
-  });
-};
+export const mystToHast: Plugin<[Options?], string, GenericParent> =
+  (opts) => (tree: GenericParent) => {
+    return toHast(tree as any, {
+      ...opts,
+      handlers: {
+        admonition,
+        admonitionTitle,
+        container,
+        image,
+        caption,
+        captionNumber,
+        legend,
+        abbreviation,
+        subscript,
+        superscript,
+        math,
+        inlineMath,
+        definitionList,
+        definitionTerm,
+        definitionDescription,
+        mystRole,
+        mystDirective,
+        block,
+        comment,
+        heading,
+        crossReference,
+        code,
+        table,
+        iframe,
+        bibliography,
+        details,
+        summary,
+        embed,
+        include,
+        linkBlock,
+        margin,
+        mdast,
+        mermaid,
+        myst,
+        output,
+        ...opts?.handlers,
+      },
+    });
+  };

--- a/packages/myst-to-html/src/state.ts
+++ b/packages/myst-to-html/src/state.ts
@@ -1,10 +1,10 @@
-import type { Content, Root } from 'mdast';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { normalizeLabel, setTextAsChild } from 'myst-common';
 import type { Heading } from 'myst-spec';
 import { visit } from 'unist-util-visit';
 import { select, selectAll } from 'unist-util-select';
 import { findAndReplace } from 'mdast-util-find-and-replace';
+import type { Content } from 'mdast';
 
 export enum TargetKind {
   heading = 'heading',
@@ -113,7 +113,7 @@ export class State {
     }
   }
 
-  initializeNumberedHeadingDepths(tree: Root) {
+  initializeNumberedHeadingDepths(tree: GenericParent) {
     const headings = selectAll('heading', tree).filter(
       (node) => (node as Heading).enumerated !== false,
     );
@@ -195,7 +195,7 @@ export class State {
   }
 }
 
-export const enumerateTargets = (state: State, tree: Root, opts: EnumeratorOptions) => {
+export const enumerateTargets = (state: State, tree: GenericParent, opts: EnumeratorOptions) => {
   state.initializeNumberedHeadingDepths(tree);
   if (!opts.disableContainerEnumeration) {
     visit(tree, 'container', (node: GenericNode) => state.addTarget(node));
@@ -209,7 +209,7 @@ export const enumerateTargets = (state: State, tree: Root, opts: EnumeratorOptio
   return tree;
 };
 
-export const resolveReferences = (state: State, tree: Root) => {
+export const resolveReferences = (state: State, tree: GenericParent) => {
   selectAll('link', tree).forEach((node: GenericNode) => {
     const reference = normalizeLabel(node.url);
     if (reference && reference.identifier in state.targets) {

--- a/packages/myst-to-html/tests/transforms/addenumerators.spec.ts
+++ b/packages/myst-to-html/tests/transforms/addenumerators.spec.ts
@@ -2,16 +2,16 @@ import { describe, expect, test } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
-import type { Root } from 'mdast';
 import { enumerateTargets, State } from '../../src/state';
+import type { GenericParent } from 'myst-common';
 
 type TestFile = {
   cases: TestCase[];
 };
 type TestCase = {
   title: string;
-  before: Root;
-  after: Root;
+  before: GenericParent;
+  after: GenericParent;
   opts?: Record<string, boolean>;
 };
 
@@ -25,7 +25,7 @@ describe('enumerateTargets', () => {
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
     '%s',
     (_, { before, after, opts }) => {
-      const transformed = enumerateTargets(new State(), before as Root, opts || {});
+      const transformed = enumerateTargets(new State(), before as GenericParent, opts || {});
       expect(yaml.dump(transformed)).toEqual(yaml.dump(after));
     },
   );

--- a/packages/myst-to-html/tests/transforms/converthtml.spec.ts
+++ b/packages/myst-to-html/tests/transforms/converthtml.spec.ts
@@ -2,16 +2,16 @@ import { describe, expect, test } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
-import type { Root } from 'mdast';
 import { convertHtmlToMdast } from '../../src/transforms';
+import type { GenericParent } from 'myst-common';
 
 type TestFile = {
   cases: TestCase[];
 };
 type TestCase = {
   title: string;
-  before: Root;
-  after: Root;
+  before: GenericParent;
+  after: GenericParent;
   opts?: Record<string, boolean>;
 };
 
@@ -25,7 +25,7 @@ describe('convertHtmlToMdast', () => {
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
     '%s',
     (_, { before, after, opts }) => {
-      const transformed = convertHtmlToMdast(before as Root, opts || {});
+      const transformed = convertHtmlToMdast(before as GenericParent, opts || {});
       expect(yaml.dump(transformed)).toEqual(yaml.dump(after));
     },
   );

--- a/packages/myst-to-jats/src/transforms/citations.ts
+++ b/packages/myst-to-jats/src/transforms/citations.ts
@@ -1,15 +1,14 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { CiteGroup } from 'myst-spec-ext';
 import { selectAll } from 'unist-util-select';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 
 /**
  * Add parentheses and separator text to citeGroup nodes as children
  *
  * This allows us to simply render children and get all the correct formatting.
  */
-export function citeGroupTransform(mdast: Root) {
+export function citeGroupTransform(mdast: GenericParent) {
   const citeGroups = selectAll('citeGroup', mdast) as CiteGroup[];
   citeGroups.forEach((node) => {
     // Only run this transform if:
@@ -50,6 +49,6 @@ export function citeGroupTransform(mdast: Root) {
   });
 }
 
-export const citeGroupPlugin: Plugin<[], Root, Root> = () => (tree) => {
+export const citeGroupPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   citeGroupTransform(tree);
 };

--- a/packages/myst-to-jats/src/transforms/containers.ts
+++ b/packages/myst-to-jats/src/transforms/containers.ts
@@ -1,9 +1,9 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { Blockquote, Legend, Caption, FlowContent } from 'myst-spec';
 import type { Container } from 'myst-spec-ext';
 import { select, selectAll } from 'unist-util-select';
 import { remove } from 'unist-util-remove';
+import type { GenericParent } from 'myst-common';
 import { normalizeLabel } from 'myst-common';
 
 export type SupplementaryMaterial = {
@@ -23,7 +23,7 @@ function liftCaptionNumber(container: Container) {
   if (captionNumber) container.children.splice(0, 0, captionNumber);
 }
 
-export function containerTransform(mdast: Root) {
+export function containerTransform(mdast: GenericParent) {
   const figures = selectAll('container', mdast) as Container[];
   figures.forEach((container) => {
     liftCaptionNumber(container);
@@ -68,6 +68,6 @@ export function containerTransform(mdast: Root) {
   });
 }
 
-export const containerPlugin: Plugin<[], Root, Root> = () => (tree) => {
+export const containerPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   containerTransform(tree);
 };

--- a/packages/myst-to-jats/src/transforms/definitions.ts
+++ b/packages/myst-to-jats/src/transforms/definitions.ts
@@ -1,12 +1,12 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { Parent } from 'myst-spec';
 import type { DefinitionList } from 'myst-spec-ext';
 import { selectAll } from 'unist-util-select';
+import type { GenericParent } from 'myst-common';
 
 type DefinitionItem = Parent & { type: 'definitionItem' };
 
-export function definitionTransform(mdast: Root) {
+export function definitionTransform(mdast: GenericParent) {
   const defList = selectAll('definitionList', mdast) as DefinitionList[];
   defList.forEach((node) => {
     const children: DefinitionItem[] = [];
@@ -28,6 +28,6 @@ export function definitionTransform(mdast: Root) {
   });
 }
 
-export const definitionPlugin: Plugin<[], Root, Root> = () => (tree) => {
+export const definitionPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   definitionTransform(tree);
 };

--- a/packages/myst-to-jats/src/transforms/index.ts
+++ b/packages/myst-to-jats/src/transforms/index.ts
@@ -1,4 +1,3 @@
-import type { Root } from 'mdast';
 import type { Plugin } from 'unified';
 
 import { definitionTransform } from './definitions.js';
@@ -7,6 +6,7 @@ import { tableTransform } from './tables.js';
 import { sectionTransform } from './sections.js';
 import { citeGroupTransform } from './citations.js';
 import type { Options } from '../types.js';
+import type { GenericParent } from 'myst-common';
 
 export { definitionTransform, definitionPlugin } from './definitions.js';
 export { containerTransform, containerPlugin } from './containers.js';
@@ -14,7 +14,7 @@ export { tableTransform, tablePlugin } from './tables.js';
 export { sectionTransform, sectionPlugin } from './sections.js';
 export { referenceTargetTransform, referenceResolutionTransform } from './references.js';
 
-export function basicTransformations(tree: Root, opts: Options) {
+export function basicTransformations(tree: GenericParent, opts: Options) {
   definitionTransform(tree);
   containerTransform(tree);
   tableTransform(tree);
@@ -22,6 +22,7 @@ export function basicTransformations(tree: Root, opts: Options) {
   citeGroupTransform(tree);
 }
 
-export const basicTransformationsPlugin: Plugin<[Options], Root, Root> = (opts) => (tree) => {
-  basicTransformations(tree, opts);
-};
+export const basicTransformationsPlugin: Plugin<[Options], GenericParent, GenericParent> =
+  (opts) => (tree) => {
+    basicTransformations(tree, opts);
+  };

--- a/packages/myst-to-jats/src/transforms/references.ts
+++ b/packages/myst-to-jats/src/transforms/references.ts
@@ -1,6 +1,5 @@
-import type { Root } from 'mdast';
 import { selectAll } from 'unist-util-select';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import type { CitationRenderer } from 'citation-js-utils';
 
 type CountAndLookup = { count: number; lookup: Record<string, string> };
@@ -43,7 +42,7 @@ function updateInventory(
  * footnotes, inlineExpressions, math, and citations.
  */
 export function referenceTargetTransform(
-  mdast: Root,
+  mdast: GenericParent,
   inventory: IdInventory,
   citations?: CitationRenderer,
 ) {
@@ -89,7 +88,7 @@ export function referenceTargetTransform(
 /**
  * Use reference lookup from referenceTargetTransform to update cross references
  */
-export function referenceResolutionTransform(mdast: Root, inventory: IdInventory) {
+export function referenceResolutionTransform(mdast: GenericParent, inventory: IdInventory) {
   const xrefs = selectAll('crossReference', mdast) as GenericNode[];
   const lookup = {
     ...inventory.section?.lookup,

--- a/packages/myst-to-jats/src/transforms/sections.ts
+++ b/packages/myst-to-jats/src/transforms/sections.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { Parent, Heading, Block } from 'myst-spec';
+import type { GenericParent } from 'myst-common';
 import { liftChildren, NotebookCell } from 'myst-common';
 import { remove } from 'unist-util-remove';
 import { selectAll } from 'unist-util-select';
@@ -29,7 +29,7 @@ function blockIsNotebookFigure(node: Block) {
   return !!node.data?.['fig-cap'];
 }
 
-function headingsToSections(tree: Root | Block, current?: Section) {
+function headingsToSections(tree: GenericParent | Block, current?: Section) {
   const children: Parent[] = [];
   // let current: Section | undefined = undefined;
   function push(child: any) {
@@ -75,7 +75,7 @@ function headingsToSections(tree: Root | Block, current?: Section) {
  *    - Top-level heading nodes are then used to break the tree into section nodes,
  *      with heading and subsequent nodes as children
  */
-export function sectionTransform(tree: Root, opts: Options) {
+export function sectionTransform(tree: GenericParent, opts: Options) {
   if (opts.isSubArticle) {
     (selectAll('block', tree) as Block[]).forEach((node) => {
       (node as any).type = 'section';
@@ -100,6 +100,6 @@ export function sectionTransform(tree: Root, opts: Options) {
   headingsToSections(tree);
 }
 
-export const sectionPlugin: Plugin<[Options], Root, Root> = (opts) => (tree) => {
+export const sectionPlugin: Plugin<[Options], GenericParent, GenericParent> = (opts) => (tree) => {
   sectionTransform(tree, opts);
 };

--- a/packages/myst-to-jats/src/transforms/tables.ts
+++ b/packages/myst-to-jats/src/transforms/tables.ts
@@ -1,9 +1,9 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { Table, TableRow } from 'myst-spec';
 import { selectAll } from 'unist-util-select';
+import type { GenericParent } from 'myst-common';
 
-export function tableTransform(mdast: Root) {
+export function tableTransform(mdast: GenericParent) {
   const tables = selectAll('table', mdast) as Table[];
   tables.forEach((table) => {
     const head: { type: 'tableHead'; children: TableRow[] } = { type: 'tableHead', children: [] };
@@ -20,6 +20,6 @@ export function tableTransform(mdast: Root) {
   });
 }
 
-export const tablePlugin: Plugin<[], Root, Root> = () => (tree) => {
+export const tablePlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   tableTransform(tree);
 };

--- a/packages/myst-transforms/src/admonitions.spec.ts
+++ b/packages/myst-transforms/src/admonitions.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { u } from 'unist-builder';
-import type { Root } from 'mdast';
 import { admonitionBlockquoteTransform, admonitionHeadersTransform } from './admonitions';
+import type { GenericParent } from 'myst-common';
 
 describe('Test admonitionBlockquoteTransform', () => {
   test('blockquote bold admonition', async () => {
@@ -13,8 +13,8 @@ describe('Test admonitionBlockquoteTransform', () => {
         ]),
       ]),
     ]);
-    admonitionBlockquoteTransform(mdast as Root);
-    admonitionHeadersTransform(mdast as Root);
+    admonitionBlockquoteTransform(mdast as GenericParent);
+    admonitionHeadersTransform(mdast as GenericParent);
     expect(mdast).toEqual(
       u('root', [
         u('admonition', { kind: 'note', class: 'simple' }, [
@@ -30,8 +30,8 @@ describe('Test admonitionBlockquoteTransform', () => {
         u('paragraph', [u('text', '[!NOTE] We know what we are, but know not what we may be.')]),
       ]),
     ]);
-    admonitionBlockquoteTransform(mdast as Root);
-    admonitionHeadersTransform(mdast as Root);
+    admonitionBlockquoteTransform(mdast as GenericParent);
+    admonitionHeadersTransform(mdast as GenericParent);
     expect(mdast).toEqual(
       u('root', [
         u('admonition', { kind: 'note', class: 'simple' }, [

--- a/packages/myst-transforms/src/admonitions.ts
+++ b/packages/myst-transforms/src/admonitions.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { Admonition, AdmonitionTitle, Blockquote, FlowContent } from 'myst-spec';
 import { selectAll } from 'unist-util-select';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { AdmonitionKind } from './types.js';
 
 type Options = {
@@ -31,7 +30,7 @@ export function admonitionKindToTitle(kind: AdmonitionKind | string) {
 /**
  * Visit all admonitions and add headers if necessary
  */
-export function admonitionHeadersTransform(tree: Root, opts?: Options) {
+export function admonitionHeadersTransform(tree: GenericParent, opts?: Options) {
   const admonitions = selectAll('admonition', tree) as Admonition[];
   admonitions.forEach((node: Admonition) => {
     if (
@@ -121,7 +120,7 @@ function transformGitHubBracketedAdmonition(node: GenericNode): boolean {
 /**
  * Visit all blockquote notes and add headers if necessary, support GitHub style admonitions
  */
-export function admonitionBlockquoteTransform(tree: Root) {
+export function admonitionBlockquoteTransform(tree: GenericParent) {
   const blockquote = selectAll('blockquote', tree) as Blockquote[];
   blockquote.forEach((node: GenericNode) => {
     // Loop through the various flavours of blockquote admonitions and return early if already transformed
@@ -132,10 +131,12 @@ export function admonitionBlockquoteTransform(tree: Root) {
   });
 }
 
-export const admonitionHeadersPlugin: Plugin<[Options?], Root, Root> = (opts) => (tree) => {
-  admonitionHeadersTransform(tree, opts);
-};
+export const admonitionHeadersPlugin: Plugin<[Options?], GenericParent, GenericParent> =
+  (opts) => (tree) => {
+    admonitionHeadersTransform(tree, opts);
+  };
 
-export const admonitionBlockquotePlugin: Plugin<[], Root, Root> = () => (tree) => {
-  admonitionBlockquoteTransform(tree);
-};
+export const admonitionBlockquotePlugin: Plugin<[], GenericParent, GenericParent> =
+  () => (tree) => {
+    admonitionBlockquoteTransform(tree);
+  };

--- a/packages/myst-transforms/src/basic.ts
+++ b/packages/myst-transforms/src/basic.ts
@@ -1,4 +1,3 @@
-import type { Root } from 'mdast';
 import type { Plugin } from 'unified';
 import type { VFile } from 'vfile';
 import { liftMystDirectivesAndRolesTransform } from './liftMystDirectivesAndRoles.js';
@@ -11,8 +10,9 @@ import { imageAltTextTransform } from './images.js';
 import { mathLabelTransform, mathNestingTransform } from './math.js';
 import { blockquoteTransform } from './blockquote.js';
 import { codeBlockToDirectiveTransform } from './code.js';
+import type { GenericParent } from 'myst-common';
 
-export function basicTransformations(tree: Root, file: VFile) {
+export function basicTransformations(tree: GenericParent, file: VFile) {
   // lifting roles and directives must happen before the mystTarget transformation
   liftMystDirectivesAndRolesTransform(tree);
   // Some specifics about the ordering are noted below
@@ -35,6 +35,7 @@ export function basicTransformations(tree: Root, file: VFile) {
   blockquoteTransform(tree);
 }
 
-export const basicTransformationsPlugin: Plugin<[], Root, Root> = () => (tree, file) => {
-  basicTransformations(tree, file);
-};
+export const basicTransformationsPlugin: Plugin<[], GenericParent, GenericParent> =
+  () => (tree, file) => {
+    basicTransformations(tree, file);
+  };

--- a/packages/myst-transforms/src/blockquote.spec.ts
+++ b/packages/myst-transforms/src/blockquote.spec.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'vitest';
 import { u } from 'unist-builder';
-import type { Root } from 'mdast';
 import { blockquoteTransform } from './blockquote';
 
 describe('Test blockquoteTransform', () => {
@@ -11,7 +10,7 @@ describe('Test blockquoteTransform', () => {
         u('list', { ordered: false }, [u('listItem', [u('text', 'Hamlet act 4, Scene 5')])]),
       ]),
     ]);
-    blockquoteTransform(mdast as Root);
+    blockquoteTransform(mdast);
     expect(mdast).toEqual(
       u('root', [
         u('container', { kind: 'quote' }, [

--- a/packages/myst-transforms/src/blockquote.ts
+++ b/packages/myst-transforms/src/blockquote.ts
@@ -1,9 +1,9 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { Blockquote, Caption, Container } from 'myst-spec';
 import { selectAll } from 'unist-util-select';
+import type { GenericParent } from 'myst-common';
 
-export function blockquoteTransform(mdast: Root) {
+export function blockquoteTransform(mdast: GenericParent) {
   const quotes = selectAll('blockquote', mdast) as Blockquote[];
   quotes.forEach((node) => {
     if (node.children.length < 2) return;
@@ -21,6 +21,6 @@ export function blockquoteTransform(mdast: Root) {
   });
 }
 
-export const blockquotePlugin: Plugin<[], Root, Root> = () => (tree) => {
+export const blockquotePlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   blockquoteTransform(tree);
 };

--- a/packages/myst-transforms/src/blocks.spec.ts
+++ b/packages/myst-transforms/src/blocks.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { u } from 'unist-builder';
 import { VFile } from 'vfile';
-import type { Root } from 'mdast';
 import { blockMetadataTransform } from './blocks';
 
 describe('Test blockMetadataTransform', () => {
@@ -11,7 +10,7 @@ describe('Test blockMetadataTransform', () => {
         u('paragraph', [u('text', 'We know what we are, but know not what we may be.')]),
       ]),
     ]) as any;
-    blockMetadataTransform(mdast as Root, new VFile());
+    blockMetadataTransform(mdast, new VFile());
     expect(mdast).toEqual(
       u('root', [
         u('block', { data: { key: 'value' } }, [
@@ -26,7 +25,7 @@ describe('Test blockMetadataTransform', () => {
         u('paragraph', [u('text', 'We know what we are, but know not what we may be.')]),
       ]),
     ]) as any;
-    blockMetadataTransform(mdast as Root, new VFile());
+    blockMetadataTransform(mdast, new VFile());
     expect(mdast).toEqual(
       u('root', [
         u('block', { data: { a: 'b', key: 'value' } }, [
@@ -41,7 +40,7 @@ describe('Test blockMetadataTransform', () => {
         u('paragraph', [u('text', 'We know what we are, but know not what we may be.')]),
       ]),
     ]) as any;
-    blockMetadataTransform(mdast as Root, new VFile());
+    blockMetadataTransform(mdast, new VFile());
     expect(mdast).toEqual(
       u('root', [
         u(
@@ -63,7 +62,7 @@ describe('Test blockMetadataTransform', () => {
         u('code', 'We know what we are, but know not what we may be.'),
       ]),
     ]) as any;
-    blockMetadataTransform(mdast as Root, new VFile());
+    blockMetadataTransform(mdast, new VFile());
     expect(mdast).toEqual(
       u('root', [
         u(
@@ -92,7 +91,7 @@ describe('Test blockMetadataTransform', () => {
         u('output', 'but know not what we may be.'),
       ]),
     ]) as any;
-    blockMetadataTransform(mdast as Root, new VFile());
+    blockMetadataTransform(mdast, new VFile());
     expect(mdast).toEqual(
       u('root', [
         u(

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -1,13 +1,12 @@
 import type { VFile } from 'vfile';
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { Node, Parent } from 'myst-spec';
 import { select, selectAll } from 'unist-util-select';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { fileError, normalizeLabel } from 'myst-common';
 import type { Code } from 'myst-spec-ext';
 
-export function blockNestingTransform(mdast: Root) {
+export function blockNestingTransform(mdast: GenericParent) {
   if (!select('block', mdast)) {
     const blockNode = { type: 'block', children: mdast.children as Node[] };
     (mdast as Parent).children = [blockNode];
@@ -23,13 +22,13 @@ export function blockNestingTransform(mdast: Root) {
   }
 }
 
-export const blockNestingPlugin: Plugin<[], Root, Root> = () => (tree) => {
+export const blockNestingPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   blockNestingTransform(tree);
 };
 
 const TRANSFORM_SOURCE = 'BlockTransform:BlockMetadata';
 
-export function blockMetadataTransform(mdast: Root, file: VFile) {
+export function blockMetadataTransform(mdast: GenericParent, file: VFile) {
   const blocks = selectAll('block', mdast) as any[];
   blocks.forEach((block) => {
     if (block.meta) {
@@ -78,6 +77,6 @@ export function blockMetadataTransform(mdast: Root, file: VFile) {
   });
 }
 
-export const blockMetadataPlugin: Plugin<[], Root, Root> = () => (tree, file) => {
+export const blockMetadataPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree, file) => {
   blockMetadataTransform(tree, file);
 };

--- a/packages/myst-transforms/src/caption.ts
+++ b/packages/myst-transforms/src/caption.ts
@@ -1,14 +1,14 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { Caption, PhrasingContent } from 'myst-spec';
 import { visit } from 'unist-util-visit';
+import type { GenericParent } from 'myst-common';
 
 /**
  * Ensure caption content is nested in a paragraph.
  *
  * This function is idempotent.
  */
-export function captionParagraphTransform(tree: Root) {
+export function captionParagraphTransform(tree: GenericParent) {
   visit(tree, 'caption', (node: Caption) => {
     if (node.children && node.children[0]?.type !== 'paragraph') {
       node.children = [
@@ -18,6 +18,6 @@ export function captionParagraphTransform(tree: Root) {
   });
 }
 
-export const captionParagraphPlugin: Plugin<[], Root, Root> = () => (tree) => {
+export const captionParagraphPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   captionParagraphTransform(tree);
 };

--- a/packages/myst-transforms/src/code.spec.ts
+++ b/packages/myst-transforms/src/code.spec.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from 'vitest';
-import type { Root } from 'mdast';
 import { VFile } from 'vfile';
 import { codeTransform } from './code';
 
@@ -7,7 +6,7 @@ describe('Test codeTransform', () => {
   test('simple code block returns self', async () => {
     const file = new VFile();
     const mdast = { type: 'root', children: [{ type: 'code', lang: 'geometry', value: 'y=mx+b' }] };
-    codeTransform(mdast as Root, file);
+    codeTransform(mdast, file);
     expect(mdast).toEqual({
       type: 'root',
       children: [{ type: 'code', lang: 'geometry', value: 'y=mx+b' }],
@@ -16,7 +15,7 @@ describe('Test codeTransform', () => {
   test('code block lang coerces to python', async () => {
     const mdast = { type: 'root', children: [{ type: 'code', lang: 'IPython3', value: 'y=mx+b' }] };
     const file = new VFile();
-    codeTransform(mdast as Root, file);
+    codeTransform(mdast, file);
     expect(mdast).toEqual({
       type: 'root',
       children: [{ type: 'code', lang: 'python', value: 'y=mx+b' }],
@@ -25,7 +24,7 @@ describe('Test codeTransform', () => {
   test('code block lang ignores frontmatter', async () => {
     const mdast = { type: 'root', children: [{ type: 'code', lang: 'IPython3', value: 'y=mx+b' }] };
     const file = new VFile();
-    codeTransform(mdast as Root, file, { lang: 'javascript' });
+    codeTransform(mdast, file, { lang: 'javascript' });
     expect(mdast).toEqual({
       type: 'root',
       children: [{ type: 'code', lang: 'python', value: 'y=mx+b' }],
@@ -34,7 +33,7 @@ describe('Test codeTransform', () => {
   test('python is not transformed', async () => {
     const mdast = { type: 'root', children: [{ type: 'code', lang: 'IPython3', value: 'y=mx+b' }] };
     const file = new VFile();
-    codeTransform(mdast as Root, file, { transformPython: false });
+    codeTransform(mdast, file, { transformPython: false });
     expect(mdast).toEqual({
       type: 'root',
       children: [{ type: 'code', lang: 'IPython3', value: 'y=mx+b' }],
@@ -43,7 +42,7 @@ describe('Test codeTransform', () => {
   test('code block lang fills frontmatter', async () => {
     const mdast = { type: 'root', children: [{ type: 'code', value: 'y=mx+b' }] };
     const file = new VFile();
-    codeTransform(mdast as Root, file, { lang: 'javascript' });
+    codeTransform(mdast, file, { lang: 'javascript' });
     expect(mdast).toEqual({
       type: 'root',
       children: [{ type: 'code', lang: 'javascript', value: 'y=mx+b' }],
@@ -52,7 +51,7 @@ describe('Test codeTransform', () => {
   test('code block lang fills frontmatter and coerces', async () => {
     const mdast = { type: 'root', children: [{ type: 'code', value: 'y=mx+b' }] };
     const file = new VFile();
-    codeTransform(mdast as Root, file, { lang: 'IPython3' });
+    codeTransform(mdast, file, { lang: 'IPython3' });
     expect(mdast).toEqual({
       type: 'root',
       children: [{ type: 'code', lang: 'python', value: 'y=mx+b' }],
@@ -61,7 +60,7 @@ describe('Test codeTransform', () => {
   test('code without lang raises warning', async () => {
     const mdast = { type: 'root', children: [{ type: 'code', value: 'y=mx+b' }] };
     const file = new VFile();
-    codeTransform(mdast as Root, file);
+    codeTransform(mdast, file);
     expect(mdast).toEqual({
       type: 'root',
       children: [{ type: 'code', value: 'y=mx+b' }],

--- a/packages/myst-transforms/src/code.ts
+++ b/packages/myst-transforms/src/code.ts
@@ -1,17 +1,16 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
-import type { Code } from 'myst-spec';
 import { selectAll } from 'unist-util-select';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { fileWarn } from 'myst-common';
 import type { VFile } from 'vfile';
+import type { Code } from 'myst-spec';
 
 type Options = {
   lang?: string;
   transformPython?: boolean;
 };
 
-export function codeTransform(mdast: Root, file: VFile, opts?: Options) {
+export function codeTransform(mdast: GenericParent, file: VFile, opts?: Options) {
   const code = selectAll('code', mdast) as Code[];
   code.forEach((node) => {
     if (!node.lang) {
@@ -28,16 +27,17 @@ export function codeTransform(mdast: Root, file: VFile, opts?: Options) {
   });
 }
 
-export const codePlugin: Plugin<[Options?], Root, Root> = (opts) => (tree, file) => {
-  codeTransform(tree, file, opts);
-};
+export const codePlugin: Plugin<[Options?], GenericParent, GenericParent> =
+  (opts) => (tree, file) => {
+    codeTransform(tree, file, opts);
+  };
 
 type CodeBlockTransformOptions = {
   translate: (string | { lang: string; directive?: string })[];
 };
 
 export function codeBlockToDirectiveTransform(
-  tree: Root,
+  tree: GenericParent,
   file: VFile,
   opts?: CodeBlockTransformOptions,
 ) {
@@ -54,7 +54,10 @@ export function codeBlockToDirectiveTransform(
   });
 }
 
-export const codeBlockToDirectivePlugin: Plugin<[CodeBlockTransformOptions?], Root, Root> =
-  (opts) => (tree, file) => {
-    codeBlockToDirectiveTransform(tree, file, opts);
-  };
+export const codeBlockToDirectivePlugin: Plugin<
+  [CodeBlockTransformOptions?],
+  GenericParent,
+  GenericParent
+> = (opts) => (tree, file) => {
+  codeBlockToDirectiveTransform(tree, file, opts);
+};

--- a/packages/myst-transforms/src/footnotes.ts
+++ b/packages/myst-transforms/src/footnotes.ts
@@ -1,8 +1,8 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { VFile } from 'vfile';
 import type { FootnoteDefinition, FootnoteReference } from 'myst-spec-ext';
 import { selectAll } from 'unist-util-select';
+import type { GenericParent } from 'myst-common';
 import { fileWarn } from 'myst-common';
 
 function nextNumber(current: number, reserved: Set<number>): number {
@@ -14,7 +14,7 @@ function nextNumber(current: number, reserved: Set<number>): number {
 
 const TRANSFORM_SOURCE = 'myst-transforms:footnotes';
 
-export function footnotesTransform(mdast: Root, file: VFile) {
+export function footnotesTransform(mdast: GenericParent, file: VFile) {
   const footnotes = selectAll('footnoteDefinition', mdast) as FootnoteDefinition[];
   const footnotesLookup = Object.fromEntries(
     footnotes.map((n) => {
@@ -60,6 +60,6 @@ export function footnotesTransform(mdast: Root, file: VFile) {
   });
 }
 
-export const footnotesPlugin: Plugin<[], Root, Root> = () => (tree, file) => {
+export const footnotesPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree, file) => {
   footnotesTransform(tree, file);
 };

--- a/packages/myst-transforms/src/frontmatter.spec.ts
+++ b/packages/myst-transforms/src/frontmatter.spec.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import type { Root } from 'mdast';
 import { VFile } from 'vfile';
 import { getFrontmatter } from './frontmatter';
 
@@ -9,7 +8,7 @@ describe('getFrontmatter', () => {
       type: 'root',
       children: [],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, {});
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, {});
     expect(tree).toEqual(input);
     expect(frontmatter).toEqual({});
   });
@@ -23,7 +22,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, {});
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, {});
     expect(tree).toEqual(input);
     expect(frontmatter).toEqual({});
   });
@@ -42,7 +41,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, {});
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, {});
     expect(tree).toEqual(input);
     expect(frontmatter).toEqual({});
   });
@@ -57,7 +56,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, {});
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, {});
     expect(tree).toEqual(input);
     expect(frontmatter).toEqual({});
   });
@@ -76,7 +75,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, {});
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, {});
     expect(tree).toEqual(input);
     expect(frontmatter).toEqual({ title: 'My Title' });
   });
@@ -92,7 +91,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root);
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input);
     expect(tree).toEqual(input);
     expect(frontmatter).toEqual({});
   });
@@ -111,7 +110,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, { removeYaml: true });
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, { removeYaml: true });
     expect(tree).toEqual({
       type: 'root',
       children: [
@@ -134,7 +133,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, { removeYaml: true });
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, { removeYaml: true });
     expect(tree).toEqual(input);
     expect(frontmatter).toEqual({ title: 'My Title' });
   });
@@ -158,7 +157,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, {});
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, {});
     expect(tree).toEqual(input);
     expect(frontmatter).toEqual({ title: 'Heading Title' });
   });
@@ -182,7 +181,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, {
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, {
       removeHeading: true,
     });
     expect(tree).toEqual({
@@ -212,7 +211,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, {
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, {
       removeHeading: true,
     });
     expect(tree).toEqual(input);
@@ -243,7 +242,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, {
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, {
       removeHeading: true,
     });
     expect(tree).toEqual(input);
@@ -274,7 +273,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, {
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, {
       removeHeading: true,
     });
     expect(tree).toEqual({
@@ -309,7 +308,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, {});
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, {});
     expect(tree).toEqual(input);
     expect(frontmatter).toEqual({ title: 'My Title' });
   });
@@ -329,7 +328,7 @@ describe('getFrontmatter', () => {
         },
       ],
     };
-    const { tree, frontmatter } = getFrontmatter(new VFile(), input as Root, {});
+    const { tree, frontmatter } = getFrontmatter(new VFile(), input, {});
     expect(tree).toEqual(input);
     expect(frontmatter).toEqual({ title: 'My Title' });
   });

--- a/packages/myst-transforms/src/frontmatter.ts
+++ b/packages/myst-transforms/src/frontmatter.ts
@@ -1,7 +1,7 @@
 import yaml from 'js-yaml';
 import { remove } from 'unist-util-remove';
-import type { Root } from 'mdast';
 import type { Block, Code, Heading } from 'myst-spec';
+import type { GenericParent } from 'myst-common';
 import { fileError, toText } from 'myst-common';
 import type { VFile } from 'vfile';
 import { mystTargetsTransform } from './targets.js';
@@ -19,9 +19,9 @@ type Options = {
 
 export function getFrontmatter(
   file: VFile,
-  tree: Root,
+  tree: GenericParent,
   opts: Options = { removeYaml: true, removeHeading: true, propagateTargets: true },
-): { tree: Root; frontmatter: Record<string, any> } {
+): { tree: GenericParent; frontmatter: Record<string, any> } {
   if (opts.propagateTargets) mystTargetsTransform(tree);
   const firstParent =
     (tree.children[0]?.type as any) === 'block' ? (tree.children[0] as any as Block) : tree;

--- a/packages/myst-transforms/src/glossary.ts
+++ b/packages/myst-transforms/src/glossary.ts
@@ -1,5 +1,4 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { Node } from 'myst-spec';
 import type { VFile } from 'vfile';
 import { selectAll } from 'unist-util-select';
@@ -11,7 +10,11 @@ export type Options = {
   state: IReferenceState;
 };
 
-export function glossaryTransform<T extends Node | Root>(mdast: T, file: VFile, opts: Options) {
+export function glossaryTransform<T extends Node | GenericParent>(
+  mdast: T,
+  file: VFile,
+  opts: Options,
+) {
   const glossaries = selectAll('glossary', mdast) as GenericParent[];
   glossaries.forEach((glossary) => {
     glossary.children.forEach((list) => {
@@ -37,6 +40,7 @@ export function glossaryTransform<T extends Node | Root>(mdast: T, file: VFile, 
   });
 }
 
-export const glossaryPlugin: Plugin<[Options], Root, Root> = (opts) => (tree, file) => {
-  glossaryTransform(tree, file, opts);
-};
+export const glossaryPlugin: Plugin<[Options], GenericParent, GenericParent> =
+  (opts) => (tree, file) => {
+    glossaryTransform(tree, file, opts);
+  };

--- a/packages/myst-transforms/src/html.ts
+++ b/packages/myst-transforms/src/html.ts
@@ -1,6 +1,5 @@
 import type { Plugin } from 'unified';
 import type { H, Handle } from 'hast-util-to-mdast';
-import type { Root } from 'mdast';
 import type { Parent } from 'myst-spec';
 import { unified } from 'unified';
 import { all } from 'hast-util-to-mdast';
@@ -9,6 +8,7 @@ import { visit } from 'unist-util-visit';
 import type { Options } from 'rehype-parse';
 import rehypeParse from 'rehype-parse';
 import rehypeRemark from 'rehype-remark';
+import type { GenericParent } from 'myst-common';
 import { liftChildren } from 'myst-common';
 
 export type HtmlTransformOptions = {
@@ -39,7 +39,7 @@ const defaultHtmlToMdastOptions: Record<keyof HtmlTransformOptions, any> = {
   },
 };
 
-export function htmlTransform(tree: Root, opts?: HtmlTransformOptions) {
+export function htmlTransform(tree: GenericParent, opts?: HtmlTransformOptions) {
   const handlers = { ...defaultHtmlToMdastOptions.htmlHandlers, ...opts?.htmlHandlers };
   const otherOptions = { ...defaultHtmlToMdastOptions, ...opts };
   const htmlNodes = selectAll('html', tree) as Parent[];
@@ -69,6 +69,7 @@ export function htmlTransform(tree: Root, opts?: HtmlTransformOptions) {
   return tree;
 }
 
-export const htmlPlugin: Plugin<[HtmlTransformOptions?], Root, Root> = (opts) => (tree) => {
-  htmlTransform(tree, opts);
-};
+export const htmlPlugin: Plugin<[HtmlTransformOptions?], GenericParent, GenericParent> =
+  (opts) => (tree) => {
+    htmlTransform(tree, opts);
+  };

--- a/packages/myst-transforms/src/htmlIds.ts
+++ b/packages/myst-transforms/src/htmlIds.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { Node } from 'myst-spec';
 import { map } from 'unist-util-map';
+import type { GenericParent } from 'myst-common';
 
 /**
  * Ensure all HTML ids in the document are unique
@@ -9,7 +9,7 @@ import { map } from 'unist-util-map';
  * @param mdast
  * @returns
  */
-export function htmlIdsTransform<T extends Node | Root>(mdast: T) {
+export function htmlIdsTransform<T extends Node | GenericParent>(mdast: T) {
   const ids = new Set();
   map(mdast as any, (node: Node & { html_id?: string }) => {
     if (!node.html_id) return;
@@ -30,6 +30,6 @@ export function htmlIdsTransform<T extends Node | Root>(mdast: T) {
   });
 }
 
-export const htmlIdsPlugin: Plugin<[], Root, Root> = () => (tree) => {
+export const htmlIdsPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   htmlIdsTransform(tree);
 };

--- a/packages/myst-transforms/src/images.ts
+++ b/packages/myst-transforms/src/images.ts
@@ -1,10 +1,10 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { Container, Paragraph, PhrasingContent, Image } from 'myst-spec';
 import { select, selectAll } from 'unist-util-select';
+import type { GenericParent } from 'myst-common';
 import { toText } from 'myst-common';
 
-export function imageAltTextTransform(tree: Root) {
+export function imageAltTextTransform(tree: GenericParent) {
   const containers = selectAll('container', tree) as Container[];
   containers.forEach((container) => {
     const image = select('image', container) as Image;
@@ -18,6 +18,6 @@ export function imageAltTextTransform(tree: Root) {
   });
 }
 
-export const imageAltTextPlugin: Plugin<[], Root, Root> = () => (tree) => {
+export const imageAltTextPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   imageAltTextTransform(tree);
 };

--- a/packages/myst-transforms/src/joinGates.ts
+++ b/packages/myst-transforms/src/joinGates.ts
@@ -1,7 +1,6 @@
 import type { GenericNode, GenericParent } from 'myst-common';
 import { fileWarn, fileError } from 'myst-common';
 import { map } from 'unist-util-map';
-import type { Root } from 'mdast';
 import type { Plugin } from 'unified';
 import type { VFile } from 'vfile';
 
@@ -47,6 +46,6 @@ export function joinGatesTransform(tree: GenericParent, file: VFile) {
   });
 }
 
-export const joinGatesPlugin: Plugin<[], Root, Root> = () => (tree, file) => {
+export const joinGatesPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree, file) => {
   joinGatesTransform(tree as GenericParent, file);
 };

--- a/packages/myst-transforms/src/keys.ts
+++ b/packages/myst-transforms/src/keys.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import type { Node } from 'myst-spec';
 import { map } from 'unist-util-map';
+import type { GenericParent } from 'myst-common';
 import { createId } from 'myst-common';
 
 function addKeys(node: Node) {
@@ -16,10 +16,10 @@ function addKeys(node: Node) {
  * @param mdast
  * @returns
  */
-export function keysTransform<T extends Node | Root>(mdast: T): Root | Node {
+export function keysTransform<T extends Node | GenericParent>(mdast: T): GenericParent | Node {
   return map(mdast as any, addKeys);
 }
 
-export const keysPlugin: Plugin<[], Root, Root> = () => (tree) => {
+export const keysPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   keysTransform(tree);
 };

--- a/packages/myst-transforms/src/liftMystDirectivesAndRoles.ts
+++ b/packages/myst-transforms/src/liftMystDirectivesAndRoles.ts
@@ -1,6 +1,5 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { liftChildren } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 
@@ -11,7 +10,7 @@ import { selectAll } from 'unist-util-select';
  *
  * @param tree The tree which is modified in place.
  */
-export function liftMystDirectivesAndRolesTransform(tree: Root) {
+export function liftMystDirectivesAndRolesTransform(tree: GenericParent) {
   const directives = selectAll('mystDirective,mystRole', tree) as GenericNode[];
   directives.forEach((n) => {
     const child = n.children?.[0];
@@ -26,6 +25,7 @@ export function liftMystDirectivesAndRolesTransform(tree: Root) {
   liftChildren(tree, 'mystRole');
 }
 
-export const liftMystDirectivesAndRolesPlugin: Plugin<[], Root, Root> = () => (tree) => {
-  liftMystDirectivesAndRolesTransform(tree);
-};
+export const liftMystDirectivesAndRolesPlugin: Plugin<[], GenericParent, GenericParent> =
+  () => (tree) => {
+    liftMystDirectivesAndRolesTransform(tree);
+  };

--- a/packages/myst-transforms/src/links/plugin.ts
+++ b/packages/myst-transforms/src/links/plugin.ts
@@ -1,8 +1,8 @@
 import type { Plugin } from 'unified';
-import type { Root } from 'mdast';
 import { selectAll } from 'unist-util-select';
 import type { VFile } from 'vfile';
 import type { Link, LinkTransformer } from './types.js';
+import type { GenericParent } from 'myst-common';
 
 type Options = {
   transformers: LinkTransformer[];
@@ -36,7 +36,7 @@ function formatLinkText(link: Link) {
   link.children[0].value = formatted;
 }
 
-export function linksTransform(mdast: Root, file: VFile, opts: Options): void {
+export function linksTransform(mdast: GenericParent, file: VFile, opts: Options): void {
   const linkNodes = selectAll(opts.selector ?? 'link,card', mdast) as Link[];
   linkNodes.forEach((link) => {
     formatLinkText(link);
@@ -55,6 +55,7 @@ export function linksTransform(mdast: Root, file: VFile, opts: Options): void {
   });
 }
 
-export const linksPlugin: Plugin<[Options], Root, Root> = (opts) => (tree, file) => {
-  linksTransform(tree, file, opts);
-};
+export const linksPlugin: Plugin<[Options], GenericParent, GenericParent> =
+  (opts) => (tree, file) => {
+    linksTransform(tree, file, opts);
+  };

--- a/packages/myst-transforms/src/math.ts
+++ b/packages/myst-transforms/src/math.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from 'unified';
 import type { VFile } from 'vfile';
 import katex from 'katex';
-import type { Root } from 'mdast';
-import type { Math, InlineMath, Node, Code } from 'myst-spec';
+import type { Math, InlineMath, Node } from 'myst-spec';
 import { selectAll } from 'unist-util-select';
 import type { GenericParent } from 'myst-common';
 import { copyNode, fileError, fileWarn, normalizeLabel } from 'myst-common';
@@ -223,14 +222,14 @@ function renderEquation(file: VFile, node: Math | InlineMath, opts?: Options) {
  * @param file
  */
 export function mathNestingTransform(
-  tree: Root,
+  tree: GenericParent,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   file: VFile,
 ) {
   unnestTransform(tree as GenericParent, 'paragraph', 'math');
 }
 
-export function mathLabelTransform(tree: Root, file: VFile) {
+export function mathLabelTransform(tree: GenericParent, file: VFile) {
   const nodes = selectAll('math,inlineMath', tree) as (Math | InlineMath)[];
   nodes.forEach((node) => {
     transformMathValue(file, node);
@@ -239,21 +238,22 @@ export function mathLabelTransform(tree: Root, file: VFile) {
   });
 }
 
-export function mathTransform(tree: Root, file: VFile, opts?: Options) {
+export function mathTransform(tree: GenericParent, file: VFile, opts?: Options) {
   const nodes = selectAll('math,inlineMath', tree) as (Math | InlineMath)[];
   nodes.forEach((node) => {
     renderEquation(file, node, opts);
   });
 }
 
-export const mathNestingPlugin: Plugin<[], Root, Root> = () => (tree, file) => {
+export const mathNestingPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree, file) => {
   mathNestingTransform(tree, file);
 };
 
-export const mathLabelPlugin: Plugin<[], Root, Root> = () => (tree, file) => {
+export const mathLabelPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree, file) => {
   mathLabelTransform(tree, file);
 };
 
-export const mathPlugin: Plugin<[Options?], Root, Root> = (opts) => (tree, file) => {
-  mathTransform(tree, file, opts);
-};
+export const mathPlugin: Plugin<[Options?], GenericParent, GenericParent> =
+  (opts) => (tree, file) => {
+    mathTransform(tree, file, opts);
+  };

--- a/packages/myst-transforms/src/targets.ts
+++ b/packages/myst-transforms/src/targets.ts
@@ -2,10 +2,10 @@ import type { Plugin } from 'unified';
 import { findAfter } from 'unist-util-find-after';
 import { visit } from 'unist-util-visit';
 import { remove } from 'unist-util-remove';
-import type { Root } from 'mdast';
 import type { Target, Parent } from 'myst-spec';
 import type { Heading } from 'myst-spec-ext';
 import { selectAll } from 'unist-util-select';
+import type { GenericParent } from 'myst-common';
 import { normalizeLabel, toText } from 'myst-common';
 
 /**
@@ -24,7 +24,7 @@ import { normalizeLabel, toText } from 'myst-common';
  * Note, this should happen after `mystDirective`s have been lifted,
  * and other structural changes to the tree that don't preserve labels.
  */
-export function mystTargetsTransform(tree: Root) {
+export function mystTargetsTransform(tree: GenericParent) {
   visit(tree, 'mystTarget', (node: Target, index: number, parent: Parent) => {
     // TODO: have multiple targets and collect the labels
     const nextNode = findAfter(parent, index) as any;
@@ -39,14 +39,14 @@ export function mystTargetsTransform(tree: Root) {
   remove(tree, 'mystTarget');
 }
 
-export const mystTargetsPlugin: Plugin<[], Root, Root> = () => (tree) => {
+export const mystTargetsPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   mystTargetsTransform(tree);
 };
 
 /**
  * Add implicit labels & identifiers to all headings
  */
-export function headingLabelTransform(tree: Root) {
+export function headingLabelTransform(tree: GenericParent) {
   const headings = selectAll('heading', tree) as Heading[];
   headings.forEach((node) => {
     if (node.label || node.identifier) return;
@@ -63,6 +63,6 @@ export function headingLabelTransform(tree: Root) {
   });
 }
 
-export const headingLabelPlugin: Plugin<[], Root, Root> = () => (tree) => {
+export const headingLabelPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   headingLabelTransform(tree);
 };

--- a/packages/myst-transforms/tests/abbreviations.spec.ts
+++ b/packages/myst-transforms/tests/abbreviations.spec.ts
@@ -2,8 +2,7 @@ import { describe, expect, test } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
-import type { Root } from 'mdast';
-import { abbreviationTransform, ReferenceState } from '../src';
+import { abbreviationTransform } from '../src';
 
 type TestFile = {
   cases: TestCase[];
@@ -24,8 +23,7 @@ describe('abbreviate', () => {
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
     '%s',
     (_, { before, after, opts }) => {
-      abbreviationTransform(before as Root, opts);
-      
+      abbreviationTransform(before, opts);
       expect(yaml.dump(before)).toEqual(yaml.dump(after));
     },
   );

--- a/packages/myst-transforms/tests/enumerators.spec.ts
+++ b/packages/myst-transforms/tests/enumerators.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
-import type { Root } from 'mdast';
 import { enumerateTargetsTransform, ReferenceState } from '../src';
 
 type TestFile = {
@@ -25,7 +24,7 @@ describe('enumerateTargets', () => {
     '%s',
     (_, { before, after, opts }) => {
       const state = new ReferenceState(opts);
-      const transformed = enumerateTargetsTransform(before as Root, { state });
+      const transformed = enumerateTargetsTransform(before, { state });
       expect(yaml.dump(transformed)).toEqual(yaml.dump(after));
     },
   );

--- a/packages/myst-transforms/tests/html.spec.ts
+++ b/packages/myst-transforms/tests/html.spec.ts
@@ -2,16 +2,16 @@ import { describe, expect, test } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
-import type { Root } from 'mdast';
 import { htmlTransform } from '../src';
+import type { GenericParent } from 'myst-common';
 
 type TestFile = {
   cases: TestCase[];
 };
 type TestCase = {
   title: string;
-  before: Root;
-  after: Root;
+  before: GenericParent;
+  after: GenericParent;
   opts?: Record<string, boolean>;
 };
 
@@ -24,7 +24,7 @@ describe('convertHtmlToMdast', () => {
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
     '%s',
     (_, { before, after, opts }) => {
-      const transformed = htmlTransform(before as Root, opts || {});
+      const transformed = htmlTransform(before, opts || {});
       expect(yaml.dump(transformed)).toEqual(yaml.dump(after));
     },
   );


### PR DESCRIPTION
There are two goals for this:

(1) the types, especially in the theme almost always break
(2) `mdast` is deprecated as a package

This moves to using `GenericNode` in place of `Root`.