### PR TITLE
📎 Handle base64 notebook cell attachments

### DIFF
--- a/.changeset/angry-mirrors-draw.md
+++ b/.changeset/angry-mirrors-draw.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Handle notebook cell image attachments

--- a/.changeset/eight-moons-repeat.md
+++ b/.changeset/eight-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Add transform to trim base64 urlSource values

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -51,6 +51,7 @@ import {
   transformBanner,
   reduceOutputs,
   transformPlaceholderImages,
+  transformDeleteBase64UrlSource,
 } from '../transforms/index.js';
 import type { ImageExtensions } from '../utils/index.js';
 import { logMessagesFromVFile } from '../utils/index.js';
@@ -225,6 +226,7 @@ export async function transformMdast(
       webp: !simplifyFigures,
     });
   }
+  await transformDeleteBase64UrlSource(mdast);
   const sha256 = selectors.selectFileInfo(store.getState(), file).sha256 as string;
   const useSlug = pageSlug !== index;
   const url = projectSlug

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -4,10 +4,17 @@ import type { GenericNode, GenericParent } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 import { nanoid } from 'nanoid';
 import type { MinifiedOutput } from 'nbtx';
-import type { ICell, INotebookContent, IOutput } from '@jupyterlab/nbformat';
+import type {
+  IAttachments,
+  ICell,
+  IMimeBundle,
+  INotebookContent,
+  IOutput,
+} from '@jupyterlab/nbformat';
 import { CELL_TYPES, minifyCellOutput } from 'nbtx';
 import { castSession } from '../session/index.js';
 import type { ISession } from '../session/types.js';
