### PR TITLE
🔧 Update generated affiliation ids to not use crypto

### DIFF
--- a/.changeset/silver-bobcats-rush.md
+++ b/.changeset/silver-bobcats-rush.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Update generated affiliation ids to not use crypto

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -658,26 +658,33 @@ describe('validateAndStashObject', () => {
       stash,
       'authors',
       (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
-      opts,
+      { ...opts, file: 'folder/test.file.yml' },
     );
-    expect(out).toEqual('[["name","Just A. Name"]]');
+    expect(out).toEqual('authors-test-file-generated-uid-0');
     expect(stash).toEqual({
-      authors: [{ id: '[["name","Just A. Name"]]', name: 'Just A. Name' }],
+      authors: [{ id: 'authors-test-file-generated-uid-0', name: 'Just A. Name' }],
     });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
   it('no id does not warn on duplicate', async () => {
-    const stash = { authors: [{ id: '[["name","Just A. Name"]]', name: 'Just A. Name' }] };
+    const stash = {};
+    validateAndStashObject(
+      { name: 'Just A. Name' },
+      stash,
+      'authors',
+      (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+      { ...opts, file: 'folder\\my_file' },
+    );
     const out = validateAndStashObject(
       { name: 'Just A. Name' },
       stash,
       'authors',
       (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
-      opts,
+      { ...opts, file: 'folder\\my_file' },
     );
-    expect(out).toEqual('[["name","Just A. Name"]]');
+    expect(out).toEqual('authors-my_file-generated-uid-0');
     expect(stash).toEqual({
-      authors: [{ id: '[["name","Just A. Name"]]', name: 'Just A. Name' }],
+      authors: [{ id: 'authors-my_file-generated-uid-0', name: 'Just A. Name' }],
     });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -660,14 +660,14 @@ describe('validateAndStashObject', () => {
       (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
       opts,
     );
-    expect(out).toEqual('472b90cf03efe64d27eb5ff708c5aa3d');
+    expect(out).toEqual('[["name","Just A. Name"]]');
     expect(stash).toEqual({
-      authors: [{ id: '472b90cf03efe64d27eb5ff708c5aa3d', name: 'Just A. Name' }],
+      authors: [{ id: '[["name","Just A. Name"]]', name: 'Just A. Name' }],
     });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
   it('no id does not warn on duplicate', async () => {
-    const stash = { authors: [{ id: '472b90cf03efe64d27eb5ff708c5aa3d', name: 'Just A. Name' }] };
+    const stash = { authors: [{ id: '[["name","Just A. Name"]]', name: 'Just A. Name' }] };
     const out = validateAndStashObject(
       { name: 'Just A. Name' },
       stash,
@@ -675,9 +675,9 @@ describe('validateAndStashObject', () => {
       (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
       opts,
     );
-    expect(out).toEqual('472b90cf03efe64d27eb5ff708c5aa3d');
+    expect(out).toEqual('[["name","Just A. Name"]]');
     expect(stash).toEqual({
-      authors: [{ id: '472b90cf03efe64d27eb5ff708c5aa3d', name: 'Just A. Name' }],
+      authors: [{ id: '[["name","Just A. Name"]]', name: 'Just A. Name' }],
     });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -42,7 +42,6 @@ import type {
   ReferenceStash,
   Affiliation,
 } from './types.js';
-import { createHash } from 'node:crypto';
 
 export const SITE_FRONTMATTER_KEYS = [
   'title',
@@ -279,7 +278,7 @@ export function validateAndStashObject<T extends { id?: string; name?: string }>
   let warnOnDuplicate = !isStashPlaceholder(value);
   if (!value.id) {
     // If object is defined without an id, generate a unique id
-    value.id = createHash('md5').update(normalizedString(value)).digest('hex');
+    value.id = normalizedString(value);
     // Do not warn on duplicates for hash ids; any duplicates here are identical
     warnOnDuplicate = false;
   }

--- a/packages/myst-frontmatter/tests/affiliations.yml
+++ b/packages/myst-frontmatter/tests/affiliations.yml
@@ -31,7 +31,7 @@ cases:
         - id: University
           name: University
     warnings: 1
-  - title: (Don't) Warn if affiliation has no name/institution
+  - title: Warn if affiliation has no name/institution
     raw:
       affiliation:
         - name: University A
@@ -39,11 +39,11 @@ cases:
         - email: universityc@example.com
     normalized:
       affiliations:
-        - id: 45d11546d183a1dd2171d715895defc2
+        - id: '[["name","University A"]]'
           name: University A
-        - id: 21431650d40dd2a2699d0e6782fec976
+        - id: '[["institution","University B"]]'
           institution: University B
-        - id: c0c33da7470923aca89c354685d85750
+        - id: '[["email","universityc@example.com"]]'
           email: universityc@example.com
     warnings: 1
   - title: Support QMD style affiliations (ref)
@@ -204,12 +204,12 @@ cases:
       authors:
         - name: Just A. Name
           affiliations:
-            - 31545614934732bb176a5935e68b9a91
+            - '[["name","University A"],["url","https://example.com"]]'
         - name: A. Nother Name
           affiliations:
-            - 31545614934732bb176a5935e68b9a91
+            - '[["name","University A"],["url","https://example.com"]]'
       affiliations:
-        - id: 31545614934732bb176a5935e68b9a91
+        - id: '[["name","University A"],["url","https://example.com"]]'
           name: University A
           url: https://example.com
   - title: Author with affiliation object replaces id at top level

--- a/packages/myst-frontmatter/tests/affiliations.yml
+++ b/packages/myst-frontmatter/tests/affiliations.yml
@@ -39,11 +39,11 @@ cases:
         - email: universityc@example.com
     normalized:
       affiliations:
-        - id: '[["name","University A"]]'
+        - id: affiliations-generated-uid-0
           name: University A
-        - id: '[["institution","University B"]]'
+        - id: affiliations-generated-uid-1
           institution: University B
-        - id: '[["email","universityc@example.com"]]'
+        - id: affiliations-generated-uid-2
           email: universityc@example.com
     warnings: 1
   - title: Support QMD style affiliations (ref)
@@ -204,12 +204,12 @@ cases:
       authors:
         - name: Just A. Name
           affiliations:
-            - '[["name","University A"],["url","https://example.com"]]'
+            - affiliations-generated-uid-0
         - name: A. Nother Name
           affiliations:
-            - '[["name","University A"],["url","https://example.com"]]'
+            - affiliations-generated-uid-0
       affiliations:
-        - id: '[["name","University A"],["url","https://example.com"]]'
+        - id: affiliations-generated-uid-0
           name: University A
           url: https://example.com
   - title: Author with affiliation object replaces id at top level


### PR DESCRIPTION
`crypto` does not play nicely with the browser and we really do not need it here, since we are are only using it for generating a basic unique ID.

Instead, I am just using stringified JSON as the unique ID. This feels super silly - these IDs are really gross looking. However, they only exist in memory for string comparisons, so, in practice, as long as we don't start writing them to file I think it's ok.