### PR TITLE
🏷 Tag reduced outputs as data.type.output

### DIFF
--- a/.changeset/smooth-pianos-reflect.md
+++ b/.changeset/smooth-pianos-reflect.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+🏷 Tag reduced outputs as data.type.output

--- a/packages/myst-cli/src/transforms/embed.ts
+++ b/packages/myst-cli/src/transforms/embed.ts
@@ -24,10 +24,14 @@ export function embedTransform(
     if (!target) return;
     let newNode = copyNode(target.node as any) as GenericNode | null;
     if (newNode && node['remove-output']) {
-      newNode = filter(newNode, (n: GenericNode) => n.type !== 'output');
+      newNode = filter(newNode, (n: GenericNode) => {
+        return n.type !== 'output' && n.data?.type !== 'output';
+      });
     }
     if (newNode && node['remove-input']) {
-      newNode = filter(newNode, (n: GenericNode) => n.type !== 'code');
+      newNode = filter(newNode, (n: GenericNode) => {
+        return n.type !== 'code' || n.data?.type === 'output';
+      });
     }
     selectAll('[identifier],[label],[html_id]', newNode).forEach((idNode: GenericNode) => {
       delete idNode.identifier;

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -95,6 +95,7 @@ export function reduceOutputs(mdast: GenericParent, file: string, writeFolder: s
           const relativePath = relative(dirname(file), output.path);
           return {
             type: 'image',
+            data: { type: 'output' },
             url: relativePath,
             urlSource: relativePath,
           };
@@ -103,6 +104,7 @@ export function reduceOutputs(mdast: GenericParent, file: string, writeFolder: s
           const content = fs.readFileSync(join(writeFolder, filename), 'utf-8');
           return {
             type: 'code',
+            data: { type: 'output' },
             value: stripAnsi(content),
           };
         }


### PR DESCRIPTION
This PR fixes a bug introduced when we reduced `output` nodes for PDF output to `code` etc. where `remove-input`/`remove-output` flags stopped filtering correctly.