### PR TITLE
👩‍💻 Refactor and export template validation functions

### DIFF
--- a/.changeset/shaggy-lemons-admire.md
+++ b/.changeset/shaggy-lemons-admire.md
@@ -1,0 +1,5 @@
+---
+'myst-templates': patch
+---
+
+Refactor and export template validation functions

--- a/packages/myst-templates/src/validators.ts
+++ b/packages/myst-templates/src/validators.ts
@@ -110,7 +110,7 @@ const conditionMet = (
   return true;
 };
 
-export function validateOptionsFunction(reservedKeys: string[]) {
+export function makeValidateOptionsFunction(reservedKeys: string[]) {
   return (
     session: ISession,
     options: any,
@@ -143,7 +143,7 @@ export function validateOptionsFunction(reservedKeys: string[]) {
   };
 }
 
-export const validateTemplateOptions = validateOptionsFunction(RESERVED_EXPORT_KEYS);
+export const validateTemplateOptions = makeValidateOptionsFunction(RESERVED_EXPORT_KEYS);
 
 export function validateTemplateParts(
   parts: any,

--- a/packages/myst-templates/src/validators.ts
+++ b/packages/myst-templates/src/validators.ts
@@ -110,36 +110,40 @@ const conditionMet = (
   return true;
 };
 
-export function validateTemplateOptions(
-  session: ISession,
-  options: any,
-  optionDefinitions: TemplateOptionDefinition[],
-  opts: FileValidationOptions,
-) {
-  const value = validateObject(options, opts);
-  if (value === undefined) return undefined;
-  const filteredOptions = optionDefinitions.filter((def) => {
-    return conditionMet(def, value);
-  });
-  const required = filteredOptions.filter((def) => isRequired(def)).map((def) => def.id);
-  const optional = filteredOptions
-    .filter((def) => !isRequired(def))
-    .map((def) => def.id)
-    .concat(RESERVED_EXPORT_KEYS);
-  validateKeys(value, { optional, required }, { returnInvalidPartial: true, ...opts });
-  const output: Record<string, any> = {};
-  filteredOptions.forEach((def) => {
-    if (defined(value[def.id]) || def.default) {
-      output[def.id] = validateTemplateOption(
-        session,
-        value[def.id] ?? def.default,
-        def,
-        incrementOptions(def.id, opts),
-      );
-    }
-  });
-  return output;
+export function validateOptionsFunction(reservedKeys: string[]) {
+  return (
+    session: ISession,
+    options: any,
+    optionDefinitions: TemplateOptionDefinition[],
+    opts: FileValidationOptions,
+  ) => {
+    const value = validateObject(options, opts);
+    if (value === undefined) return undefined;
+    const filteredOptions = optionDefinitions.filter((def) => {
+      return conditionMet(def, value);
+    });
+    const required = filteredOptions.filter((def) => isRequired(def)).map((def) => def.id);
+    const optional = filteredOptions
+      .filter((def) => !isRequired(def))
+      .map((def) => def.id)
+      .concat(reservedKeys);
+    validateKeys(value, { optional, required }, { returnInvalidPartial: true, ...opts });
+    const output: Record<string, any> = {};
+    filteredOptions.forEach((def) => {
+      if (defined(value[def.id]) || def.default) {
+        output[def.id] = validateTemplateOption(
+          session,
+          value[def.id] ?? def.default,
+          def,
+          incrementOptions(def.id, opts),
+        );
+      }
+    });
+    return output;
+  };
 }
+
+export const validateTemplateOptions = validateOptionsFunction(RESERVED_EXPORT_KEYS);
 
 export function validateTemplateParts(
   parts: any,


### PR DESCRIPTION
This just allows us to reuse `validateOptionsFunction` with different reserved keys.