### PR TITLE
📡 enable custom binder providers in frontmatter

### DIFF
--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -76,7 +76,7 @@ const TEST_THEBE: Thebe = {
     url: 'https://my.binder.org/blah',
     ref: 'HEAD',
     repo: 'my-org/my-repo',
-    provider: 'github' as any,
+    provider: 'github',
   },
   server: {
     url: 'https://my.server.org',
@@ -321,6 +321,47 @@ describe('validateThebe', () => {
   });
   it('full object returns self', async () => {
     expect(validateThebe(TEST_THEBE, opts)).toEqual(TEST_THEBE);
+  });
+  it('custom provider accepts url as repo value', async () => {
+    const output = validateThebe(
+      {
+        ...TEST_THEBE,
+        binder: {
+          url: 'https://binder.curvenote.com/services/binder/',
+          repo: 'https://curvenote.com/sub/bundle.zip',
+          provider: 'custom',
+        },
+      },
+      opts,
+    );
+    expect(output?.binder).toEqual({
+      url: 'https://binder.curvenote.com/services/binder/',
+      repo: 'https://curvenote.com/sub/bundle.zip',
+      provider: 'custom',
+    });
+  });
+  it('errors if no repo with custom provider', async () => {
+    expect(opts.messages).toEqual({});
+    expect(
+      validateThebe(
+        {
+          ...TEST_THEBE,
+          binder: {
+            url: 'https://binder.curvenote.com/services/binder/',
+            provider: 'custom',
+          },
+        },
+        opts,
+      ),
+    ).toEqual({
+      ...TEST_THEBE,
+      binder: {
+        url: 'https://binder.curvenote.com/services/binder/',
+        provider: 'custom',
+      },
+    });
+    expect(opts.messages.errors?.length).toEqual(1);
+    expect(opts.messages.errors).toEqual({});
   });
 });
 

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -361,7 +361,7 @@ describe('validateThebe', () => {
       },
     });
     expect(opts.messages.errors?.length).toEqual(1);
-    expect(opts.messages.errors).toEqual({});
+    expect(opts.messages.errors?.[0].property).toEqual('repo');
   });
 });
 

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -72,16 +72,13 @@ export type Thebe = {
   local?: boolean | JupyterLocalOptions;
 };
 
-export enum BinderProviders {
-  git = 'git',
-  github = 'github',
-  gitlab = 'gitlab',
-}
+export type WellKnownRepoProviders = 'github' | 'gitlab' | 'git' | 'gist';
+export type BinderProviders = WellKnownRepoProviders | string;
 
 export type BinderHubOptions = {
   url?: string;
-  ref?: string; // org-name/repo-name
-  repo?: string; // valid git refs only?
+  ref?: string; // org-name/repo-name for WellKnownRepoProviders, url for 'meca', otherwise any string
+  repo?: string;
   provider?: BinderProviders;
 };
 

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -672,22 +672,15 @@ export function validateBinderHubOptions(input: any, opts: ValidationOptions) {
       ...incrementOptions('provider', opts),
       regex: /.+/,
     });
-    if (output.provider?.match(/^(git|github|gitlab|gist)$/i)) {
-      if (defined(value.repo)) {
-        output.repo = validateString(value.repo, {
-          ...incrementOptions('repo', opts),
-          regex: GITHUB_USERNAME_REPO_REGEX,
-        });
-      }
-    } else {
-      // otherwise repo can be any value, validate as any non empty string
-      output.repo = validateString(value.repo, {
-        ...incrementOptions('repo', opts),
-        regex: /.+/,
-      });
-    }
+  }
+  if (defined(value.provider) && !output.provider?.match(/^(git|github|gitlab|gist)$/i)) {
+    // repo can be any value, but must be present -> validate as any non empty string
+    output.repo = validateString(value.repo, {
+      ...incrementOptions('repo', opts),
+      regex: /.+/,
+    });
   } else {
-    // assumes a WellKnownRepoProvider defaulting to 'github', validate repo as a git*/gist spec
+    // otherwise repo is optional, but must be a valid GitHub username/repo is defined
     if (defined(value.repo)) {
       output.repo = validateString(value.repo, {
         ...incrementOptions('repo', opts),
@@ -695,7 +688,6 @@ export function validateBinderHubOptions(input: any, opts: ValidationOptions) {
       });
     }
   }
-
   if (defined(value.ref)) {
     output.ref = validateString(value.ref, incrementOptions('ref', opts));
   }

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -22,7 +22,7 @@ import {
   validateNumber,
 } from 'simple-validators';
 import { validateLicenses } from '../licenses/validators.js';
-import { BinderProviders, ExportFormats } from './types.js';
+import { ExportFormats } from './types.js';
 import type {
   Author,
   Biblio,

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -667,21 +667,39 @@ export function validateBinderHubOptions(input: any, opts: ValidationOptions) {
   if (defined(value.url)) {
     output.url = validateUrl(value.url, incrementOptions('url', opts));
   }
+  if (defined(value.provider)) {
+    output.provider = validateString(value.provider, {
+      ...incrementOptions('provider', opts),
+      regex: /.+/,
+    });
+    if (output.provider?.match(/^(git|github|gitlab|gist)$/i)) {
+      if (defined(value.repo)) {
+        output.repo = validateString(value.repo, {
+          ...incrementOptions('repo', opts),
+          regex: GITHUB_USERNAME_REPO_REGEX,
+        });
+      }
+    } else {
+      // otherwise provider can be any value, validate as any non empty string
+      output.repo = validateString(value.repo, {
+        ...incrementOptions('repo', opts),
+        regex: /.+/,
+      });
+    }
+  } else {
+    // assumes a WellKnownRepoProvider defaulting to 'github', validate repo as a git*/gist spec
+    if (defined(value.repo)) {
+      output.repo = validateString(value.repo, {
+        ...incrementOptions('repo', opts),
+        regex: GITHUB_USERNAME_REPO_REGEX,
+      });
+    }
+  }
+
   if (defined(value.ref)) {
     output.ref = validateString(value.ref, incrementOptions('ref', opts));
   }
-  if (defined(value.repo)) {
-    output.repo = validateString(value.repo, {
-      ...incrementOptions('repo', opts),
-      regex: GITHUB_USERNAME_REPO_REGEX,
-    });
-  }
-  if (defined(value.provider)) {
-    output.provider = validateEnum<BinderProviders>(value.provider, {
-      ...incrementOptions('provider', opts),
-      enum: BinderProviders,
-    });
-  }
+
   return output;
 }
 

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -680,7 +680,7 @@ export function validateBinderHubOptions(input: any, opts: ValidationOptions) {
         });
       }
     } else {
-      // otherwise provider can be any value, validate as any non empty string
+      // otherwise repo can be any value, validate as any non empty string
       output.repo = validateString(value.repo, {
         ...incrementOptions('repo', opts),
         regex: /.+/,


### PR DESCRIPTION
This opens up access to other providers (e.g. zenodo) beyond those supported in thebe 0.8.2 by default and is paired with changes to allow custom providers to be specified in thebe here https://github.com/executablebooks/thebe/pull/681