### PR TITLE
🏷 Allow for an extra space in `# | label:` syntax

### DIFF
--- a/.changeset/lemon-flowers-taste.md
+++ b/.changeset/lemon-flowers-taste.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'mystmd': patch
+---
+
+Allow for an extra space between # and | in starting the labeled code cell.

--- a/docs/reuse-jupyter-outputs.md
+++ b/docs/reuse-jupyter-outputs.md
@@ -15,12 +15,14 @@ A scientific article with two figures created in Jupyter Notebooks. Each figure 
 
 ## Label a Notebook Cell
 
-You can label notebook cells using a comment at the top of the cell, using a `#| label:` syntax, or have this added directly in the notebook metadata for the cell.
+You can label notebook cells using a comment at the top of the cell, using a `#| label:` syntax[^black], or have this added directly in the notebook metadata for the cell.
 
 ```python
 #| label: my-cell
 print('hello world')
 ```
+
+[^black]: If your code formatter changes this to a `# | label:` with an extra space that is fine too! 🎉
 
 ## Cross References
 

--- a/packages/myst-cli/src/transforms/code.spec.ts
+++ b/packages/myst-cli/src/transforms/code.spec.ts
@@ -32,6 +32,13 @@ describe('metadataFromCode', () => {
       metadata: { key: 'value', flag: true },
     });
   });
+  it('basic metadata with SPACE between `#` and `|` is parsed', async () => {
+    const value = '# | key: value\n# | flag: true\n\na = 5 + 5\nprint(a)';
+    expect(metadataFromCode(new Session(), '', value)).toEqual({
+      value,
+      metadata: { key: 'value', flag: true },
+    });
+  });
   it('whitespace is ignored around metadata', async () => {
     const value = '\n\n#| key: value\n\n#| flag: true\n\n\na = 5 + 5\nprint(a)';
     expect(metadataFromCode(new Session(), '', value)).toEqual({

--- a/packages/myst-cli/src/transforms/code.ts
+++ b/packages/myst-cli/src/transforms/code.ts
@@ -5,7 +5,8 @@ import yaml from 'js-yaml';
 import type { ISession } from '../session/types.js';
 import type { VFile } from 'vfile';
 
-const CELL_OPTION_PREFIX = '#| ';
+// Note: There may be a space in between the "# |", which is introduced by `black` in python.
+const CELL_OPTION_PREFIX = /^#\s?\| /;
 
 /**
  * Parse metadata from code block using js-yaml
@@ -34,8 +35,8 @@ export function metadataFromCode(
   let inHeader = true;
   value.split('\n').forEach((line) => {
     if (inHeader) {
-      if (line.startsWith(CELL_OPTION_PREFIX)) {
-        metaLines.push(line.substring(CELL_OPTION_PREFIX.length));
+      if (line.match(CELL_OPTION_PREFIX)) {
+        metaLines.push(line.replace(CELL_OPTION_PREFIX, ''));
       } else if (line.trim()) {
         inHeader = false;
       }


### PR DESCRIPTION
This allows for formatting using black, and still getting picked up!

See https://github.com/executablebooks/mystmd/issues/541