### PR TITLE
📇 Support parsed author names and parse string names

### DIFF
--- a/.changeset/wet-jeans-sell.md
+++ b/.changeset/wet-jeans-sell.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Support parsed author names and parse string names

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -33,7 +33,7 @@ import {
 const TEST_AUTHOR: Author = {
   userId: '',
   name: 'Test Author',
-  nameParsed: { display: 'Test Author', given: 'Test', family: 'Author' },
+  nameParsed: { literal: 'Test Author', given: 'Test', family: 'Author' },
   orcid: '0000-0000-0000-0000',
   corresponding: true,
   email: 'test@example.com',
@@ -143,7 +143,7 @@ const TEST_PROJECT_FRONTMATTER: ProjectFrontmatter = {
   authors: [
     {
       name: 'John Doe',
-      nameParsed: { display: 'John Doe', given: 'John', family: 'Doe' },
+      nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
       affiliations: ['univa'],
     },
   ],
@@ -188,7 +188,7 @@ const TEST_PAGE_FRONTMATTER: PageFrontmatter = {
   authors: [
     {
       name: 'Jane Doe',
-      nameParsed: { display: 'Jane Doe', given: 'Jane', family: 'Doe' },
+      nameParsed: { literal: 'Jane Doe', given: 'Jane', family: 'Doe' },
       affiliations: ['univb'],
     },
   ],
@@ -261,7 +261,7 @@ describe('validateAuthor', () => {
   it('unknown roles warn', async () => {
     expect(validateAuthor({ name: 'my name', roles: ['example'] }, {}, opts)).toEqual({
       name: 'my name',
-      nameParsed: { display: 'my name', given: 'my', family: 'name' },
+      nameParsed: { literal: 'my name', given: 'my', family: 'name' },
       roles: ['example'],
     });
     expect(opts.messages.warnings?.length).toEqual(1);
@@ -695,7 +695,7 @@ describe('validateAndStashObject', () => {
         {
           id: 'Just A. Name',
           name: 'Just A. Name',
-          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
       ],
     });
@@ -707,7 +707,7 @@ describe('validateAndStashObject', () => {
         {
           id: 'auth1',
           name: 'Just A. Name',
-          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
       ],
     };
@@ -724,7 +724,7 @@ describe('validateAndStashObject', () => {
         {
           id: 'auth1',
           name: 'Just A. Name',
-          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
       ],
     });
@@ -745,7 +745,7 @@ describe('validateAndStashObject', () => {
         {
           id: 'authors-test-file-generated-uid-0',
           name: 'Just A. Name',
-          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
       ],
     });
@@ -773,7 +773,7 @@ describe('validateAndStashObject', () => {
         {
           id: 'authors-my_file-generated-uid-0',
           name: 'Just A. Name',
-          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
       ],
     });
@@ -785,7 +785,7 @@ describe('validateAndStashObject', () => {
         {
           id: 'auth1',
           name: 'Just A. Name',
-          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
       ],
     };
@@ -802,12 +802,12 @@ describe('validateAndStashObject', () => {
         {
           id: 'auth1',
           name: 'Just A. Name',
-          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
         {
           id: 'auth2',
           name: 'A. Nother Name',
-          nameParsed: { display: 'A. Nother Name', given: 'A. Nother', family: 'Name' },
+          nameParsed: { literal: 'A. Nother Name', given: 'A. Nother', family: 'Name' },
         },
       ],
     });
@@ -838,7 +838,7 @@ describe('validateAndStashObject', () => {
         {
           id: 'auth1',
           name: 'Just A. Name',
-          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
       ],
     });
@@ -850,7 +850,7 @@ describe('validateAndStashObject', () => {
         {
           id: 'auth1',
           name: 'Just A. Name',
-          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
       ],
     };
@@ -870,7 +870,7 @@ describe('validateAndStashObject', () => {
         {
           id: 'auth1',
           name: 'Just A. Name',
-          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
       ],
     });

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -32,7 +32,8 @@ import {
 
 const TEST_AUTHOR: Author = {
   userId: '',
-  name: 'test user',
+  name: 'Test Author',
+  nameParsed: { display: 'Test Author', given: 'Test', family: 'Author' },
   orcid: '0000-0000-0000-0000',
   corresponding: true,
   email: 'test@example.com',
@@ -139,7 +140,13 @@ const TEST_PROJECT_FRONTMATTER: ProjectFrontmatter = {
   title: 'frontmatter',
   description: 'project frontmatter',
   venue: { title: 'test' },
-  authors: [{ name: 'John Doe', affiliations: ['univa'] }],
+  authors: [
+    {
+      name: 'John Doe',
+      nameParsed: { display: 'John Doe', given: 'John', family: 'Doe' },
+      affiliations: ['univa'],
+    },
+  ],
   affiliations: [{ id: 'univa', name: 'University A' }],
   date: '14 Dec 2021',
   name: 'example.md',
@@ -178,7 +185,13 @@ const TEST_PAGE_FRONTMATTER: PageFrontmatter = {
   title: 'frontmatter',
   description: 'page frontmatter',
   venue: { title: 'test' },
-  authors: [{ name: 'Jane Doe', affiliations: ['univb'] }],
+  authors: [
+    {
+      name: 'Jane Doe',
+      nameParsed: { display: 'Jane Doe', given: 'Jane', family: 'Doe' },
+      affiliations: ['univb'],
+    },
+  ],
   affiliations: [{ id: 'univb', name: 'University B' }],
   name: 'example.md',
   doi: '10.1000/abcd/efg012',
@@ -248,6 +261,7 @@ describe('validateAuthor', () => {
   it('unknown roles warn', async () => {
     expect(validateAuthor({ name: 'my name', roles: ['example'] }, {}, opts)).toEqual({
       name: 'my name',
+      nameParsed: { display: 'my name', given: 'my', family: 'name' },
       roles: ['example'],
     });
     expect(opts.messages.warnings?.length).toEqual(1);
@@ -676,11 +690,27 @@ describe('validateAndStashObject', () => {
       opts,
     );
     expect(out).toEqual('Just A. Name');
-    expect(stash).toEqual({ authors: [{ id: 'Just A. Name', name: 'Just A. Name' }] });
+    expect(stash).toEqual({
+      authors: [
+        {
+          id: 'Just A. Name',
+          name: 'Just A. Name',
+          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+        },
+      ],
+    });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
   it('string returns itself when in stash', async () => {
-    const stash = { authors: [{ id: 'auth1', name: 'Just A. Name' }] };
+    const stash = {
+      authors: [
+        {
+          id: 'auth1',
+          name: 'Just A. Name',
+          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+        },
+      ],
+    };
     const out = validateAndStashObject(
       'auth1',
       stash,
@@ -689,7 +719,15 @@ describe('validateAndStashObject', () => {
       opts,
     );
     expect(out).toEqual('auth1');
-    expect(stash).toEqual({ authors: [{ id: 'auth1', name: 'Just A. Name' }] });
+    expect(stash).toEqual({
+      authors: [
+        {
+          id: 'auth1',
+          name: 'Just A. Name',
+          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+        },
+      ],
+    });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
   it('no id creates hashed id', async () => {
@@ -703,7 +741,13 @@ describe('validateAndStashObject', () => {
     );
     expect(out).toEqual('authors-test-file-generated-uid-0');
     expect(stash).toEqual({
-      authors: [{ id: 'authors-test-file-generated-uid-0', name: 'Just A. Name' }],
+      authors: [
+        {
+          id: 'authors-test-file-generated-uid-0',
+          name: 'Just A. Name',
+          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+        },
+      ],
     });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
@@ -725,12 +769,26 @@ describe('validateAndStashObject', () => {
     );
     expect(out).toEqual('authors-my_file-generated-uid-0');
     expect(stash).toEqual({
-      authors: [{ id: 'authors-my_file-generated-uid-0', name: 'Just A. Name' }],
+      authors: [
+        {
+          id: 'authors-my_file-generated-uid-0',
+          name: 'Just A. Name',
+          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+        },
+      ],
     });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
   it('object with id added to stash', async () => {
-    const stash = { authors: [{ id: 'auth1', name: 'Just A. Name' }] };
+    const stash = {
+      authors: [
+        {
+          id: 'auth1',
+          name: 'Just A. Name',
+          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+        },
+      ],
+    };
     const out = validateAndStashObject(
       { id: 'auth2', name: 'A. Nother Name' },
       stash,
@@ -741,36 +799,81 @@ describe('validateAndStashObject', () => {
     expect(out).toEqual('auth2');
     expect(stash).toEqual({
       authors: [
-        { id: 'auth1', name: 'Just A. Name' },
-        { id: 'auth2', name: 'A. Nother Name' },
+        {
+          id: 'auth1',
+          name: 'Just A. Name',
+          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+        },
+        {
+          id: 'auth2',
+          name: 'A. Nother Name',
+          nameParsed: { display: 'A. Nother Name', given: 'A. Nother', family: 'Name' },
+        },
       ],
     });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
   it('object with id replaces simple object', async () => {
-    const stash = { authors: [{ id: 'auth1', name: 'auth1' }] };
+    const stash = {
+      authors: [
+        {
+          id: 'auth1',
+          name: 'auth1',
+        },
+      ],
+    };
     const out = validateAndStashObject(
-      { id: 'auth1', name: 'Just A. Name' },
+      {
+        id: 'auth1',
+        name: 'Just A. Name',
+      },
       stash,
       'authors',
       (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
       opts,
     );
     expect(out).toEqual('auth1');
-    expect(stash).toEqual({ authors: [{ id: 'auth1', name: 'Just A. Name' }] });
+    expect(stash).toEqual({
+      authors: [
+        {
+          id: 'auth1',
+          name: 'Just A. Name',
+          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+        },
+      ],
+    });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
   it('object with id warns on duplicate', async () => {
-    const stash = { authors: [{ id: 'auth1', name: 'Just A. Name' }] };
+    const stash = {
+      authors: [
+        {
+          id: 'auth1',
+          name: 'Just A. Name',
+          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+        },
+      ],
+    };
     const out = validateAndStashObject(
-      { id: 'auth1', name: 'A. Nother Name' },
+      {
+        id: 'auth1',
+        name: 'A. Nother Name',
+      },
       stash,
       'authors',
       (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
       opts,
     );
     expect(out).toEqual('auth1');
-    expect(stash).toEqual({ authors: [{ id: 'auth1', name: 'Just A. Name' }] });
+    expect(stash).toEqual({
+      authors: [
+        {
+          id: 'auth1',
+          name: 'Just A. Name',
+          nameParsed: { display: 'Just A. Name', given: 'Just A.', family: 'Name' },
+        },
+      ],
+    });
     expect(opts.messages.warnings?.length).toEqual(1);
   });
 });

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -23,9 +23,20 @@ export interface Affiliation {
 
 export type AuthorRoles = CreditRole | string;
 
+export type Name = {
+  display?: string;
+  given?: string;
+  family?: string;
+  particle?: string;
+  suffix?: string;
+};
+
+/**
+ * Au
+ */
 export interface Author {
   id?: string;
-  name?: string; // or Name object?
+  name?: string; // may be set to Name object
   userId?: string;
   orcid?: string;
   corresponding?: boolean;
@@ -40,6 +51,8 @@ export interface Author {
   note?: string;
   phone?: string;
   fax?: string;
+  // Computed property; only 'name' should be set in frontmatter as string or Name object
+  nameParsed?: Name;
 }
 
 /**

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -24,10 +24,11 @@ export interface Affiliation {
 export type AuthorRoles = CreditRole | string;
 
 export type Name = {
-  display?: string;
+  literal?: string;
   given?: string;
   family?: string;
-  particle?: string;
+  dropping_particle?: string;
+  non_dropping_particle?: string;
   suffix?: string;
 };
 

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -22,6 +22,7 @@ import {
   validateNumber,
 } from 'simple-validators';
 import { validateLicenses } from '../licenses/validators.js';
+import { parseName, renderName } from '../utils/parseName.js';
 import { ExportFormats } from './types.js';
 import type {
   Author,
@@ -41,6 +42,7 @@ import type {
   JupyterLocalOptions,
   ReferenceStash,
   Affiliation,
+  Name,
 } from './types.js';
 
 export const SITE_FRONTMATTER_KEYS = [
@@ -145,6 +147,14 @@ const AUTHOR_ALIASES = {
   role: 'roles',
   affiliation: 'affiliations',
   website: 'url',
+};
+
+const NAME_KEYS = ['display', 'given', 'particle', 'family', 'suffix'];
+const NAME_ALIASES = {
+  surname: 'family',
+  last: 'family',
+  forename: 'given',
+  first: 'given',
 };
 
 const AFFILIATION_ALIASES = {
@@ -433,6 +443,56 @@ export function validateAffiliation(input: any, opts: ValidationOptions) {
 }
 
 /**
+ * Validate Name object against the schema
+ */
+export function validateName(input: any, opts: ValidationOptions) {
+  let output: Name;
+  if (typeof input === 'string') {
+    output = parseName(input);
+  } else {
+    const value = validateObjectKeys(input, { optional: NAME_KEYS, alias: NAME_ALIASES }, opts);
+    if (value === undefined) return undefined;
+    output = {};
+    if (defined(value.display)) {
+      output.display = validateString(value.display, incrementOptions('display', opts));
+    }
+    if (defined(value.given)) {
+      output.given = validateString(value.given, incrementOptions('given', opts));
+    }
+    if (defined(value.particle)) {
+      output.particle = validateString(value.particle, incrementOptions('particle', opts));
+    }
+    if (defined(value.family)) {
+      output.family = validateString(value.family, incrementOptions('family', opts));
+    }
+    if (defined(value.suffix)) {
+      output.suffix = validateString(value.suffix, incrementOptions('suffix', opts));
+    }
+    if (Object.keys(output).length === 1 && output.display) {
+      output = { ...output, ...parseName(output.display) };
+    } else if (!output.display) {
+      output.display = renderName(output);
+    }
+  }
+  const warnOnComma = (part: string | undefined, o: ValidationOptions) => {
+    if (part && part.includes(',')) {
+      validationWarning(`unexpected comma in name part: ${part}`, o);
+    }
+  };
+  warnOnComma(output.given, incrementOptions('given', opts));
+  warnOnComma(output.particle, incrementOptions('particle', opts));
+  warnOnComma(output.family, incrementOptions('family', opts));
+  warnOnComma(output.suffix, incrementOptions('suffix', opts));
+  if (!output.family) {
+    validationWarning(`No family name for name '${output.display}'`, opts);
+  }
+  if (!output.given) {
+    validationWarning(`No given name for name '${output.display}'`, opts);
+  }
+  return output;
+}
+
+/**
  * Validate Author object against the schema
  */
 export function validateAuthor(input: any, stash: ReferenceStash, opts: ValidationOptions) {
@@ -450,7 +510,8 @@ export function validateAuthor(input: any, stash: ReferenceStash, opts: Validati
     output.userId = validateString(value.userId, incrementOptions('userId', opts));
   }
   if (defined(value.name)) {
-    output.name = validateString(value.name, incrementOptions('name', opts));
+    output.nameParsed = validateName(value.name, incrementOptions('name', opts));
+    output.name = output.nameParsed?.display;
   } else {
     validationWarning('author should include name', opts);
   }

--- a/packages/myst-frontmatter/src/utils/edgecases.yml
+++ b/packages/myst-frontmatter/src/utils/edgecases.yml
@@ -1,0 +1,9 @@
+title: Parsing of name edge cases
+cases:
+  - formatted: ',,,,,,'
+    parsed:
+      family: ',,,,'
+  - formatted: ''
+    parsed: {}
+    alternatives:
+      - "  \t "

--- a/packages/myst-frontmatter/src/utils/index.ts
+++ b/packages/myst-frontmatter/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './parseName.js';

--- a/packages/myst-frontmatter/src/utils/parseName.spec.ts
+++ b/packages/myst-frontmatter/src/utils/parseName.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'vitest';
+import type { Name } from '../frontmatter/types.js';
+import { parseName, renderName, startsWithUpperCase } from './parseName.js';
+
+describe('Test name parsing', () => {
+  test.each([
+    ['Abc', true],
+    ['ABC', true],
+    ['aBC', false],
+    ['abc', false],
+    ['àbc', false],
+    ['àBC', false],
+    ['Àbc', true],
+    ['1Abc', true],
+    ['1aBC', false],
+    ['123', true],
+  ])('test startsWithUpperCase: %s', async (word, upper) => {
+    expect(startsWithUpperCase(word)).toEqual(upper);
+  });
+  test.each<[string, Name, string?]>([
+    ['aa', { display: 'aa', family: 'aa' }, 'aa,'],
+    ['AA', { display: 'AA', family: 'AA' }, 'AA,'],
+    ['AA BB', { display: 'AA BB', family: 'BB', given: 'AA' }, 'BB, AA'],
+    [' AA \t BB  ', { display: ' AA \t BB  ', family: 'BB', given: 'AA' }, 'BB, AA'],
+    ['AA bb', { display: 'AA bb', family: 'bb', given: 'AA' }, 'bb, AA'],
+    ['AA bb CC', { display: 'AA bb CC', family: 'CC', given: 'AA', particle: 'bb' }, 'bb CC, AA'],
+    [
+      'AA bb CC dd EE',
+      { display: 'AA bb CC dd EE', family: 'EE', given: 'AA', particle: 'bb CC dd' },
+      'bb CC dd EE, AA',
+    ],
+    [
+      'AA 1B cc dd',
+      { display: 'AA 1B cc dd', family: 'dd', given: 'AA 1B', particle: 'cc' },
+      'cc dd, AA 1B',
+    ],
+    [
+      'AA 1b cc dd',
+      { display: 'AA 1b cc dd', family: 'dd', given: 'AA', particle: '1b cc' },
+      '1b cc dd, AA',
+    ],
+    [
+      'AA bb CC DD',
+      { display: 'AA bb CC DD', family: 'CC DD', given: 'AA', particle: 'bb' },
+      'bb CC DD, AA',
+    ],
+    [
+      'AA bb CC dd',
+      { display: 'AA bb CC dd', family: 'CC dd', given: 'AA', particle: 'bb' },
+      'bb CC dd, AA',
+    ],
+    ['bb CC, AA', { display: 'bb CC, AA', family: 'CC', given: 'AA', particle: 'bb' }, 'bb CC, AA'],
+    ['bb CC, aa', { display: 'bb CC, aa', family: 'CC', given: 'aa', particle: 'bb' }, 'bb CC, aa'],
+    [
+      'bb CC dd EE, AA',
+      { display: 'bb CC dd EE, AA', family: 'EE', given: 'AA', particle: 'bb CC dd' },
+    ],
+    ['CC dd EE, AA', { display: 'CC dd EE, AA', family: 'CC dd EE', given: 'AA' }],
+    ['CC dd EE,', { display: 'CC dd EE,', family: 'CC dd EE' }],
+    ['bb, AA', { display: 'bb, AA', family: 'bb', given: 'AA' }],
+    ['BB, ', { display: 'BB, ', family: 'BB' }, 'BB,'],
+    [
+      'bb CC, XX, AA ',
+      { display: 'bb CC, XX, AA ', family: 'CC', given: 'AA', particle: 'bb', suffix: 'XX' },
+      'bb CC, XX, AA',
+    ],
+    [
+      'bb CC, xx, AA ',
+      { display: 'bb CC, xx, AA ', family: 'CC', given: 'AA', particle: 'bb', suffix: 'xx' },
+      'bb CC, xx, AA',
+    ],
+    ['BB, , AA ', { display: 'BB, , AA ', family: 'BB', given: 'AA' }, 'BB, AA'],
+    [
+      'bb, , ,, CC, XX, AA',
+      {
+        display: 'bb, , ,, CC, XX, AA',
+        family: ', ,, CC',
+        given: 'AA',
+        particle: 'bb,',
+        suffix: 'XX',
+      },
+    ],
+    [',,,,,,', { display: ',,,,,,', family: ',,,,' }, ' ,,,,, , '],
+    [',AA', { display: ',AA', given: 'AA' }, ', AA'],
+    [',XX,AA', { display: ',XX,AA', given: 'AA', suffix: 'XX' }, ', XX, AA'],
+    ['', { display: '' }],
+  ])('string names parse and render correctly: %s', async (name, parsedName, renderedName?) => {
+    expect(parseName(name)).toEqual(parsedName);
+    delete parsedName.display;
+    renderedName = renderedName ?? name;
+    expect(renderName(parsedName)).toEqual(renderedName);
+    expect(parseName(renderedName)).toEqual({ display: renderedName, ...parsedName });
+  });
+});

--- a/packages/myst-frontmatter/src/utils/parseName.spec.ts
+++ b/packages/myst-frontmatter/src/utils/parseName.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import type { Name } from '../frontmatter/types.js';
-import { parseName, renderName, startsWithUpperCase } from './parseName.js';
+import { formatName, parseName, startsWithUpperCase } from './parseName.js';
 
 describe('Test name parsing', () => {
   test.each([
@@ -18,77 +18,119 @@ describe('Test name parsing', () => {
     expect(startsWithUpperCase(word)).toEqual(upper);
   });
   test.each<[string, Name, string?]>([
-    ['aa', { display: 'aa', family: 'aa' }, 'aa,'],
-    ['AA', { display: 'AA', family: 'AA' }, 'AA,'],
-    ['AA BB', { display: 'AA BB', family: 'BB', given: 'AA' }, 'BB, AA'],
-    [' AA \t BB  ', { display: ' AA \t BB  ', family: 'BB', given: 'AA' }, 'BB, AA'],
-    ['AA bb', { display: 'AA bb', family: 'bb', given: 'AA' }, 'bb, AA'],
-    ['AA bb CC', { display: 'AA bb CC', family: 'CC', given: 'AA', particle: 'bb' }, 'bb CC, AA'],
+    ['aa', { literal: 'aa', family: 'aa' }],
+    ['AA', { literal: 'AA', family: 'AA' }],
+    ['AA BB', { literal: 'AA BB', family: 'BB', given: 'AA' }],
+    [' AA \t BB  ', { literal: ' AA \t BB  ', family: 'BB', given: 'AA' }, 'AA BB'],
+    ['AA bb', { literal: 'AA bb', family: 'bb', given: 'AA' }],
+    ['AA bb CC', { literal: 'AA bb CC', family: 'CC', given: 'AA', non_dropping_particle: 'bb' }],
     [
       'AA bb CC dd EE',
-      { display: 'AA bb CC dd EE', family: 'EE', given: 'AA', particle: 'bb CC dd' },
-      'bb CC dd EE, AA',
+      { literal: 'AA bb CC dd EE', family: 'EE', given: 'AA', non_dropping_particle: 'bb CC dd' },
     ],
     [
       'AA 1B cc dd',
-      { display: 'AA 1B cc dd', family: 'dd', given: 'AA 1B', particle: 'cc' },
-      'cc dd, AA 1B',
+      { literal: 'AA 1B cc dd', family: 'dd', given: 'AA 1B', non_dropping_particle: 'cc' },
     ],
     [
       'AA 1b cc dd',
-      { display: 'AA 1b cc dd', family: 'dd', given: 'AA', particle: '1b cc' },
-      '1b cc dd, AA',
+      { literal: 'AA 1b cc dd', family: 'dd', given: 'AA', non_dropping_particle: '1b cc' },
     ],
     [
       'AA bb CC DD',
-      { display: 'AA bb CC DD', family: 'CC DD', given: 'AA', particle: 'bb' },
-      'bb CC DD, AA',
+      { literal: 'AA bb CC DD', family: 'CC DD', given: 'AA', non_dropping_particle: 'bb' },
     ],
     [
       'AA bb CC dd',
-      { display: 'AA bb CC dd', family: 'CC dd', given: 'AA', particle: 'bb' },
-      'bb CC dd, AA',
+      { literal: 'AA bb CC dd', family: 'CC dd', given: 'AA', non_dropping_particle: 'bb' },
     ],
-    ['bb CC, AA', { display: 'bb CC, AA', family: 'CC', given: 'AA', particle: 'bb' }, 'bb CC, AA'],
-    ['bb CC, aa', { display: 'bb CC, aa', family: 'CC', given: 'aa', particle: 'bb' }, 'bb CC, aa'],
+    [
+      'bb CC, AA',
+      { literal: 'bb CC, AA', family: 'CC', given: 'AA', non_dropping_particle: 'bb' },
+      'AA bb CC',
+    ],
+    [
+      'bb CC, aa',
+      { literal: 'bb CC, aa', family: 'CC', given: 'aa', non_dropping_particle: 'bb' },
+      'aa bb CC',
+    ],
     [
       'bb CC dd EE, AA',
-      { display: 'bb CC dd EE, AA', family: 'EE', given: 'AA', particle: 'bb CC dd' },
+      {
+        literal: 'bb CC dd EE, AA',
+        family: 'EE',
+        given: 'AA',
+        non_dropping_particle: 'bb CC dd',
+      },
+      'AA bb CC dd EE',
     ],
-    ['CC dd EE, AA', { display: 'CC dd EE, AA', family: 'CC dd EE', given: 'AA' }],
-    ['CC dd EE,', { display: 'CC dd EE,', family: 'CC dd EE' }],
-    ['bb, AA', { display: 'bb, AA', family: 'bb', given: 'AA' }],
-    ['BB, ', { display: 'BB, ', family: 'BB' }, 'BB,'],
+    ['CC dd EE, AA', { literal: 'CC dd EE, AA', family: 'CC dd EE', given: 'AA' }],
+    ['CC dd EE,', { literal: 'CC dd EE,', family: 'CC dd EE' }],
+    ['bb, AA', { literal: 'bb, AA', family: 'bb', given: 'AA' }, 'AA bb'],
+    ['BB, ', { literal: 'BB, ', family: 'BB' }, 'BB'],
     [
       'bb CC, XX, AA ',
-      { display: 'bb CC, XX, AA ', family: 'CC', given: 'AA', particle: 'bb', suffix: 'XX' },
+      {
+        literal: 'bb CC, XX, AA ',
+        family: 'CC',
+        given: 'AA',
+        non_dropping_particle: 'bb',
+        suffix: 'XX',
+      },
       'bb CC, XX, AA',
     ],
     [
       'bb CC, xx, AA ',
-      { display: 'bb CC, xx, AA ', family: 'CC', given: 'AA', particle: 'bb', suffix: 'xx' },
+      {
+        literal: 'bb CC, xx, AA ',
+        family: 'CC',
+        given: 'AA',
+        non_dropping_particle: 'bb',
+        suffix: 'xx',
+      },
       'bb CC, xx, AA',
     ],
-    ['BB, , AA ', { display: 'BB, , AA ', family: 'BB', given: 'AA' }, 'BB, AA'],
+    ['BB, , AA ', { literal: 'BB, , AA ', family: 'BB', given: 'AA' }, 'AA BB'],
     [
       'bb, , ,, CC, XX, AA',
       {
-        display: 'bb, , ,, CC, XX, AA',
+        literal: 'bb, , ,, CC, XX, AA',
         family: ', ,, CC',
         given: 'AA',
-        particle: 'bb,',
+        non_dropping_particle: 'bb,',
         suffix: 'XX',
       },
     ],
-    [',,,,,,', { display: ',,,,,,', family: ',,,,' }, ' ,,,,, , '],
-    [',AA', { display: ',AA', given: 'AA' }, ', AA'],
-    [',XX,AA', { display: ',XX,AA', given: 'AA', suffix: 'XX' }, ', XX, AA'],
-    ['', { display: '' }],
+    [
+      'bb CC, AA ee',
+      {
+        literal: 'bb CC, AA ee',
+        family: 'CC',
+        given: 'AA',
+        dropping_particle: 'ee',
+        non_dropping_particle: 'bb',
+      },
+    ],
+    [
+      'bb CC, xx, AA ee',
+      {
+        literal: 'bb CC, xx, AA ee',
+        family: 'CC',
+        given: 'AA',
+        dropping_particle: 'ee',
+        non_dropping_particle: 'bb',
+        suffix: 'xx',
+      },
+    ],
+    [',,,,,,', { literal: ',,,,,,', family: ',,,,' }, ',,,,,,'],
+    [',AA', { literal: ',AA', given: 'AA' }, ', AA'],
+    [',XX,AA', { literal: ',XX,AA', given: 'AA', suffix: 'XX' }, ', XX, AA'],
+    ['', { literal: '' }],
   ])('string names parse and render correctly: %s', async (name, parsedName, renderedName?) => {
     expect(parseName(name)).toEqual(parsedName);
-    delete parsedName.display;
+    delete parsedName.literal;
     renderedName = renderedName ?? name;
-    expect(renderName(parsedName)).toEqual(renderedName);
-    expect(parseName(renderedName)).toEqual({ display: renderedName, ...parsedName });
+    expect(formatName(parsedName)).toEqual(renderedName);
+    expect(parseName(renderedName)).toEqual({ literal: renderedName, ...parsedName });
   });
 });

--- a/packages/myst-frontmatter/src/utils/parseName.spec.ts
+++ b/packages/myst-frontmatter/src/utils/parseName.spec.ts
@@ -1,8 +1,47 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'js-yaml';
 import { describe, expect, test } from 'vitest';
 import type { Name } from '../frontmatter/types.js';
 import { formatName, parseName, startsWithUpperCase } from './parseName.js';
 
-describe('Test name parsing', () => {
+type TestCase = {
+  // Formatted name - result of calling formatName on parsed name
+  formatted: string;
+  // Parsed name - result of calling parseName on formatted name
+  parsed: Name;
+  // Alternatives - other names that parse to the same parsed name
+  alternatives?: string[];
+};
+
+type TestCases = {
+  title: string;
+  cases: TestCase[];
+};
+
+const casesList: TestCases[] = fs
+  .readdirSync(__dirname)
+  .filter((file) => file.endsWith('.yml'))
+  .map((file) => {
+    const content = fs.readFileSync(path.join(__dirname, file), { encoding: 'utf-8' });
+    return yaml.load(content) as TestCases;
+  });
+
+casesList.forEach(({ title, cases }) => {
+  describe(title, () => {
+    test.each(cases.map((c): [string, TestCase] => [c.formatted, c]))(
+      '%s',
+      (_, { formatted, parsed, alternatives }) => {
+        [formatted, ...(alternatives ?? [])].forEach((name) => {
+          expect(parseName(name)).toEqual({ literal: name, ...parsed });
+        });
+        expect(formatName(parsed)).toEqual(formatted);
+      },
+    );
+  });
+});
+
+describe('Parsing utilities', () => {
   test.each([
     ['Abc', true],
     ['ABC', true],
@@ -16,121 +55,5 @@ describe('Test name parsing', () => {
     ['123', true],
   ])('test startsWithUpperCase: %s', async (word, upper) => {
     expect(startsWithUpperCase(word)).toEqual(upper);
-  });
-  test.each<[string, Name, string?]>([
-    ['aa', { literal: 'aa', family: 'aa' }],
-    ['AA', { literal: 'AA', family: 'AA' }],
-    ['AA BB', { literal: 'AA BB', family: 'BB', given: 'AA' }],
-    [' AA \t BB  ', { literal: ' AA \t BB  ', family: 'BB', given: 'AA' }, 'AA BB'],
-    ['AA bb', { literal: 'AA bb', family: 'bb', given: 'AA' }],
-    ['AA bb CC', { literal: 'AA bb CC', family: 'CC', given: 'AA', non_dropping_particle: 'bb' }],
-    [
-      'AA bb CC dd EE',
-      { literal: 'AA bb CC dd EE', family: 'EE', given: 'AA', non_dropping_particle: 'bb CC dd' },
-    ],
-    [
-      'AA 1B cc dd',
-      { literal: 'AA 1B cc dd', family: 'dd', given: 'AA 1B', non_dropping_particle: 'cc' },
-    ],
-    [
-      'AA 1b cc dd',
-      { literal: 'AA 1b cc dd', family: 'dd', given: 'AA', non_dropping_particle: '1b cc' },
-    ],
-    [
-      'AA bb CC DD',
-      { literal: 'AA bb CC DD', family: 'CC DD', given: 'AA', non_dropping_particle: 'bb' },
-    ],
-    [
-      'AA bb CC dd',
-      { literal: 'AA bb CC dd', family: 'CC dd', given: 'AA', non_dropping_particle: 'bb' },
-    ],
-    [
-      'bb CC, AA',
-      { literal: 'bb CC, AA', family: 'CC', given: 'AA', non_dropping_particle: 'bb' },
-      'AA bb CC',
-    ],
-    [
-      'bb CC, aa',
-      { literal: 'bb CC, aa', family: 'CC', given: 'aa', non_dropping_particle: 'bb' },
-      'aa bb CC',
-    ],
-    [
-      'bb CC dd EE, AA',
-      {
-        literal: 'bb CC dd EE, AA',
-        family: 'EE',
-        given: 'AA',
-        non_dropping_particle: 'bb CC dd',
-      },
-      'AA bb CC dd EE',
-    ],
-    ['CC dd EE, AA', { literal: 'CC dd EE, AA', family: 'CC dd EE', given: 'AA' }],
-    ['CC dd EE,', { literal: 'CC dd EE,', family: 'CC dd EE' }],
-    ['bb, AA', { literal: 'bb, AA', family: 'bb', given: 'AA' }, 'AA bb'],
-    ['BB, ', { literal: 'BB, ', family: 'BB' }, 'BB'],
-    [
-      'bb CC, XX, AA ',
-      {
-        literal: 'bb CC, XX, AA ',
-        family: 'CC',
-        given: 'AA',
-        non_dropping_particle: 'bb',
-        suffix: 'XX',
-      },
-      'bb CC, XX, AA',
-    ],
-    [
-      'bb CC, xx, AA ',
-      {
-        literal: 'bb CC, xx, AA ',
-        family: 'CC',
-        given: 'AA',
-        non_dropping_particle: 'bb',
-        suffix: 'xx',
-      },
-      'bb CC, xx, AA',
-    ],
-    ['BB, , AA ', { literal: 'BB, , AA ', family: 'BB', given: 'AA' }, 'AA BB'],
-    [
-      'bb, , ,, CC, XX, AA',
-      {
-        literal: 'bb, , ,, CC, XX, AA',
-        family: ', ,, CC',
-        given: 'AA',
-        non_dropping_particle: 'bb,',
-        suffix: 'XX',
-      },
-    ],
-    [
-      'bb CC, AA ee',
-      {
-        literal: 'bb CC, AA ee',
-        family: 'CC',
-        given: 'AA',
-        dropping_particle: 'ee',
-        non_dropping_particle: 'bb',
-      },
-    ],
-    [
-      'bb CC, xx, AA ee',
-      {
-        literal: 'bb CC, xx, AA ee',
-        family: 'CC',
-        given: 'AA',
-        dropping_particle: 'ee',
-        non_dropping_particle: 'bb',
-        suffix: 'xx',
-      },
-    ],
-    [',,,,,,', { literal: ',,,,,,', family: ',,,,' }, ',,,,,,'],
-    [',AA', { literal: ',AA', given: 'AA' }, ', AA'],
-    [',XX,AA', { literal: ',XX,AA', given: 'AA', suffix: 'XX' }, ', XX, AA'],
-    ['', { literal: '' }],
-  ])('string names parse and render correctly: %s', async (name, parsedName, renderedName?) => {
-    expect(parseName(name)).toEqual(parsedName);
-    delete parsedName.literal;
-    renderedName = renderedName ?? name;
-    expect(formatName(parsedName)).toEqual(renderedName);
-    expect(parseName(renderedName)).toEqual({ literal: renderedName, ...parsedName });
   });
 });

--- a/packages/myst-frontmatter/src/utils/parseName.ts
+++ b/packages/myst-frontmatter/src/utils/parseName.ts
@@ -1,0 +1,102 @@
+import type { Name } from '../index.js';
+
+/**
+ * Check if the first letter in a word is uppercase
+ *
+ * Non-letters are bypassed; if the entire word is non-letters it is considered uppercase
+ */
+export function startsWithUpperCase(word: string) {
+  for (const letter of word) {
+    // Non-letters are unchanged by lower/upper case
+    if (letter.toLowerCase() === letter.toUpperCase()) continue;
+    return letter === letter.toUpperCase();
+  }
+  return true;
+}
+
+/**
+ * Parse string display name to family, given, particle, and suffix parts
+ *
+ * This function attempts to follow bibtex rules described here:
+ * http://maverick.inria.fr/~Xavier.Decoret/resources/xdkbibtex/bibtex_summary.html#names
+ * However, unlike the description in the site above, for input, we only expect simple
+ * unicode string names, no latex.
+ */
+export function parseName(display: string): Name {
+  const parsed: Name = { display };
+  const displayParts = display.split(',');
+  // Handle "Given particle Family"
+  if (displayParts.length === 1) {
+    return { ...parsed, ...parseGivenParticleFamily(display) };
+  }
+  // Handle "particle Family, Given"
+  const given = displayParts.pop()?.trim();
+  if (given) parsed.given = given;
+  if (displayParts.length === 1) {
+    return { ...parsed, ...parseParticleFamily(displayParts[0]) };
+  }
+  // Handle "particle Family, Suffix, Given"
+  const suffix = displayParts.pop()?.trim();
+  const particleAndFamily = parseParticleFamily(displayParts.join(','));
+  if (!suffix) return { ...parsed, ...particleAndFamily };
+  return { ...parsed, ...particleAndFamily, suffix };
+}
+
+/**
+ * Parse string as "particle Family"
+ */
+function parseParticleFamily(name: string): Name {
+  const nameParts = name.trim().split(/\s+/);
+  if (!nameParts.length) return {};
+  let family = nameParts.pop();
+  if (!family) return {};
+  if (!nameParts.length) return { family };
+  if (startsWithUpperCase(nameParts[0])) {
+    return { family: [...nameParts, family].join(' ') };
+  }
+  while (nameParts.length && startsWithUpperCase(nameParts[nameParts.length - 1])) {
+    family = `${nameParts.pop()} ${family}`;
+  }
+  if (!nameParts.length) return { family };
+  return { particle: nameParts.join(' '), family };
+}
+
+/**
+ * Parse string as "Given particle Family"
+ */
+function parseGivenParticleFamily(name: string): Name {
+  const nameParts = name.trim().split(/\s+/);
+  if (!nameParts.length) return {};
+  let family = nameParts.pop();
+  if (!family) return {};
+  if (!nameParts.length) return { family };
+  let given = nameParts.shift();
+  if (!nameParts.length) return { given, family };
+  while (nameParts.length && startsWithUpperCase(nameParts[0])) {
+    given = `${given} ${nameParts.shift()}`;
+  }
+  while (nameParts.length && startsWithUpperCase(nameParts[nameParts.length - 1])) {
+    family = `${nameParts.pop()} ${family}`;
+  }
+  if (!nameParts.length) return { given, family };
+  return { given, particle: nameParts.join(' '), family };
+}
+
+/**
+ * Render parsed name to a string
+ *
+ * If parsed name has display value, this is simply returned.
+ * Otherwise, it is rendered as "particle Family, Suffix, Given"
+ */
+export function renderName(name: Name): string {
+  const { display, given, particle, family, suffix } = name;
+  if (display) return display;
+  let output = ',';
+  const unexpectedCommas = `${given}${particle}${family}${suffix}`.includes(',');
+  if (suffix || unexpectedCommas) output = `${output} ${suffix ?? ''},`;
+  if (given || unexpectedCommas) output = `${output} ${given ?? ''}`;
+  if (family || unexpectedCommas) output = `${family ?? ''}${output}`;
+  if (particle || unexpectedCommas) output = `${particle ?? ''} ${output}`;
+  if (output === ',') return '';
+  return output;
+}

--- a/packages/myst-frontmatter/src/utils/parseName.ts
+++ b/packages/myst-frontmatter/src/utils/parseName.ts
@@ -15,54 +15,72 @@ export function startsWithUpperCase(word: string) {
 }
 
 /**
- * Parse string display name to family, given, particle, and suffix parts
+ * Parse string literal name to family, dropping-particle, non-dropping-particle, given, and suffix parts
  *
  * This function attempts to follow bibtex rules described here:
  * http://maverick.inria.fr/~Xavier.Decoret/resources/xdkbibtex/bibtex_summary.html#names
  * However, unlike the description in the site above, for input, we only expect simple
  * unicode string names, no latex.
+ *
+ * We also take some inspiration from https://github.com/citation-js/name
+ * particularly around non-dropping vs. dropping particles.
+ * However, that library is very under-tested, and some of the behavior around parsing commas
+ * and formatting particles feels wrong.
  */
-export function parseName(display: string): Name {
-  const parsed: Name = { display };
-  const displayParts = display.split(',');
+export function parseName(literal: string): Name {
+  const displayParts = literal.split(',');
   // Handle "Given particle Family"
   if (displayParts.length === 1) {
-    return { ...parsed, ...parseGivenParticleFamily(display) };
+    return { literal, ...parseGivenParticleFamily(literal) };
   }
-  // Handle "particle Family, Given"
-  const given = displayParts.pop()?.trim();
-  if (given) parsed.given = given;
+  // Handle "non-dropping-particle Family, Given dropping-particle"
+  const lastPart = displayParts.pop()?.trim();
+  const givenAndParticle = parseGivenParticle(lastPart);
   if (displayParts.length === 1) {
-    return { ...parsed, ...parseParticleFamily(displayParts[0]) };
+    return { literal, ...givenAndParticle, ...parseParticleFamily(displayParts[0]) };
   }
-  // Handle "particle Family, Suffix, Given"
+  // Handle "non-dropping-particle Family, Suffix, Given dropping-particle"
   const suffix = displayParts.pop()?.trim();
   const particleAndFamily = parseParticleFamily(displayParts.join(','));
-  if (!suffix) return { ...parsed, ...particleAndFamily };
-  return { ...parsed, ...particleAndFamily, suffix };
+  if (!suffix) return { literal, ...givenAndParticle, ...particleAndFamily };
+  return { literal, ...givenAndParticle, ...particleAndFamily, suffix };
 }
 
 /**
- * Parse string as "particle Family"
+ * Parse string as "Given dropping-particle"
+ */
+function parseGivenParticle(name?: string): Name {
+  const nameParts = name?.trim().split(/\s+/);
+  if (!nameParts?.length) return {};
+  let given = nameParts.shift();
+  if (!given) return {};
+  while (nameParts.length && startsWithUpperCase(nameParts[0])) {
+    given = `${given} ${nameParts.shift()}`;
+  }
+  if (!nameParts.length) return { given };
+  return { given, dropping_particle: nameParts.join(' ') };
+}
+
+/**
+ * Parse string as "non-dropping-particle Family"
  */
 function parseParticleFamily(name: string): Name {
   const nameParts = name.trim().split(/\s+/);
   if (!nameParts.length) return {};
   let family = nameParts.pop();
   if (!family) return {};
-  if (!nameParts.length) return { family };
-  if (startsWithUpperCase(nameParts[0])) {
+  if (nameParts.length && startsWithUpperCase(nameParts[0])) {
     return { family: [...nameParts, family].join(' ') };
   }
   while (nameParts.length && startsWithUpperCase(nameParts[nameParts.length - 1])) {
     family = `${nameParts.pop()} ${family}`;
   }
   if (!nameParts.length) return { family };
-  return { particle: nameParts.join(' '), family };
+  return { non_dropping_particle: nameParts.join(' '), family };
 }
 
 /**
- * Parse string as "Given particle Family"
+ * Parse string as "Given non-dropping-particle Family"
  */
 function parseGivenParticleFamily(name: string): Name {
   const nameParts = name.trim().split(/\s+/);
@@ -71,7 +89,6 @@ function parseGivenParticleFamily(name: string): Name {
   if (!family) return {};
   if (!nameParts.length) return { family };
   let given = nameParts.shift();
-  if (!nameParts.length) return { given, family };
   while (nameParts.length && startsWithUpperCase(nameParts[0])) {
     given = `${given} ${nameParts.shift()}`;
   }
@@ -79,24 +96,45 @@ function parseGivenParticleFamily(name: string): Name {
     family = `${nameParts.pop()} ${family}`;
   }
   if (!nameParts.length) return { given, family };
-  return { given, particle: nameParts.join(' '), family };
+  return { given, non_dropping_particle: nameParts.join(' '), family };
 }
 
 /**
  * Render parsed name to a string
  *
- * If parsed name has display value, this is simply returned.
- * Otherwise, it is rendered as "particle Family, Suffix, Given"
+ * If parsed name has literal value, this value is always returned.
+ *
+ * If alwaysReverse is not set to true, we try to format the name as "Given non-dropping-particle Family"
+ * However, it must roundtrip successfully and parse to equal the input.
+ *
+ * Otherwise, it is rendered as "non-dropping-particle Family, Suffix, Given dropping-particle"
  */
-export function renderName(name: Name): string {
-  const { display, given, particle, family, suffix } = name;
-  if (display) return display;
+export function formatName(name: Name, alwaysReversed = false): string {
+  const { literal, given, dropping_particle, non_dropping_particle, family, suffix } = name;
+  // Always return literal if we can.
+  if (literal) return literal;
+  // Check if there are any unexpected commas in the name parts; if so, we must format as reversed.
+  const hasCommas = [given, dropping_particle, non_dropping_particle, family, suffix]
+    .join('')
+    .includes(',');
+  // We can try to format the string "normally" given these checks:
+  if (!alwaysReversed && !hasCommas && !dropping_particle && !suffix) {
+    const formattedName = [given, non_dropping_particle, family].filter(Boolean).join(' ');
+    const reParsedName = parseName(formattedName);
+    delete reParsedName.literal;
+    const serializedParsedName = JSON.stringify(Object.entries(reParsedName).sort());
+    const serializedSourceName = JSON.stringify(Object.entries(name).sort());
+    if (serializedParsedName === serializedSourceName) {
+      return formattedName;
+    }
+  }
+  // Otherwise, format the string "reversed"
   let output = ',';
-  const unexpectedCommas = `${given}${particle}${family}${suffix}`.includes(',');
-  if (suffix || unexpectedCommas) output = `${output} ${suffix ?? ''},`;
-  if (given || unexpectedCommas) output = `${output} ${given ?? ''}`;
-  if (family || unexpectedCommas) output = `${family ?? ''}${output}`;
-  if (particle || unexpectedCommas) output = `${particle ?? ''} ${output}`;
+  if (suffix || hasCommas) output = `${output}${suffix ? ' ' : ''}${suffix ?? ''},`;
+  if (given) output = `${output} ${given}`;
+  if (family) output = `${family}${output}`;
+  if (dropping_particle) output = `${output} ${dropping_particle}`;
+  if (non_dropping_particle) output = `${non_dropping_particle} ${output}`;
   if (output === ',') return '';
   return output;
 }

--- a/packages/myst-frontmatter/src/utils/realnames.yml
+++ b/packages/myst-frontmatter/src/utils/realnames.yml
@@ -1,0 +1,66 @@
+title: Parsing of real names
+cases:
+  - formatted: John Doe
+    parsed:
+      family: Doe
+      given: John
+  - formatted: Mary Jane Watson
+    parsed:
+      family: Watson
+      given: Mary Jane
+  - formatted: Vincent van Gogh
+    parsed:
+      family: Gogh
+      given: Vincent
+      non_dropping_particle: van
+  - formatted: João de Silva
+    parsed:
+      family: Silva
+      given: João
+      non_dropping_particle: de
+  - formatted: Brun, Charles le
+    parsed:
+      family: Brun
+      given: Charles
+      dropping_particle: le
+  - formatted: Jean-Luc Picard
+    parsed:
+      family: Picard
+      given: Jean-Luc
+  - formatted: D'Arcy Wretzky
+    parsed:
+      family: Wretzky
+      given: D'Arcy
+  - formatted: Madeleine L'Engle
+    parsed:
+      family: L'Engle
+      given: Madeleine
+  - formatted: Charles d'Artagnan
+    parsed:
+      family: d'Artagnan
+      given: Charles
+  - formatted: Jean-François Millet
+    parsed:
+      family: Millet
+      given: Jean-François
+  - formatted: Diego J. Rivera-Gutierrez
+    parsed:
+      family: Rivera-Gutierrez
+      given: Diego J.
+  - formatted: Smith, Jr., John
+    parsed:
+      family: Smith
+      given: John
+      suffix: Jr.
+  - formatted: Sir Paul McCartney
+    parsed:
+      family: McCartney
+      given: Sir Paul
+  - formatted: F. Scott Fitzgerald
+    parsed:
+      family: Fitzgerald
+      given: F. Scott
+  - formatted: JRR Tolkien
+    parsed:
+      family: Tolkien
+      given: JRR

--- a/packages/myst-frontmatter/src/utils/testnames.yml
+++ b/packages/myst-frontmatter/src/utils/testnames.yml
@@ -1,0 +1,135 @@
+title: Parsing of test name strings
+# From http://maverick.inria.fr/~Xavier.Decoret/resources/xdkbibtex/bibtex_summary.html#names
+cases:
+  - formatted: aa
+    parsed:
+      family: aa
+
+  - formatted: AA
+    alternative:
+      - 'AA, '
+    parsed:
+      family: AA
+
+  - formatted: AA BB
+    alternatives:
+      - " AA \t BB  "
+      - 'BB, , AA '
+    parsed:
+      family: BB
+      given: AA
+
+  - formatted: AA bb
+    alternatives:
+      - bb, AA
+    parsed:
+      family: bb
+      given: AA
+
+  - formatted: AA bb CC
+    alternatives:
+      - bb CC, AA
+    parsed:
+      family: CC
+      given: AA
+      non_dropping_particle: bb
+
+  - formatted: aa bb CC
+    alternatives:
+      - bb CC, aa
+    parsed:
+      family: CC
+      given: aa
+      non_dropping_particle: bb
+
+  - formatted: AA 1B cc dd
+    parsed:
+      family: dd
+      given: AA 1B
+      non_dropping_particle: cc
+
+  - formatted: AA 1b cc dd
+    parsed:
+      family: dd
+      given: AA
+      non_dropping_particle: 1b cc
+
+  - formatted: AA bb CC DD
+    parsed:
+      family: CC DD
+      given: AA
+      non_dropping_particle: bb
+
+  - formatted: AA bb CC dd
+    parsed:
+      family: CC dd
+      given: AA
+      non_dropping_particle: bb
+
+  - formatted: AA bb CC dd EE
+    alternatives:
+      - bb CC dd EE, AA
+    parsed:
+      family: EE
+      given: AA
+      non_dropping_particle: bb CC dd
+
+  - formatted: CC dd EE, AA
+    parsed:
+      family: CC dd EE
+      given: AA
+
+  - formatted: CC dd EE,
+    parsed:
+      family: CC dd EE
+
+  - formatted: bb CC, XX, AA
+    alternatives:
+      - 'bb CC, XX, AA '
+    parsed:
+      family: CC
+      given: AA
+      non_dropping_particle: bb
+      suffix: XX
+
+  - formatted: bb CC, xx, AA
+    parsed:
+      family: CC
+      given: AA
+      non_dropping_particle: bb
+      suffix: xx
+
+  - formatted: bb, , ,, CC, XX, AA
+    parsed:
+      family: ', ,, CC'
+      given: AA
+      non_dropping_particle: bb,
+      suffix: XX
+
+  - formatted: bb CC, AA ee
+    parsed:
+      family: CC
+      given: AA
+      dropping_particle: ee
+      non_dropping_particle: bb
+
+  - formatted: bb CC, xx, AA ee
+    parsed:
+      family: CC
+      given: AA
+      dropping_particle: ee
+      non_dropping_particle: bb
+      suffix: xx
+
+  - formatted: ', AA'
+    alternatives:
+      - ',AA'
+    parsed:
+      given: 'AA'
+
+  - formatted: ', XX, AA'
+    alternatives:
+      - ',XX,AA'
+    parsed:
+      given: AA
+      suffix: XX

--- a/packages/myst-frontmatter/tests/affiliations.yml
+++ b/packages/myst-frontmatter/tests/affiliations.yml
@@ -65,13 +65,13 @@ cases:
       authors:
         - name: Norah Jones
           nameParsed:
-            display: Norah Jones
+            literal: Norah Jones
             given: Norah
             family: Jones
           affiliations: [cmu, chicago]
         - name: John Hamm
           nameParsed:
-            display: John Hamm
+            literal: John Hamm
             given: John
             family: Hamm
           affiliations: [cmu]
@@ -96,13 +96,13 @@ cases:
       authors:
         - name: Norah Jones
           nameParsed:
-            display: Norah Jones
+            literal: Norah Jones
             given: Norah
             family: Jones
           affiliations: [cmu, chicago]
         - name: John Hamm
           nameParsed:
-            display: John Hamm
+            literal: John Hamm
             given: John
             family: Hamm
           affiliations: [cmu]
@@ -133,7 +133,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
@@ -151,7 +151,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
@@ -170,7 +170,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
@@ -192,7 +192,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
@@ -214,14 +214,14 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
             - University A
         - name: A. Nother Name
           nameParsed:
-            display: A. Nother Name
+            literal: A. Nother Name
             given: A. Nother
             family: Name
           affiliations:
@@ -244,14 +244,14 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
             - affiliations-generated-uid-0
         - name: A. Nother Name
           nameParsed:
-            display: A. Nother Name
+            literal: A. Nother Name
             given: A. Nother
             family: Name
           affiliations:
@@ -273,7 +273,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:

--- a/packages/myst-frontmatter/tests/affiliations.yml
+++ b/packages/myst-frontmatter/tests/affiliations.yml
@@ -64,8 +64,16 @@ cases:
     normalized:
       authors:
         - name: Norah Jones
+          nameParsed:
+            display: Norah Jones
+            given: Norah
+            family: Jones
           affiliations: [cmu, chicago]
         - name: John Hamm
+          nameParsed:
+            display: John Hamm
+            given: John
+            family: Hamm
           affiliations: [cmu]
       affiliations:
         - id: cmu
@@ -87,8 +95,16 @@ cases:
     normalized:
       authors:
         - name: Norah Jones
+          nameParsed:
+            display: Norah Jones
+            given: Norah
+            family: Jones
           affiliations: [cmu, chicago]
         - name: John Hamm
+          nameParsed:
+            display: John Hamm
+            given: John
+            family: Hamm
           affiliations: [cmu]
       affiliations:
         - id: cmu
@@ -116,6 +132,10 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           affiliations:
             - univa
       affiliations:
@@ -130,6 +150,10 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           affiliations:
             - University A
       affiliations:
@@ -145,6 +169,10 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           affiliations:
             - univa
       affiliations:
@@ -163,6 +191,10 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           affiliations:
             - univa
       affiliations:
@@ -181,9 +213,17 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           affiliations:
             - University A
         - name: A. Nother Name
+          nameParsed:
+            display: A. Nother Name
+            given: A. Nother
+            family: Name
           affiliations:
             - University A
       affiliations:
@@ -203,9 +243,17 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           affiliations:
             - affiliations-generated-uid-0
         - name: A. Nother Name
+          nameParsed:
+            display: A. Nother Name
+            given: A. Nother
+            family: Name
           affiliations:
             - affiliations-generated-uid-0
       affiliations:
@@ -224,6 +272,10 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           affiliations:
             - univa
       affiliations:

--- a/packages/myst-frontmatter/tests/authors.yml
+++ b/packages/myst-frontmatter/tests/authors.yml
@@ -9,7 +9,7 @@ cases:
         - id: Just A. Name
           name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
   - title: Simple Authors String
@@ -20,7 +20,7 @@ cases:
         - id: Just A. Name
           name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
   - title: Use Author rather than author`s`
@@ -31,7 +31,7 @@ cases:
         - id: Just A. Name
           name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
   - title: Using both author and author`s` shows a warning
@@ -43,7 +43,7 @@ cases:
         - id: Just A. Name
           name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
     warnings: 1
@@ -56,7 +56,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
@@ -76,7 +76,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           email: example@example.com
@@ -91,7 +91,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           email: example@example.com
@@ -108,13 +108,13 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           email: example@example.com
         - name: A. Nother Name
           nameParsed:
-            display: A. Nother Name
+            literal: A. Nother Name
             given: A. Nother
             family: Name
           email: example@example.com
@@ -130,7 +130,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           email: example@example.com
@@ -146,7 +146,7 @@ cases:
       authors:
         - name: ', Someone'
           nameParsed:
-            display: ', Someone'
+            literal: ', Someone'
             given: Someone
     warnings: 1
   - title: Warn if author has no given name
@@ -157,43 +157,43 @@ cases:
       authors:
         - name: 'Someone'
           nameParsed:
-            display: 'Someone'
+            literal: 'Someone'
             family: Someone
     warnings: 1
   - title: Parsed name is maintained
     raw:
       authors:
         - name:
-            display: Just A. Name
+            literal: Just A. Name
             given: Little
-            particle: von
+            non_dropping_particle: von
             family: Junior
             suffix: Jr.
     normalized:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Little
-            particle: von
+            non_dropping_particle: von
             family: Junior
             suffix: Jr.
   - title: Name object with lots of commas warns
     raw:
       authors:
         - name:
-            display: Commas, here, are, great,
+            literal: Commas, here, are, great,
             given: Commas,
-            particle: here,
+            non_dropping_particle: here,
             family: are,
             suffix: warnings,
     normalized:
       authors:
         - name: Commas, here, are, great,
           nameParsed:
-            display: Commas, here, are, great,
+            literal: Commas, here, are, great,
             given: Commas,
-            particle: here,
+            non_dropping_particle: here,
             family: are,
             suffix: warnings,
     warnings: 4
@@ -205,7 +205,7 @@ cases:
       authors:
         - name: A, B, C, D
           nameParsed:
-            display: A, B, C, D
+            literal: A, B, C, D
             given: D
             family: A, B
             suffix: C
@@ -214,23 +214,42 @@ cases:
     raw:
       authors:
         - name:
-            display: Just A. Name
+            literal: Just A. Name
     normalized:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
   - title: Display name expands
     raw:
       authors:
         - name:
-            display: Just A. Name
+            literal: Just A. Name
     normalized:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
+  - title: Complex name renders
+    raw:
+      authors:
+        - name:
+            given: A
+            dropping_particle: b
+            non_dropping_particle: c
+            family: D
+            suffix: E
+    normalized:
+      authors:
+        - name: c D, E, A b
+          nameParsed:
+            literal: c D, E, A b
+            given: A
+            dropping_particle: b
+            non_dropping_particle: c
+            family: D
+            suffix: E

--- a/packages/myst-frontmatter/tests/authors.yml
+++ b/packages/myst-frontmatter/tests/authors.yml
@@ -8,6 +8,10 @@ cases:
       authors:
         - id: Just A. Name
           name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
   - title: Simple Authors String
     raw:
       authors: Just A. Name
@@ -15,6 +19,10 @@ cases:
       authors:
         - id: Just A. Name
           name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
   - title: Use Author rather than author`s`
     raw:
       author: Just A. Name
@@ -22,6 +30,10 @@ cases:
       authors:
         - id: Just A. Name
           name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
   - title: Using both author and author`s` shows a warning
     raw:
       author: nope
@@ -30,15 +42,23 @@ cases:
       authors:
         - id: Just A. Name
           name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
     warnings: 1
   - title: Affiliations unpack semicolon-delimited lists
     raw:
       author:
-        name: Someone
+        name: Just A. Name
         affiliation: University; Company
     normalized:
       authors:
-        - name: Someone
+        - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           affiliations:
             - University
             - Company
@@ -50,50 +70,167 @@ cases:
   - title: First email is corresponding
     raw:
       author:
-        name: Someone
+        name: Just A. Name
         email: example@example.com
     normalized:
       authors:
-        - name: Someone
+        - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           email: example@example.com
           corresponding: true
   - title: First email is corresponding (unless false)
     raw:
       author:
-        name: Someone
+        name: Just A. Name
         email: example@example.com
         corresponding: false
     normalized:
       authors:
-        - name: Someone
+        - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           email: example@example.com
           corresponding: false
   - title: Respect corresponding flag
     raw:
       authors:
-        - name: Someone
+        - name: Just A. Name
           email: example@example.com
-        - name: Next
+        - name: A. Nother Name
           email: example@example.com
           corresponding: true
     normalized:
       authors:
-        - name: Someone
+        - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           email: example@example.com
-        - name: Next
+        - name: A. Nother Name
+          nameParsed:
+            display: A. Nother Name
+            given: A. Nother
+            family: Name
           email: example@example.com
           corresponding: true
   - title: Warn if author has no name
     raw:
       authors:
-        - name: Someone
+        - name: Just A. Name
           email: example@example.com
         - email: example@example.com
           corresponding: true
     normalized:
       authors:
-        - name: Someone
+        - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           email: example@example.com
         - email: example@example.com
           corresponding: true
     warnings: 1
+  - title: Warn if author has no family name
+    raw:
+      authors:
+        - name:
+            given: Someone
+    normalized:
+      authors:
+        - name: ', Someone'
+          nameParsed:
+            display: ', Someone'
+            given: Someone
+    warnings: 1
+  - title: Warn if author has no given name
+    raw:
+      authors:
+        - name: Someone
+    normalized:
+      authors:
+        - name: 'Someone'
+          nameParsed:
+            display: 'Someone'
+            family: Someone
+    warnings: 1
+  - title: Parsed name is maintained
+    raw:
+      authors:
+        - name:
+            display: Just A. Name
+            given: Little
+            particle: von
+            family: Junior
+            suffix: Jr.
+    normalized:
+      authors:
+        - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Little
+            particle: von
+            family: Junior
+            suffix: Jr.
+  - title: Name object with lots of commas warns
+    raw:
+      authors:
+        - name:
+            display: Commas, here, are, great,
+            given: Commas,
+            particle: here,
+            family: are,
+            suffix: warnings,
+    normalized:
+      authors:
+        - name: Commas, here, are, great,
+          nameParsed:
+            display: Commas, here, are, great,
+            given: Commas,
+            particle: here,
+            family: are,
+            suffix: warnings,
+    warnings: 4
+  - title: Name string with extra comma warns
+    raw:
+      authors:
+        - name: A, B, C, D
+    normalized:
+      authors:
+        - name: A, B, C, D
+          nameParsed:
+            display: A, B, C, D
+            given: D
+            family: A, B
+            suffix: C
+    warnings: 1
+  - title: Display name expands
+    raw:
+      authors:
+        - name:
+            display: Just A. Name
+    normalized:
+      authors:
+        - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
+  - title: Display name expands
+    raw:
+      authors:
+        - name:
+            display: Just A. Name
+    normalized:
+      authors:
+        - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name

--- a/packages/myst-frontmatter/tests/credit.yml
+++ b/packages/myst-frontmatter/tests/credit.yml
@@ -9,7 +9,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           roles:
@@ -23,7 +23,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           roles:
@@ -38,7 +38,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           roles:
@@ -52,7 +52,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           roles:

--- a/packages/myst-frontmatter/tests/credit.yml
+++ b/packages/myst-frontmatter/tests/credit.yml
@@ -8,6 +8,10 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           roles:
             - Conceptualization
   - title: String list
@@ -18,6 +22,10 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           roles:
             - Conceptualization
             - Supervision
@@ -29,6 +37,10 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           roles:
             - Writing – review & editing
   - title: Any role, but raise a warning
@@ -39,6 +51,10 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           roles:
             - Hustling for grants
     warnings: 1

--- a/packages/myst-frontmatter/tests/orcid.yml
+++ b/packages/myst-frontmatter/tests/orcid.yml
@@ -8,6 +8,10 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           orcid: 0000-0000-0000-0000
   - title: Using http
     raw:
@@ -17,6 +21,10 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
           orcid: 0000-0000-0000-000X
   - title: Not a valid ORCID
     raw:
@@ -26,4 +34,8 @@ cases:
     normalized:
       authors:
         - name: Just A. Name
+          nameParsed:
+            display: Just A. Name
+            given: Just A.
+            family: Name
     errors: 1

--- a/packages/myst-frontmatter/tests/orcid.yml
+++ b/packages/myst-frontmatter/tests/orcid.yml
@@ -9,7 +9,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           orcid: 0000-0000-0000-0000
@@ -22,7 +22,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
           orcid: 0000-0000-0000-000X
@@ -35,7 +35,7 @@ cases:
       authors:
         - name: Just A. Name
           nameParsed:
-            display: Just A. Name
+            literal: Just A. Name
             given: Just A.
             family: Name
     errors: 1


### PR DESCRIPTION
This introduces a new utility to parse `given`, `particle`, `family`, `suffix` from string name (maybe this utility should be split out into a separate library!?). The rules of this parsing attempt to follow bibtex patters as documented here: http://maverick.inria.fr/~Xavier.Decoret/resources/xdkbibtex/bibtex_summary.html#names - I had trouble finding a super-legitimate-feeling source of truth... But if we have a separate library, anyone could update it 🙂 

Anyway - on top of that, users may now specify frontmatter `name` as a string as before or as a `Name` object with the above fields, plus `display`. Then, on validation, this is normalized to `name: string` and `nameParsed: Name`. This means the display `name` is still unchanged, but libraries like `myst-to-jats` can access the structured parsed name.