### PR TITLE
🔧 A couple tweaks for consuming the myst-cli package

### DIFF
--- a/.changeset/grumpy-rice-eat.md
+++ b/.changeset/grumpy-rice-eat.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+checkLink is exported

--- a/.changeset/sweet-dragons-live.md
+++ b/.changeset/sweet-dragons-live.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+selectFile resolves the input file path

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -131,6 +131,7 @@ export async function bibFilesInDir(session: ISession, dir: string, load = true)
 
 export function selectFile(session: ISession, file: string): RendererData | undefined {
   const cache = castSession(session);
+  file = path.resolve(file);
   if (!cache.$mdast[file]) {
     session.log.error(`Expected mdast to be processed for ${file}`);
     return undefined;

--- a/packages/myst-cli/src/transforms/links.ts
+++ b/packages/myst-cli/src/transforms/links.ts
@@ -24,7 +24,7 @@ const skippedDomains = [
   'en.wikipedia.org',
 ];
 
-async function checkLink(session: ISession, url: string): Promise<ExternalLinkResult> {
+export async function checkLink(session: ISession, url: string): Promise<ExternalLinkResult> {
   const cached = selectors.selectLinkStatus(session.store.getState(), url);
   if (cached) return cached;
   const link: ExternalLinkResult = {


### PR DESCRIPTION
- `selectFile` resolves the input file path
- `checkLink` is exported