### PR TITLE
📌 add relative location to pages and sources

### DIFF
--- a/.changeset/fifty-pants-remain.md
+++ b/.changeset/fifty-pants-remain.md
@@ -1,0 +1,6 @@
+---
+'myst-spec-ext': patch
+'myst-cli': patch
+---
+
+Added location field to page data, dependencies and source fields which contains the path to the file relative to the project root. This is primarily used to appropraitely configure a thebe session with the correct notebook path.

--- a/packages/myst-cli/src/build/utils/getFileContent.ts
+++ b/packages/myst-cli/src/build/utils/getFileContent.ts
@@ -44,9 +44,11 @@ export async function getFileContent(
   const allFiles = [...new Set([...files, ...projectFiles])];
   await Promise.all([
     // Load all citations (.bib)
-    ...project.bibliography.map((path) => loadFile(session, path, '.bib')),
+    ...project.bibliography.map((path) => loadFile(session, path, projectPath, '.bib')),
     // Load all content (.md and .ipynb)
-    ...allFiles.map((file) => loadFile(session, file, undefined, { minifyMaxCharacters: 0 })),
+    ...allFiles.map((file) =>
+      loadFile(session, file, projectPath, undefined, { minifyMaxCharacters: 0 }),
+    ),
     // Load up all the intersphinx references
     loadIntersphinx(session, { projectPath }) as Promise<any>,
   ]);

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -37,12 +37,10 @@ export async function loadFile(
 
   let location = file;
   if (projectPath) {
-    try {
-      location = file.split(projectPath)[1];
-    } catch (err: any) {
-      session.log.error('👎 could not determine relative path from project path');
-    }
+    location = path.relative(projectPath, file);
   }
+  // ensure forward slashes and not windows backslashes
+  location = location.replaceAll('\\', '/');
 
   try {
     const ext = extension || path.extname(file).toLowerCase();

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -37,7 +37,7 @@ export async function loadFile(
 
   let location = file;
   if (projectPath) {
-    location = path.relative(projectPath, file);
+    location = `/${path.relative(projectPath, file)}`;
   }
   // ensure forward slashes and not windows backslashes
   location = location.replaceAll('\\', '/');

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -120,7 +120,7 @@ export async function transformMdast(
   const { store, log } = session;
   const cache = castSession(session);
   if (!cache.$mdast[file]) return;
-  const { mdast: mdastPre, kind, frontmatter: preFrontmatter } = cache.$mdast[file].pre;
+  const { mdast: mdastPre, kind, frontmatter: preFrontmatter, location } = cache.$mdast[file].pre;
   if (!mdastPre) throw new Error(`Expected mdast to be parsed for ${file}`);
   log.debug(`Processing "${file}"`);
   // Use structuredClone in future (available in node 17)
@@ -252,6 +252,7 @@ export async function transformMdast(
   const data: RendererData = {
     kind: frontmatter.kernelspec || frontmatter.jupytext ? SourceFileKind.Notebook : kind,
     file,
+    location,
     sha256,
     slug: pageSlug,
     dependencies: [],

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -180,12 +180,7 @@ export async function resolvePageExports(session: ISession, file: string) {
 
 export async function writeFile(
   session: ISession,
-  {
-    projectPath,
-    file,
-    pageSlug,
-    projectSlug,
-  }: { projectPath: string; file: string; pageSlug: string; projectSlug?: string },
+  { file, pageSlug, projectSlug }: { file: string; pageSlug: string; projectSlug?: string },
 ) {
   const toc = tic();
   const selectedFile = selectFile(session, file);
@@ -259,7 +254,7 @@ export async function fastProcessFile(
     imageExtensions: WEB_IMAGE_EXTENSIONS,
   });
 
-  await writeFile(session, { projectPath, file, pageSlug, projectSlug });
+  await writeFile(session, { file, pageSlug, projectSlug });
   session.log.info(toc(`📖 Built ${file} in %s.`));
   await writeSiteManifest(session, { defaultTemplate });
 }
@@ -350,7 +345,6 @@ export async function processProject(
     await Promise.all(
       pages.map((page) =>
         writeFile(session, {
-          projectPath: project.path,
           file: page.file,
           projectSlug: siteProject.slug as string,
           pageSlug: page.slug,

--- a/packages/myst-cli/src/project/load.ts
+++ b/packages/myst-cli/src/project/load.ts
@@ -90,7 +90,7 @@ export async function loadProjectFromDisk(
   } else {
     bibliography = allBibFiles;
   }
-  await Promise.all(bibliography.map((p: string) => loadFile(session, p, undefined, '.bib')));
+  await Promise.all(bibliography.map((p: string) => loadFile(session, p, path, '.bib')));
   const project: LocalProject = { ...newProject, bibliography };
   session.store.dispatch(projects.actions.receive(project));
   combineProjectCitationRenderers(session, path);

--- a/packages/myst-cli/src/project/load.ts
+++ b/packages/myst-cli/src/project/load.ts
@@ -90,7 +90,7 @@ export async function loadProjectFromDisk(
   } else {
     bibliography = allBibFiles;
   }
-  await Promise.all(bibliography.map((p: string) => loadFile(session, p, '.bib')));
+  await Promise.all(bibliography.map((p: string) => loadFile(session, p, undefined, '.bib')));
   const project: LocalProject = { ...newProject, bibliography };
   session.store.dispatch(projects.actions.receive(project));
   combineProjectCitationRenderers(session, path);

--- a/packages/myst-cli/src/transforms/embed.ts
+++ b/packages/myst-cli/src/transforms/embed.ts
@@ -48,9 +48,10 @@ export function embedTransform(
     if (!url) return;
     const source: Dependency = { url, label: node.source?.label };
     if (file) {
-      const { kind, slug, frontmatter } = selectFile(session, file) ?? {};
+      const { kind, slug, frontmatter, location } = selectFile(session, file) ?? {};
       if (kind) source.kind = kind;
       if (slug) source.slug = slug;
+      if (location) source.location = location;
       if (frontmatter?.title) source.title = frontmatter.title;
       if (frontmatter?.short_title) source.short_title = frontmatter.short_title;
     }

--- a/packages/myst-cli/src/transforms/types.ts
+++ b/packages/myst-cli/src/transforms/types.ts
@@ -5,6 +5,7 @@ import type { CitationRenderer } from 'citation-js-utils';
 
 export type PreRendererData = {
   file: string;
+  location: string;
   mdast: GenericParent;
   kind: SourceFileKind;
   frontmatter?: PageFrontmatter;

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -139,6 +139,7 @@ export type Dependency = {
   title?: string;
   short_title?: string;
   label?: string;
+  location?: string;
 };
 
 export type Embed = {


### PR DESCRIPTION
Purpose of this PR is to make available the project relative path to the different files within a myst site. 

In particular for notebooks, this allows us to understand the folder structure within which he notebooks are developed and executed, where we make the assumption that a jupyter server would be started at the project root and code within the notebooks would be written relative to that. 

When using thebe for computation the correct relative paths for a notebook is required when starting a jupyter session, in order to correctly allow for explicit loading of files or importing of code from local files.

This PR is an attempt at adding this relative path information at `loadFile` time, so that is can be easily used later when constructing the data structure for the page, as well as `source` and `dependencies` fields appropriately for embedded outputs.



## Resulting data structure for a markdown file with embedded notebook output

```json
{
  "kind": "Article",
  "sha256": "af6ad42d1c6fd43f801d737818c1ceac0a4343766abcaf88c28bfd06f89a8a0f",
  "slug": "index",
  "location": "[/index.md](http://localhost:3000/index.md)",
  "dependencies": [
    {
      "url": "[/notebook](http://localhost:3000/notebook)",
      "label": "cell-1",
      "kind": "Notebook",
      "slug": "notebook",
      "location": "[/notebooks/notebook.ipynb](http://localhost:3000/notebooks/notebook.ipynb)"
    }
  ],
  "frontmatter": {
  "title": "Index page",
  "authors": [],
  "keywords": [],
  "exports": [
    {
      "format": "md",
      "filename": "index.md",
      "url": "http://localhost:3100/index-f6b7382f9a12935e3d515998ca5fff7b.md"
    }
  ],
  ...
},
```
