### PR TITLE
🏷 Support ipython magic for label syntax

### DIFF
--- a/.changeset/silver-spoons-shake.md
+++ b/.changeset/silver-spoons-shake.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'mystmd': patch
+---
+
+Allow for `#| label` to come after an ipython magic.

--- a/packages/myst-cli/src/transforms/code.spec.ts
+++ b/packages/myst-cli/src/transforms/code.spec.ts
@@ -59,6 +59,20 @@ describe('metadataFromCode', () => {
       value,
     });
   });
+  it('allows for a cell-magic to come first', async () => {
+    const value = '%%time\n#| key: value\n\n#| flag: true\n\n\na = 5 + 5\nprint(a)';
+    expect(metadataFromCode(new Session(), '', value)).toEqual({
+      value,
+      metadata: { key: 'value', flag: true },
+    });
+  });
+  it('allows for a cell-magic to come first, but not in the middle', async () => {
+    const value = '\n\n%%time\n#| key: value\n%%time\n#| flag: true\n\n\na = 5 + 5\nprint(a)';
+    expect(metadataFromCode(new Session(), '', value)).toEqual({
+      value,
+      metadata: { key: 'value' },
+    });
+  });
 });
 
 describe('liftCodeMetadataToBlock', () => {


### PR DESCRIPTION
See #268

This allows for a `#| label:` to come after an ipython magic command, but still requires them to be at the top of the cell.