+import { BASE64_HEADER_SPLIT } from '../transforms/images.js';
 import { parseMyst } from './myst.js';
 
 function asString(source?: string | string[]): string {
@@ -19,9 +26,42 @@ function createOutputDirective(): { myst: string; id: string } {
   return { myst: `\`\`\`{output}\n:id: ${id}\n\`\`\``, id };
 }
 
-function blockDivider(cell: ICell) {
+function blockParent(cell: ICell, children: GenericNode[]) {
   const type = cell.cell_type === CELL_TYPES.code ? NotebookCell.code : NotebookCell.content;
-  return `+++ ${JSON.stringify({ type, ...cell.metadata })}\n\n`;
+  return { type: 'block', meta: JSON.stringify({ type, ...cell.metadata }), children };
+}
+
+/**
+ *  mdast transform to move base64 cell attachments directly to image nodes
+ *
+ * The image transform subsequently handles writing this in-line base64 to file.
+ */
+function replaceAttachmentsTransform(
+  session: ISession,
+  mdast: GenericParent,
+  attachments: IAttachments,
+  file: string,
+) {
+  const imageNodes = selectAll('image', mdast);
+  imageNodes.forEach((image: GenericNode) => {
+    if (!image.url) return;
+    const attachmentKey = (image.url as string).match(/^attachment:(.*)$/)?.[1];
+    if (!attachmentKey) return;
+    try {
+      const attachment = Object.entries(attachments[attachmentKey] as IMimeBundle)[0];
+      const mimeType = attachment[0];
+      const attachmentVal = asString(attachment[1] as string | string[]);
+      if (!attachmentVal) {
+        session.log.warn(`Unrecognized attachment name in ${file}: ${attachmentKey}`);
+      } else if (attachmentVal.includes(BASE64_HEADER_SPLIT)) {
+        image.url = attachmentVal;
+      } else {
+        image.url = `data:${mimeType}${BASE64_HEADER_SPLIT}${attachmentVal}`;
+      }
+    } catch {
+      session.log.warn(`Unable to resolve attachment in ${file}: ${attachmentKey}`);
+    }
+  });
 }
 
 export async function processNotebook(
@@ -53,13 +93,23 @@ export async function processNotebook(
         const cellContent = asString(cell.source);
         // If the first cell is a frontmatter block, do not put a block break above it
         const omitBlockDivider = index === 0 && cellContent.startsWith('---\n');
-        return acc.concat(`${omitBlockDivider ? '' : blockDivider(cell)}${cellContent}`);
+        const cellMdast = parseMyst(session, cellContent, file);
+        if (cell.attachments) {
+          replaceAttachmentsTransform(session, cellMdast, cell.attachments as IAttachments, file);
+        }
+        if (omitBlockDivider) {
+          return acc.concat(...cellMdast.children);
+        }
+        return acc.concat(blockParent(cell, cellMdast.children));
       }
       if (cell.cell_type === CELL_TYPES.raw) {
-        return acc.concat(`${blockDivider(cell)}\`\`\`\n${asString(cell.source)}\n\`\`\``);
+        const cellContent = `\`\`\`\n${asString(cell.source)}\n\`\`\``;
+        const cellMdast = parseMyst(session, cellContent, file);
+        return acc.concat(blockParent(cell, cellMdast.children));
       }
       if (cell.cell_type === CELL_TYPES.code) {
-        const code = `\`\`\`{code-cell} ${language}\n${asString(cell.source)}\n\`\`\``;
+        const cellCodeContent = `\`\`\`{code-cell} ${language}\n${asString(cell.source)}\n\`\`\``;
+        const cellCodeMdast = parseMyst(session, cellCodeContent, file);
         const { myst, id } = createOutputDirective();
         if (cell.outputs && (cell.outputs as IOutput[]).length > 0) {
           const minified: MinifiedOutput[] = await minifyCellOutput(
@@ -71,14 +121,17 @@ export async function processNotebook(
         } else {
           outputMap[id] = [];
         }
-        return acc.concat(`${blockDivider(cell)}${code}\n\n${myst}`);
+        const cellOutputMdast = parseMyst(session, myst, file);
+        return acc.concat(
+          blockParent(cell, [...cellCodeMdast.children, ...cellOutputMdast.children]),
+        );
       }
       return acc;
     },
-    Promise.resolve([] as string[]),
+    Promise.resolve([] as GenericNode[]),
   );
 
-  const mdast = parseMyst(session, items.join('\n\n'), file);
+  const mdast = { type: 'root', children: items };
 
   selectAll('output', mdast).forEach((output: GenericNode) => {
     output.data = outputMap[output.id];

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -21,8 +21,10 @@ import type { ISession } from '../session/types.js';
 import { castSession } from '../session/index.js';
 import { watch } from '../store/index.js';
 
+export const BASE64_HEADER_SPLIT = ';base64,';
+
 function isBase64(data: string) {
-  return data.split(';base64,').length === 2;
+  return data.split(BASE64_HEADER_SPLIT).length === 2;
 }
 
 function getGithubRawUrl(url?: string): string | undefined {
@@ -46,7 +48,7 @@ async function writeBase64(
   data: string,
   contentType?: string,
 ) {
-  const [justData, header] = data.split(';base64,').reverse(); // reverse as sometimes there is no header
+  const [justData, header] = data.split(BASE64_HEADER_SPLIT).reverse(); // reverse as sometimes there is no header
   const ext = extFromMimeType(header?.replace('data:', '') ?? contentType);
   const hash = computeHash(justData);
   const file = `${hash}${ext}`;


### PR DESCRIPTION
This PR changes how notebooks are parsed to MyST: Instead of building a single markdown document from the cells and calling `parseMyst` once, each cell is parsed individually, nested into `block` nodes (except frontmatter), and concatenated.

This allows us to run mdast transforms at a notebook-cell level (the only time we have access to cell `attachments`), which we use to replace `![](attachment:...)` image links with the base64 value directly. This base64 image is resolved later in `transformImages` (this functionality already existed prior to this PR).

Finally, we add one additional transform that trims base64 `urlSource` values on image nodes, so huge base64 payloads are not bundled into the mdast data.

Fixes: https://github.com/executablebooks/mystmd/issues/528