### PR TITLE
👩‍🎓 Extract abstract part for JATS frontmatter

### DIFF
--- a/.changeset/chatty-forks-kick.md
+++ b/.changeset/chatty-forks-kick.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Keep article-id/article-version in correct order for JATS

--- a/.changeset/fair-spoons-itch.md
+++ b/.changeset/fair-spoons-itch.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Extract abstract part for JATS frontmatter

--- a/.changeset/gentle-socks-rescue.md
+++ b/.changeset/gentle-socks-rescue.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Do not move abstract to frontmatter on raw notebook representation of article in JATS

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -1,5 +1,5 @@
 import type { ProjectFrontmatter } from 'myst-frontmatter';
-import type { Element } from './types.js';
+import type { Element, IJatsSerializer } from './types.js';
 
 export function getJournalIds(): Element[] {
   // [{ type: 'element', name: 'journal-id', attributes: {'journal-id-type': ...}, text: ...}]
@@ -227,44 +227,52 @@ export function getArticlePages(frontmatter: ProjectFrontmatter): Element[] {
   return pages;
 }
 
-export function getArticleMeta(frontmatter?: ProjectFrontmatter): Element {
-  const elements = frontmatter
-    ? [
-        // article-id
-        // article-version, article-version-alternatives
-        // article-categories
-        ...getArticleTitle(frontmatter),
-        ...getArticleAuthors(frontmatter),
-        // author-notes
-        // pub-date or pub-date-not-available
-        ...getArticleVolume(frontmatter),
-        // volume-id
-        // volume-series
-        ...getArticleIssue(frontmatter),
-        // issue-id
-        // issue-title
-        // issue-title-group
-        // issue-sponsor
-        // issue-part
-        // volume-issue-group
-        // isbn
-        // supplement
-        ...getArticlePages(frontmatter),
-        // email, ext-link, uri, product, supplementary-material
-        // history
-        // pub-history
-        ...getArticlePermissions(frontmatter),
-        // self-uri
-        // related-article, related-object
-        // abstract
-        // trans-abstract
-        // kwd-group
-        // funding-group
-        // support-group
-        // conference
-        // counts
-      ]
-    : [];
+export function getAbstract(state: IJatsSerializer): Element[] {
+  if (!state.data.abstract?.length) return [];
+  return [{ type: 'element', name: 'abstract', elements: state.data.abstract }];
+}
+
+export function getArticleMeta(frontmatter?: ProjectFrontmatter, state?: IJatsSerializer): Element {
+  const elements = [];
+  if (frontmatter) {
+    elements.push(
+      // article-id
+      // article-version, article-version-alternatives
+      // article-categories
+      ...getArticleTitle(frontmatter),
+      ...getArticleAuthors(frontmatter),
+      // author-notes
+      // pub-date or pub-date-not-available
+      ...getArticleVolume(frontmatter),
+      // volume-id
+      // volume-series
+      ...getArticleIssue(frontmatter),
+      // issue-id
+      // issue-title
+      // issue-title-group
+      // issue-sponsor
+      // issue-part
+      // volume-issue-group
+      // isbn
+      // supplement
+      ...getArticlePages(frontmatter),
+      // email, ext-link, uri, product, supplementary-material
+      // history
+      // pub-history
+      ...getArticlePermissions(frontmatter),
+      // self-uri
+      // related-article, related-object
+      // trans-abstract
+      // kwd-group
+      // funding-group
+      // support-group
+      // conference
+      // counts
+    );
+  }
+  if (state) {
+    elements.push(...getAbstract(state));
+  }
   return { type: 'element', name: 'article-meta', elements };
 }
 
@@ -273,11 +281,11 @@ export function getArticleMeta(frontmatter?: ProjectFrontmatter): Element {
  *
  * This element must be defined in a JATS article and must include <article-meta>
  */
-export function getFront(frontmatter?: ProjectFrontmatter): Element[] {
+export function getFront(frontmatter?: ProjectFrontmatter, state?: IJatsSerializer): Element[] {
   const elements: Element[] = [];
   const journalMeta = getJournalMeta();
   if (journalMeta) elements.push(journalMeta);
-  const articleMeta = getArticleMeta(frontmatter);
+  const articleMeta = getArticleMeta(frontmatter, state);
   elements.push(articleMeta);
   return [{ type: 'element', name: 'front', elements }];
 }

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -673,8 +673,8 @@ export class JatsDocument {
         // No citations here - don't want duplicates in the jats
       });
     }
-    const subArticleStates = subArticles.map((article) => {
-      const subArticleState = this.subArticleState(article);
+    const subArticleStates = subArticles.map((article, ind) => {
+      const subArticleState = this.subArticleState(article, ind === 0 && isNotebookArticleRep);
       referenceTargetTransform(subArticleState.mdast as any, inventory, article.citations);
       return subArticleState;
     });
@@ -736,13 +736,13 @@ export class JatsDocument {
     return [{ type: 'element', name: 'front-stub', elements }];
   }
 
-  subArticleState(content: ArticleContent): IJatsSerializer {
+  subArticleState(content: ArticleContent, notebookRep: boolean): IJatsSerializer {
     return new JatsSerializer(this.file, content.mdast, {
       ...this.options,
       isNotebookArticleRep: false,
       isSubArticle: true,
       slug: content.slug,
-      extractAbstract: true,
+      extractAbstract: !notebookRep,
     });
   }
 

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -718,14 +718,20 @@ export class JatsDocument {
       });
     }
     const articleMeta = getArticleMeta(stubFrontmatter, state);
-    const elements = articleMeta?.elements ?? [];
+    let elements = articleMeta?.elements ?? [];
     if (notebookRep) {
-      elements.push({
+      const articleVersion: Element = {
         type: 'element',
         name: 'article-version',
         attributes: { 'article-version-type': 'alt representation' },
         elements: [{ type: 'text', text: 'notebook' }],
-      });
+      };
+      // For valid JATS, article-id must be first if it is present and article-version must be next
+      if (elements[0]?.name === 'article-id') {
+        elements = [elements[0], articleVersion, ...elements.slice(1)];
+      } else {
+        elements.unshift(articleVersion);
+      }
     }
     return [{ type: 'element', name: 'front-stub', elements }];
   }

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -24,6 +24,7 @@ export type Options = {
   isNotebookArticleRep?: boolean;
   isSubArticle?: boolean;
   slug?: string;
+  extractAbstract?: boolean;
 };
 
 export type DocumentOptions = Options & {
@@ -36,6 +37,7 @@ export type StateData = {
   isInContainer?: boolean;
   isNotebookArticleRep?: boolean;
   slug?: string;
+  abstract?: Element[];
 };
 
 export type ArticleContent = {

--- a/packages/myst-to-jats/tests/article.yml
+++ b/packages/myst-to-jats/tests/article.yml
@@ -254,3 +254,36 @@ cases:
           </fn-group>
         </back>
       </article>
+  - title: Abstract frontmatter
+    tree:
+      type: root
+      children:
+        - type: block
+          data:
+            part: abstract
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: My Abstract!
+        - type: block
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: My content.
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <abstract>
+              <p>My Abstract!</p>
+            </abstract>
+          </article-meta>
+        </front>
+        <body>
+          <p>My content.</p>
+        </body>
+      </article>

--- a/packages/myst-to-jats/tests/notebooks.yml
+++ b/packages/myst-to-jats/tests/notebooks.yml
@@ -294,3 +294,100 @@ cases:
           </body>
         </sub-article>
       </article>
+  - title: Notebook with abstract
+    tree:
+      type: root
+      children:
+        - type: block
+          data:
+            id: nb-cell-0
+            type: notebook-code
+          identifier: nb-cell-0
+          label: nb-cell-0
+          html_id: nb-cell-0
+          children:
+            - type: code
+              lang: python
+              executable: true
+              value: print('abc')
+              identifier: nb-cell-0-code
+              enumerator: 1
+              html_id: nb-cell-0-code
+            - type: output
+              id: T7FMDqDm8dM2bOT1tKeeM
+              identifier: nb-cell-0-output
+              html_id: nb-cell-0-output
+              data:
+                - name: stdout
+                  output_type: stream
+                  text: abc\n...
+                  hash: a
+                  path: files/a.txt
+        - type: block
+          data:
+            part: abstract
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: My abstract!
+        - type: block
+          data:
+            id: nb-cell-1
+            type: notebook-content
+          identifier: nb-cell-1
+          label: nb-cell-1
+          html_id: nb-cell-1
+          children:
+            - type: heading
+              identifier: sec1
+              depth: 1
+              children:
+                - type: text
+                  value: a section
+            - type: paragraph
+              children:
+                - type: text
+                  value: content
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <abstract>
+              <p>My abstract!</p>
+            </abstract>
+          </article-meta>
+        </front>
+        <body>
+          <sec id="sec-1">
+            <title>a section</title>
+            <p>content</p>
+          </sec>
+        </body>
+        <sub-article>
+          <front-stub>
+            <article-version article-version-type="alt representation">notebook</article-version>
+          </front-stub>
+          <body>
+            <sec id="sec-2" sec-type="notebook-code">
+              <code id="nb-cell-0-code" language="python" executable="yes">print('abc')</code>
+              <sec sec-type="notebook-output" id="nb-cell-0-output-0">
+                <alternatives>
+                  <media specific-use="stream" mimetype="text" mime-subtype="plain" xlink:href="files/a.txt"/>
+                </alternatives>
+              </sec>
+            </sec>
+            <sec id="sec-3">
+              <p>My abstract!</p>
+            </sec>
+            <sec id="sec-4" sec-type="notebook-content">
+              <sec id="sec-5">
+                <title>a section</title>
+                <p>content</p>
+              </sec>
+            </sec>
+          </body>
+        </sub-article>
+      </article>


### PR DESCRIPTION
Blocks tagged with `part: 'abstract'` are now respected by JATS export and moved appropriately to `<article-meta><abstract>`.

Resolves #560 