### PR TITLE
📗 update docs to correct myst parser usage

### DIFF
--- a/packages/myst-parser/docs/consuming/advanced.md
+++ b/packages/myst-parser/docs/consuming/advanced.md
@@ -26,9 +26,9 @@ There are two ways to use the library, you can use the `MyST` wrapper,
 which creates a `MarkdownIt` tokenizer for you:
 
 ```javascript
-import { MyST } from 'myst-parser';
-const myst = MyST(); // Can override options here!
-const mdast = myst.parse(myString);
+import { mystParse } from 'myst-parser';
+const opts = {}; // Can override options here!
+const mdast = mystParse(myString, opts);
 ```
 
 Alternatively, you can use this with other packages in a more granular way:


### PR DESCRIPTION
`myst-parser` no longer exports the `MyST` object and plain js/ts usage would now be via the `mystParse` function. Docs have been updated to reflect this.