### PR TITLE
🕵️‍♀️ Add User-Agent to image and link fetches

### DIFF
--- a/.changeset/weak-bats-tell.md
+++ b/.changeset/weak-bats-tell.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Add User-Agent to image and link fetches

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -12,6 +12,7 @@ import type { Image } from 'myst-spec-ext';
 import { extFromMimeType } from 'nbtx';
 import {
   addWarningForFile,
+  EXT_REQUEST_HEADERS,
   ImageExtensions,
   imagemagick,
   inkscape,
@@ -76,7 +77,7 @@ export async function downloadAndSaveImage(
   session.log.debug(`Fetching image: ${url}...\n  -> saving to: ${filePath}`);
   try {
     const github = getGithubRawUrl(url);
-    const res = await fetch(github ?? url);
+    const res = await fetch(github ?? url, { headers: EXT_REQUEST_HEADERS });
     const contentType = res.headers.get('content-type') || '';
     const extension = mime.extension(contentType);
     if (!extension || !contentType) throw new Error('No content-type for image found.');

--- a/packages/myst-cli/src/transforms/links.ts
+++ b/packages/myst-cli/src/transforms/links.ts
@@ -11,7 +11,7 @@ import { hashAndCopyStaticFile, tic } from 'myst-cli-utils';
 import type { VFile } from 'vfile';
 import type { ISession } from '../session/types.js';
 import { selectors } from '../store/index.js';
-import { addWarningForFile } from '../utils/index.js';
+import { EXT_REQUEST_HEADERS, addWarningForFile } from '../utils/index.js';
 import { links } from '../store/reducers.js';
 import type { ExternalLinkResult } from '../store/types.js';
 
@@ -45,7 +45,7 @@ async function checkLink(session: ISession, url: string): Promise<ExternalLinkRe
       return link;
     }
     session.log.debug(`Checking that "${url}" exists`);
-    const resp = await fetch(url);
+    const resp = await fetch(url, { headers: EXT_REQUEST_HEADERS });
     link.ok = resp.ok;
     link.status = resp.status;
     link.statusText = resp.statusText;

--- a/packages/myst-cli/src/utils/headers.ts
+++ b/packages/myst-cli/src/utils/headers.ts
@@ -1,0 +1,7 @@
+import version from '../version.js';
+
+const USER_AGENT = `myst-cli/${version}`;
+
+export const EXT_REQUEST_HEADERS = {
+  'User-Agent': USER_AGENT,
+};

--- a/packages/myst-cli/src/utils/index.ts
+++ b/packages/myst-cli/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from './createTempFolder.js';
 export * from './fileInfo.js';
 export * from './filterFilenamesByExtension.js';
 export * from './getAllBibtexFiles.js';
+export * from './headers.js';
 export * from './logMessagesFromVFile.js';
 export * from './nextLevel.js';
 export * from './removeExtension.js';


### PR DESCRIPTION
This should address #563 - imgur was unhappy with no `User-Agent` header. Now these links seem to work fine:

![image](https://github.com/executablebooks/mystmd/assets/9453731/46878cbe-9862-4a44-b04d-19d7961bd757)
