### PR TITLE
Add support for glossary

### DIFF
--- a/.changeset/wise-grapes-tell.md
+++ b/.changeset/wise-grapes-tell.md
@@ -1,0 +1,8 @@
+---
+'myst-common': patch
+'myst-to-tex': patch
+'myst-cli': patch
+'jtex': patch
+---
+
+Added support for glossaries and TEX/PDF export. Now it is possible to render glossaries in TeX and PDF documents.

--- a/packages/jtex/package.json
+++ b/packages/jtex/package.json
@@ -51,6 +51,7 @@
     "myst-cli-utils": "^2.0.3",
     "myst-frontmatter": "^1.1.5",
     "myst-templates": "^1.0.8",
+    "myst-common": "^1.1.5",
     "node-fetch": "^3.3.1",
     "nunjucks": "^3.2.4",
     "pretty-hrtime": "^1.0.3",

--- a/packages/jtex/src/export.ts
+++ b/packages/jtex/src/export.ts
@@ -1,6 +1,7 @@
+import path from 'node:path';
 import type MystTemplate from 'myst-templates';
 
-export function pdfExportCommand(texFile: string, logFile: string, template?: MystTemplate) {
+export function pdfExportCommand(texFile: string, logFile: string, template?: MystTemplate): string {
   const templateYml = template?.getValidatedTemplateYml();
   const engine = templateYml?.build?.engine ?? '-xelatex';
   if (process.platform === 'win32') {
@@ -8,4 +9,9 @@ export function pdfExportCommand(texFile: string, logFile: string, template?: My
   } else {
     return `latexmk -f ${engine} -synctex=1 -interaction=batchmode -file-line-error -latexoption="-shell-escape" ${texFile} &> ${logFile}`;
   }
+}
+
+export function texMakeGlossariesCommand(texFile: string): string {
+  const fileNameNoExt = path.basename(texFile, '.tex');
+  return `makeglossaries ${fileNameNoExt}`;
 }

--- a/packages/jtex/src/export.ts
+++ b/packages/jtex/src/export.ts
@@ -1,7 +1,11 @@
 import path from 'node:path';
 import type MystTemplate from 'myst-templates';
 
-export function pdfExportCommand(texFile: string, logFile: string, template?: MystTemplate): string {
+export function pdfExportCommand(
+  texFile: string,
+  logFile: string,
+  template?: MystTemplate,
+): string {
   const templateYml = template?.getValidatedTemplateYml();
   const engine = templateYml?.build?.engine ?? '-xelatex';
   const baseCommand = `latexmk -f ${engine} -synctex=1 -interaction=batchmode -file-line-error -latexoption="-shell-escape" ${texFile}`;

--- a/packages/jtex/src/export.ts
+++ b/packages/jtex/src/export.ts
@@ -4,14 +4,20 @@ import type MystTemplate from 'myst-templates';
 export function pdfExportCommand(texFile: string, logFile: string, template?: MystTemplate): string {
   const templateYml = template?.getValidatedTemplateYml();
   const engine = templateYml?.build?.engine ?? '-xelatex';
-  if (process.platform === 'win32') {
-    return `latexmk -f ${engine} -synctex=1 -interaction=batchmode -file-line-error -latexoption="-shell-escape" ${texFile} 1> ${logFile} 2>&1`;
-  } else {
-    return `latexmk -f ${engine} -synctex=1 -interaction=batchmode -file-line-error -latexoption="-shell-escape" ${texFile} &> ${logFile}`;
-  }
+  const baseCommand = `latexmk -f ${engine} -synctex=1 -interaction=batchmode -file-line-error -latexoption="-shell-escape" ${texFile}`;
+
+  return createCommand(baseCommand, logFile);
 }
 
-export function texMakeGlossariesCommand(texFile: string): string {
+export function texMakeGlossariesCommand(texFile: string, logFile: string): string {
   const fileNameNoExt = path.basename(texFile, '.tex');
-  return `makeglossaries ${fileNameNoExt}`;
+  const baseCommand = `makeglossaries ${fileNameNoExt}`;
+
+  return createCommand(baseCommand, logFile);
+}
+
+function createCommand(baseCommand: string, logFile: string): string {
+  return process.platform === 'win32'
+    ? `${baseCommand} 1> ${logFile} 2>&1`
+    : `${baseCommand} &> ${logFile}`;
 }

--- a/packages/jtex/src/imports.ts
+++ b/packages/jtex/src/imports.ts
@@ -1,7 +1,7 @@
 import type { TemplateImports } from './types.js';
 import { writeTexLabelledComment } from 'myst-common';
 
-const commentLenth = 50;
+const commentLength = 50;
 
 export function createImportCommands(commands: Set<string>, existingPackages?: string[]): string[] {
   const sorted = [...commands].sort();
@@ -25,11 +25,11 @@ export function renderImports(
 ): string {
   if (!templateImports || typeof templateImports === 'string') return templateImports || '';
   const packages = new Set(templateImports.imports);
-  const imports = writeTexLabelledComment('imports', createImportCommands(packages, existingPackages), commentLenth);
-  const commands = writeTexLabelledComment('math commands', createMathCommands(templateImports.commands), commentLenth);
+  const imports = writeTexLabelledComment('imports', createImportCommands(packages, existingPackages), commentLength);
+  const commands = writeTexLabelledComment('math commands', createMathCommands(templateImports.commands), commentLength);
   const block = `${imports}${commands}`;
   if (!block) return '';
-  const percents = ''.padEnd(commentLenth, '%');
+  const percents = ''.padEnd(commentLength, '%');
   return `${percents}\n${block}${percents}`;
 }
 

--- a/packages/jtex/src/imports.ts
+++ b/packages/jtex/src/imports.ts
@@ -1,5 +1,5 @@
 import type { TemplateImports } from './types.js';
-import { label } from 'myst-common';
+import { writeTexLabelledComment } from 'myst-common';
 
 const commentLenth = 50;
 
@@ -25,8 +25,8 @@ export function renderImports(
 ): string {
   if (!templateImports || typeof templateImports === 'string') return templateImports || '';
   const packages = new Set(templateImports.imports);
-  const imports = label('imports', createImportCommands(packages, existingPackages), commentLenth);
-  const commands = label('math commands', createMathCommands(templateImports.commands), commentLenth);
+  const imports = writeTexLabelledComment('imports', createImportCommands(packages, existingPackages), commentLenth);
+  const commands = writeTexLabelledComment('math commands', createMathCommands(templateImports.commands), commentLenth);
   const block = `${imports}${commands}`;
   if (!block) return '';
   const percents = ''.padEnd(commentLenth, '%');

--- a/packages/jtex/src/imports.ts
+++ b/packages/jtex/src/imports.ts
@@ -1,28 +1,13 @@
-import type { GlossaryDirective, TemplateImports } from './types.js';
+import type { TemplateImports } from './types.js';
+import { label } from 'myst-common';
 
 const commentLenth = 50;
-
-function label(title: string, commands: string[]) {
-  if (!commands || commands?.length === 0) return '';
-  const len = (commentLenth - title.length - 4) / 2;
-  const start = ''.padEnd(Math.ceil(len), '%');
-  const end = ''.padEnd(Math.floor(len), '%');
-  const titleBlock = `${start}  ${title}  ${end}\n`;
-  return `${titleBlock}${commands.join('\n')}\n`;
-}
 
 export function createImportCommands(commands: Set<string>, existingPackages?: string[]): string[] {
   const sorted = [...commands].sort();
   const existingSet = new Set(existingPackages);
   const filtered = existingPackages ? sorted.filter((p) => !existingSet.has(p)) : sorted;
   return filtered.map((c) => `\\usepackage{${c}}`);
-}
-
-export function createGlossaryDirectives(directives: GlossaryDirective[]): string[] {
-  const usepackage = '\\usepackage{glossaries}';
-  const makeglossaries = '\\makeglossaries';
-  const entries = directives.map((entry) => `\\newglossaryentry{${entry.key}}{name=${entry.name},description={${entry.description}}}`);
-  return [usepackage, makeglossaries].concat(entries);
 }
 
 export function createMathCommands(plugins: Record<string, string>): string[] {
@@ -34,29 +19,14 @@ export function createMathCommands(plugins: Record<string, string>): string[] {
   });
 }
 
-export function renderGlossaryImports(directives?: GlossaryDirective[]): string {
-  if (!directives) return '';
-  const block = label('glossary', createGlossaryDirectives(directives));
-  if (!block) return '';
-  const percents = ''.padEnd(commentLenth, '%');
-  return `${percents}\n${block}${percents}`;
-}
-
-export function renderGlossary(directives?: GlossaryDirective[]): string {
-  if (!directives) return '';
-  const block = label('glossary', ['\\printglossaries']);
-  const percents = ''.padEnd(commentLenth, '%');
-  return `${percents}\n${block}${percents}`;
-}
-
 export function renderImports(
   templateImports?: string | TemplateImports,
   existingPackages?: string[],
 ): string {
   if (!templateImports || typeof templateImports === 'string') return templateImports || '';
   const packages = new Set(templateImports.imports);
-  const imports = label('imports', createImportCommands(packages, existingPackages));
-  const commands = label('math commands', createMathCommands(templateImports.commands));
+  const imports = label('imports', createImportCommands(packages, existingPackages), commentLenth);
+  const commands = label('math commands', createMathCommands(templateImports.commands), commentLenth);
   const block = `${imports}${commands}`;
   if (!block) return '';
   const percents = ''.padEnd(commentLenth, '%');

--- a/packages/jtex/src/imports.ts
+++ b/packages/jtex/src/imports.ts
@@ -1,4 +1,4 @@
-import type { TemplateImports } from './types.js';
+import type { GlossaryDirective, TemplateImports } from './types.js';
 
 const commentLenth = 50;
 
@@ -11,11 +11,18 @@ function label(title: string, commands: string[]) {
   return `${titleBlock}${commands.join('\n')}\n`;
 }
 
-export function createImportCommands(commands: Set<string>, existingPackages?: string[]) {
+export function createImportCommands(commands: Set<string>, existingPackages?: string[]): string[] {
   const sorted = [...commands].sort();
   const existingSet = new Set(existingPackages);
   const filtered = existingPackages ? sorted.filter((p) => !existingSet.has(p)) : sorted;
   return filtered.map((c) => `\\usepackage{${c}}`);
+}
+
+export function createGlossaryDirectives(directives: GlossaryDirective[]): string[] {
+  const usepackage = '\\usepackage{glossaries}';
+  const makeglossaries = '\\makeglossaries';
+  const entries = directives.map((entry) => `\\newglossaryentry{${entry.key}}{name=${entry.name},description={${entry.description}}}`);
+  return [usepackage, makeglossaries].concat(entries);
 }
 
 export function createMathCommands(plugins: Record<string, string>): string[] {
@@ -25,6 +32,21 @@ export function createMathCommands(plugins: Record<string, string>): string[] {
     if (numArgs === 0) return `\\newcommand{${k}}{${v}}`;
     return `\\newcommand{${k}}[${numArgs}]{${v}}`;
   });
+}
+
+export function renderGlossaryImports(directives?: GlossaryDirective[]): string {
+  if (!directives) return '';
+  const block = label('glossary', createGlossaryDirectives(directives));
+  if (!block) return '';
+  const percents = ''.padEnd(commentLenth, '%');
+  return `${percents}\n${block}${percents}`;
+}
+
+export function renderGlossary(directives?: GlossaryDirective[]): string {
+  if (!directives) return '';
+  const block = label('glossary', ['\\printglossaries']);
+  const percents = ''.padEnd(commentLenth, '%');
+  return `${percents}\n${block}${percents}`;
 }
 
 export function renderImports(

--- a/packages/jtex/src/imports.ts
+++ b/packages/jtex/src/imports.ts
@@ -25,8 +25,16 @@ export function renderImports(
 ): string {
   if (!templateImports || typeof templateImports === 'string') return templateImports || '';
   const packages = new Set(templateImports.imports);
-  const imports = writeTexLabelledComment('imports', createImportCommands(packages, existingPackages), commentLength);
-  const commands = writeTexLabelledComment('math commands', createMathCommands(templateImports.commands), commentLength);
+  const imports = writeTexLabelledComment(
+    'imports',
+    createImportCommands(packages, existingPackages),
+    commentLength,
+  );
+  const commands = writeTexLabelledComment(
+    'math commands',
+    createMathCommands(templateImports.commands),
+    commentLength,
+  );
   const block = `${imports}${commands}`;
   if (!block) return '';
   const percents = ''.padEnd(commentLength, '%');

--- a/packages/jtex/src/jtex.ts
+++ b/packages/jtex/src/jtex.ts
@@ -58,7 +58,6 @@ export function renderTex(
   }
   const { options, parts, doc } = template.prepare(opts);
   let importsContent = renderImports(opts.imports, opts.packages);
-  // Glossary should always be at the end of the page
   importsContent += '\n' + opts.glossaryPreamble;
   const renderer: TexRenderer = {
     CONTENT: content,

--- a/packages/jtex/src/jtex.ts
+++ b/packages/jtex/src/jtex.ts
@@ -58,7 +58,7 @@ export function renderTex(
   }
   const { options, parts, doc } = template.prepare(opts);
   let importsContent = renderImports(opts.imports, opts.packages);
-  importsContent += '\n' + opts.glossaryPreamble;
+  importsContent += '\n' + (opts.glossaryPreamble || '');
   const renderer: TexRenderer = {
     CONTENT: content,
     doc,

--- a/packages/jtex/src/jtex.ts
+++ b/packages/jtex/src/jtex.ts
@@ -3,8 +3,8 @@ import { extname, dirname } from 'node:path';
 import type MystTemplate from 'myst-templates';
 import { TEMPLATE_FILENAME } from 'myst-templates';
 import nunjucks from 'nunjucks';
-import { renderGlossary, renderGlossaryImports, renderImports } from './imports.js';
-import type { TexRenderer, TemplateImports, GlossaryDirective } from './types.js';
+import { renderImports } from './imports.js';
+import type { TexRenderer, TemplateImports } from './types.js';
 import version from './version.js';
 
 function ensureDirectoryExists(directory: string) {
@@ -40,7 +40,7 @@ export function renderTex(
     bibliography?: string[];
     sourceFile?: string;
     imports?: string | TemplateImports;
-    glossary?: GlossaryDirective[];
+    glossaryPreamble?: string;
     force?: boolean;
     packages?: string[];
     filesPath?: string;
@@ -57,17 +57,15 @@ export function renderTex(
     content = opts.contentOrPath;
   }
   const { options, parts, doc } = template.prepare(opts);
-  const allImports = [
-    renderImports(opts.imports, opts.packages),
-    renderGlossaryImports(opts.glossary),
-  ].join('');
-  content += renderGlossary(opts.glossary);
+  let importsContent = renderImports(opts.imports, opts.packages);
+  // Glossary should always be at the end of the page
+  importsContent += '\n' + opts.glossaryPreamble;
   const renderer: TexRenderer = {
     CONTENT: content,
     doc,
     parts,
     options,
-    IMPORTS: allImports,
+    IMPORTS: importsContent,
   };
   const env = getDefaultEnv(template);
   const rendered = env.render(TEMPLATE_FILENAME, renderer);

--- a/packages/jtex/src/jtex.ts
+++ b/packages/jtex/src/jtex.ts
@@ -58,7 +58,7 @@ export function renderTex(
   }
   const { options, parts, doc } = template.prepare(opts);
   let importsContent = renderImports(opts.imports, opts.packages);
-  importsContent += '\n' + (opts.glossaryPreamble || '');
+  importsContent += opts.glossaryPreamble ? '\n' + opts.glossaryPreamble : '';
   const renderer: TexRenderer = {
     CONTENT: content,
     doc,

--- a/packages/jtex/src/jtex.ts
+++ b/packages/jtex/src/jtex.ts
@@ -63,7 +63,7 @@ export function renderTex(
   ].join('');
   content += renderGlossary(opts.glossary);
   const renderer: TexRenderer = {
-    CONTENT: content, // TODO: Add the print glossary
+    CONTENT: content,
     doc,
     parts,
     options,

--- a/packages/jtex/src/types.ts
+++ b/packages/jtex/src/types.ts
@@ -1,5 +1,11 @@
 import type { RendererDoc } from 'myst-templates';
 
+export type GlossaryDirective = {
+  key: string;
+  name: string;
+  description: string;
+};
+
 export type TemplateImports = {
   imports: string[];
   commands: Record<string, string>;

--- a/packages/jtex/src/types.ts
+++ b/packages/jtex/src/types.ts
@@ -1,11 +1,5 @@
 import type { RendererDoc } from 'myst-templates';
 
-export type GlossaryDirective = {
-  key: string;
-  name: string;
-  description: string;
-};
-
 export type TemplateImports = {
   imports: string[];
   commands: Record<string, string>;

--- a/packages/myst-cli/src/build/pdf/create.ts
+++ b/packages/myst-cli/src/build/pdf/create.ts
@@ -302,7 +302,7 @@ async function runGlossariesBuildCommand(
 
   let buildError = false;
   try {
-    session.log.info(`🔖  Creating glossaries in ${buildPath}`);
+    session.log.info(`🔖 Creating glossaries in ${buildPath}`);
     session.log.debug(`Running command:\n> ${buildCommand}`);
     await exec(buildCommand, { cwd: buildPath });
     session.log.debug(`Done building glossaries.`);

--- a/packages/myst-cli/src/build/pdf/create.ts
+++ b/packages/myst-cli/src/build/pdf/create.ts
@@ -60,7 +60,7 @@ export async function createPdfGivenTexExport(
     logOutput,
     texLogOutput,
   } = ensurePaths(session, texOutput, pdfOutput);
-  
+
   if (clean) cleanOutput(session, logOutputFolder);
 
   const { buildError, toc } = await runCommands(
@@ -156,7 +156,7 @@ export async function createPdfGivenTexExport(
     (err as any).logFiles = logFiles;
     throw err;
   }
-  
+
   return { logFiles, tempFolders: [buildPath] };
 }
 
@@ -208,7 +208,15 @@ async function runCommands(
   glossaries?: boolean,
 ) {
   const toc = tic();
-  let buildError = await runPdfBuildCommand(session, texFile, texLogFile, templateLogString, template, pdfBuild, buildPath);
+  let buildError = await runPdfBuildCommand(
+    session,
+    texFile,
+    texLogFile,
+    templateLogString,
+    template,
+    pdfBuild,
+    buildPath,
+  );
 
   if (buildError || !glossaries) {
     return { buildError, toc };
@@ -221,7 +229,15 @@ async function runCommands(
     return { buildError, toc };
   }
 
-  buildError = await runPdfBuildCommand(session, texFile, texLogFile, templateLogString, template, pdfBuild, buildPath);
+  buildError = await runPdfBuildCommand(
+    session,
+    texFile,
+    texLogFile,
+    templateLogString,
+    template,
+    pdfBuild,
+    buildPath,
+  );
 
   return { buildError, toc };
 }
@@ -270,11 +286,7 @@ async function runPdfBuildCommand(
   return buildError;
 }
 
-async function runGlossariesBuildCommand(
-  session: ISession,
-  texFile: string,
-  buildPath: string,
-) {
+async function runGlossariesBuildCommand(session: ISession, texFile: string, buildPath: string) {
   if (!isMakeglossariesAvailable()) {
     session.log.error(
       `⚠️  The "makeglossaries" command is not available. See documentation on installing LaTeX:\n\n${docLinks.installLatex}`,
@@ -291,9 +303,7 @@ async function runGlossariesBuildCommand(
     session.log.debug(`Done building glossaries.`);
   } catch (err) {
     session.log.debug((err as Error).stack);
-    session.log.error(
-      `🛑 Command makeglossaries reported an error for ${texFile}`,
-    );
+    session.log.error(`🛑 Command makeglossaries reported an error for ${texFile}`);
     buildError = true;
   }
 

--- a/packages/myst-cli/src/build/pdf/create.ts
+++ b/packages/myst-cli/src/build/pdf/create.ts
@@ -223,7 +223,7 @@ async function runCommands(
   }
 
   // Glossaries require two more commands to be run
-  buildError = await runGlossariesBuildCommand(session, texFile, buildPath);
+  buildError = await runGlossariesBuildCommand(session, texFile, texLogFile, buildPath);
 
   if (buildError) {
     return { buildError, toc };
@@ -286,14 +286,19 @@ async function runPdfBuildCommand(
   return buildError;
 }
 
-async function runGlossariesBuildCommand(session: ISession, texFile: string, buildPath: string) {
+async function runGlossariesBuildCommand(
+  session: ISession,
+  texFile: string,
+  texLogFile: string,
+  buildPath: string,
+) {
   if (!isMakeglossariesAvailable()) {
     session.log.error(
       `⚠️  The "makeglossaries" command is not available. See documentation on installing LaTeX:\n\n${docLinks.installLatex}`,
     );
   }
 
-  const buildCommand = texMakeGlossariesCommand(texFile);
+  const buildCommand = texMakeGlossariesCommand(texFile, texLogFile);
 
   let buildError = false;
   try {

--- a/packages/myst-cli/src/build/pdf/create.ts
+++ b/packages/myst-cli/src/build/pdf/create.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import util from 'util';
-import { pdfExportCommand } from 'jtex';
+import { pdfExportCommand, texMakeGlossariesCommand } from 'jtex';
 import { exec, tic } from 'myst-cli-utils';
 import MystTemplate from 'myst-templates';
 import type { ISession } from '../../session/types.js';
@@ -10,7 +10,7 @@ import type { ExportResults, ExportWithOutput } from '../types.js';
 import { cleanOutput } from '../utils/cleanOutput.js';
 import { TemplateKind } from 'myst-common';
 import chalk from 'chalk';
-import { isLatexmkAvailable } from './utils.js';
+import { isLatexmkAvailable, isMakeglossariesAvailable } from './utils.js';
 import { docLinks } from '../../docs.js';
 
 const copyFile = util.promisify(fs.copyFile);
@@ -44,67 +44,35 @@ export async function createPdfGivenTexExport(
   pdfOutput: string,
   copyLogs?: boolean,
   clean?: boolean,
+  glossaries?: boolean,
 ): Promise<ExportResults> {
   if (clean) cleanOutput(session, pdfOutput);
   const { output: texOutput, template } = texExportOptions;
-
   const templateLogString = `(${template ?? 'default'})`;
-
-  const buildPath = createTempFolder(session);
-  const texFile = path.basename(texOutput);
-  const texBuild = path.join(buildPath, texFile);
-  copyContents(path.dirname(texOutput), buildPath);
-
-  if (!fs.existsSync(texBuild)) {
-    throw Error(`Error exporting: ${pdfOutput}\nCould not find tex file: ${texOutput}`);
-  }
-
-  const pdfBasename = path.basename(pdfOutput, path.extname(pdfOutput));
-  const pdfFile = `${pdfBasename}.pdf`;
-  const pdfBuild = path.join(buildPath, pdfFile);
-
-  const logFile = `${pdfBasename}.log`;
-  const texLogFile = `${pdfBasename}.shell.log`;
-  // Temporary log file locations
-  const logBuild = path.join(buildPath, logFile);
-  const texLogBuild = path.join(buildPath, texLogFile);
-  // Log file location saved alongside pdf
-  const logOutputFolder = getLogOutputFolder(pdfOutput);
-  const logOutput = path.join(logOutputFolder, logFile);
-  const texLogOutput = path.join(logOutputFolder, texLogFile);
+  const {
+    buildPath,
+    texFile,
+    texLogFile,
+    pdfBuild,
+    logBuild,
+    texLogBuild,
+    logOutputFolder,
+    logOutput,
+    texLogOutput,
+  } = ensurePaths(session, texOutput, pdfOutput);
+  
   if (clean) cleanOutput(session, logOutputFolder);
 
-  if (!isLatexmkAvailable()) {
-    session.log.error(
-      `⚠️  The "latexmk" command is not available. See documentation on installing LaTeX:\n\n${docLinks.installLatex}`,
-    );
-  }
-
-  let buildCommand: string;
-  if (!template) {
-    buildCommand = pdfExportCommand(texFile, texLogFile);
-  } else {
-    const mystTemplate = new MystTemplate(session, {
-      kind: TemplateKind.tex,
-      template: template || undefined,
-      buildDir: session.buildPath(),
-    });
-    buildCommand = pdfExportCommand(texFile, texLogFile, mystTemplate);
-  }
-  const toc = tic();
-  let buildError = false;
-  try {
-    session.log.info(`🖨  Rendering PDF ${templateLogString} to ${pdfBuild}`);
-    session.log.debug(`Running command:\n> ${buildCommand}`);
-    await exec(buildCommand, { cwd: buildPath });
-    session.log.debug(`Done building LaTeX.`);
-  } catch (err) {
-    session.log.debug((err as Error).stack);
-    session.log.error(
-      `🛑 LaTeX reported an error building your PDF ${templateLogString} for ${texFile}`,
-    );
-    buildError = true;
-  }
+  const { buildError, toc } = await runCommands(
+    session,
+    template,
+    texFile,
+    texLogFile,
+    templateLogString,
+    pdfBuild,
+    buildPath,
+    glossaries,
+  );
 
   const logs = uniqueArray(
     fs
@@ -123,10 +91,12 @@ export async function createPdfGivenTexExport(
     .filter((sty) => !!sty)
     .map((p) => `${p}.sty`);
   session.log.debug(`Unknown style files: "${packageErrors.join('", "')}"`);
+
   // Here we could search for packages and install:
   // const packages = await Promise.all(
   //   packageErrors.map((sty) => searchForPackage(session, sty, { cwd: buildPath })),
   // );
+
   if (logs.length > 0) {
     if (buildError) {
       if (fs.existsSync(pdfBuild)) {
@@ -164,6 +134,7 @@ export async function createPdfGivenTexExport(
   } else {
     session.log.error(`Could not find ${pdfBuild} as expected`);
   }
+
   if (copyLogs) {
     if ((logBuildExists || texLogBuildExists) && !fs.existsSync(path.dirname(logOutput))) {
       fs.mkdirSync(path.dirname(logOutput), { recursive: true });
@@ -178,11 +149,153 @@ export async function createPdfGivenTexExport(
       await copyFile(texLogBuild, texLogOutput);
     }
   }
+
   const logFiles = copyLogs ? [logOutput, texLogOutput] : [logBuild, texLogBuild];
   if (!fs.existsSync(pdfOutput)) {
     const err = Error(`Error exporting: ${pdfOutput}`);
     (err as any).logFiles = logFiles;
     throw err;
   }
+  
   return { logFiles, tempFolders: [buildPath] };
+}
+
+function ensurePaths(session: ISession, texOutput: string, pdfOutput: string) {
+  const buildPath = createTempFolder(session);
+  const texFile = path.basename(texOutput);
+  const texBuild = path.join(buildPath, texFile);
+  copyContents(path.dirname(texOutput), buildPath);
+
+  if (!fs.existsSync(texBuild)) {
+    throw Error(`Error exporting: ${pdfOutput}\nCould not find tex file: ${texOutput}`);
+  }
+
+  const pdfBasename = path.basename(pdfOutput, path.extname(pdfOutput));
+  const pdfFile = `${pdfBasename}.pdf`;
+  const pdfBuild = path.join(buildPath, pdfFile);
+
+  const logFile = `${pdfBasename}.log`;
+  const texLogFile = `${pdfBasename}.shell.log`;
+  // Temporary log file locations
+  const logBuild = path.join(buildPath, logFile);
+  const texLogBuild = path.join(buildPath, texLogFile);
+  // Log file location saved alongside pdf
+  const logOutputFolder = getLogOutputFolder(pdfOutput);
+  const logOutput = path.join(logOutputFolder, logFile);
+  const texLogOutput = path.join(logOutputFolder, texLogFile);
+
+  return {
+    buildPath,
+    texFile,
+    texLogFile,
+    pdfBuild,
+    logBuild,
+    texLogBuild,
+    logOutputFolder,
+    logOutput,
+    texLogOutput,
+  };
+}
+
+async function runCommands(
+  session: ISession,
+  template: string | null | undefined,
+  texFile: string,
+  texLogFile: string,
+  templateLogString: string,
+  pdfBuild: string,
+  buildPath: string,
+  glossaries?: boolean,
+) {
+  const toc = tic();
+  let buildError = await runPdfBuildCommand(session, texFile, texLogFile, templateLogString, template, pdfBuild, buildPath);
+
+  if (buildError || !glossaries) {
+    return { buildError, toc };
+  }
+
+  // Glossaries require two more commands to be run
+  buildError = await runGlossariesBuildCommand(session, texFile, buildPath);
+
+  if (buildError) {
+    return { buildError, toc };
+  }
+
+  buildError = await runPdfBuildCommand(session, texFile, texLogFile, templateLogString, template, pdfBuild, buildPath);
+
+  return { buildError, toc };
+}
+
+async function runPdfBuildCommand(
+  session: ISession,
+  texFile: string,
+  texLogFile: string,
+  templateLogString: string,
+  template: string | null | undefined,
+  pdfBuild: string,
+  buildPath: string,
+) {
+  if (!isLatexmkAvailable()) {
+    session.log.error(
+      `⚠️  The "latexmk" command is not available. See documentation on installing LaTeX:\n\n${docLinks.installLatex}`,
+    );
+  }
+
+  let buildCommand: string;
+  if (!template) {
+    buildCommand = pdfExportCommand(texFile, texLogFile);
+  } else {
+    const mystTemplate = new MystTemplate(session, {
+      kind: TemplateKind.tex,
+      template: template || undefined,
+      buildDir: session.buildPath(),
+    });
+    buildCommand = pdfExportCommand(texFile, texLogFile, mystTemplate);
+  }
+
+  let buildError = false;
+  try {
+    session.log.info(`🖨  Rendering PDF ${templateLogString} to ${pdfBuild}`);
+    session.log.debug(`Running command:\n> ${buildCommand}`);
+    await exec(buildCommand, { cwd: buildPath });
+    session.log.debug(`Done building LaTeX.`);
+  } catch (err) {
+    session.log.debug((err as Error).stack);
+    session.log.error(
+      `🛑 LaTeX reported an error building your PDF ${templateLogString} for ${texFile}`,
+    );
+    buildError = true;
+  }
+
+  return buildError;
+}
+
+async function runGlossariesBuildCommand(
+  session: ISession,
+  texFile: string,
+  buildPath: string,
+) {
+  if (!isMakeglossariesAvailable()) {
+    session.log.error(
+      `⚠️  The "makeglossaries" command is not available. See documentation on installing LaTeX:\n\n${docLinks.installLatex}`,
+    );
+  }
+
+  const buildCommand = texMakeGlossariesCommand(texFile);
+
+  let buildError = false;
+  try {
+    session.log.info(`🔖  Creating glossaries in ${buildPath}`);
+    session.log.debug(`Running command:\n> ${buildCommand}`);
+    await exec(buildCommand, { cwd: buildPath });
+    session.log.debug(`Done building glossaries.`);
+  } catch (err) {
+    session.log.debug((err as Error).stack);
+    session.log.error(
+      `🛑 Command makeglossaries reported an error for ${texFile}`,
+    );
+    buildError = true;
+  }
+
+  return buildError;
 }

--- a/packages/myst-cli/src/build/pdf/utils.ts
+++ b/packages/myst-cli/src/build/pdf/utils.ts
@@ -6,6 +6,10 @@ export function isLatexmkAvailable() {
   return which.sync('latexmk', { nothrow: true });
 }
 
+export function isMakeglossariesAvailable() {
+  return which.sync('makeglossaries', { nothrow: true });
+}
+
 export function isTlmgrAvailable() {
   return which.sync('tlmgr', { nothrow: true });
 }

--- a/packages/myst-cli/src/build/tex/single.spec.ts
+++ b/packages/myst-cli/src/build/tex/single.spec.ts
@@ -42,6 +42,7 @@ describe('extractPart', () => {
         value: 'tagged content\n\nalso tagged content',
         imports: [],
         commands: {},
+        glossaryPreamble: "",
       },
     );
     expect(tree).toEqual({
@@ -79,6 +80,7 @@ describe('extractPart', () => {
       value: 'tagged content',
       imports: [],
       commands: {},
+      glossaryPreamble: "",
     });
   });
   it('exceeding max chars passes', async () => {
@@ -98,6 +100,7 @@ describe('extractPart', () => {
       value: 'tagged content',
       imports: [],
       commands: {},
+      glossaryPreamble: "",
     });
   });
   it('exceeding max words passes', async () => {
@@ -117,6 +120,7 @@ describe('extractPart', () => {
       value: 'tagged content',
       imports: [],
       commands: {},
+      glossaryPreamble: "",
     });
   });
 });

--- a/packages/myst-cli/src/build/tex/single.spec.ts
+++ b/packages/myst-cli/src/build/tex/single.spec.ts
@@ -42,7 +42,7 @@ describe('extractPart', () => {
         value: 'tagged content\n\nalso tagged content',
         imports: [],
         commands: {},
-        glossaryPreamble: "",
+        glossaryPreamble: '',
       },
     );
     expect(tree).toEqual({
@@ -80,7 +80,7 @@ describe('extractPart', () => {
       value: 'tagged content',
       imports: [],
       commands: {},
-      glossaryPreamble: "",
+      glossaryPreamble: '',
     });
   });
   it('exceeding max chars passes', async () => {
@@ -100,7 +100,7 @@ describe('extractPart', () => {
       value: 'tagged content',
       imports: [],
       commands: {},
-      glossaryPreamble: "",
+      glossaryPreamble: '',
     });
   });
   it('exceeding max words passes', async () => {
@@ -120,7 +120,7 @@ describe('extractPart', () => {
       value: 'tagged content',
       imports: [],
       commands: {},
-      glossaryPreamble: "",
+      glossaryPreamble: '',
     });
   });
 });

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -26,6 +26,7 @@ import {
   getFileContent,
   resolveAndLogErrors,
 } from '../utils/index.js';
+import { select } from 'unist-util-select';
 
 export const DEFAULT_BIB_FILENAME = 'main.bib';
 const TEX_IMAGE_EXTENSIONS = [
@@ -164,6 +165,7 @@ export async function localArticleToTexTemplated(
   // This probably means we need to store tags alongside oxa link for blocks
   // This will need opts eventually --v
   const result = mdastToTex(session, mdast, references, frontmatter, templateYml);
+  console.log("HAS GLOSSARY?", hasGlossary(mdast)); // DBG
   // Fill in template
   session.log.info(toc(`📑 Exported TeX in %s, copying to ${templateOptions.output}`));
   renderTex(mystTemplate, {
@@ -180,10 +182,10 @@ export async function localArticleToTexTemplated(
     packages: templateYml.packages,
     filesPath,
   });
-  return { tempFolders: [] };
+  return { tempFolders: [], hasGlossaries: hasGlossary(mdast) };
 }
 
-export async function runTexExport(
+export async function runTexExport( // DBG: Must return an info on whether glossaries are present
   session: ISession,
   file: string,
   exportOptions: ExportWithOutput,
@@ -275,4 +277,9 @@ export async function localArticleToTex(
     opts.throwOnFailure,
   );
   return results;
+}
+
+function hasGlossary(mdast: GenericParent): boolean {
+  const glossary = select('glossary', mdast);
+  return glossary !== null;
 }

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -179,7 +179,7 @@ export async function localArticleToTexTemplated(
     bibliography: [DEFAULT_BIB_FILENAME],
     sourceFile: file,
     imports: mergeTemplateImports(collectedImports, result),
-    glossary: result.glossary,
+    glossaryPreamble: result.glossaryPreamble,
     force,
     packages: templateYml.packages,
     filesPath,

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -165,7 +165,6 @@ export async function localArticleToTexTemplated(
   // This probably means we need to store tags alongside oxa link for blocks
   // This will need opts eventually --v
   const result = mdastToTex(session, mdast, references, frontmatter, templateYml);
-  console.log("HAS GLOSSARY?", hasGlossary(mdast)); // DBG
   // Fill in template
   session.log.info(toc(`📑 Exported TeX in %s, copying to ${templateOptions.output}`));
   renderTex(mystTemplate, {

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -175,6 +175,7 @@ export async function localArticleToTexTemplated(
     bibliography: [DEFAULT_BIB_FILENAME],
     sourceFile: file,
     imports: mergeTemplateImports(collectedImports, result),
+    glossary: result.glossary,
     force,
     packages: templateYml.packages,
     filesPath,

--- a/packages/myst-cli/src/build/types.ts
+++ b/packages/myst-cli/src/build/types.ts
@@ -21,6 +21,7 @@ export type ExportOptions = {
   disableTemplate?: boolean;
   templateOptions?: Record<string, any>;
   clean?: boolean;
+  glossaries?: boolean;
   zip?: boolean;
   force?: boolean;
   projectPath?: string;
@@ -38,4 +39,5 @@ export type ExportOptions = {
 export type ExportResults = {
   logFiles?: string[];
   tempFolders: string[];
+  hasGlossaries?: boolean;
 };

--- a/packages/myst-cli/src/build/utils/localArticleExport.ts
+++ b/packages/myst-cli/src/build/utils/localArticleExport.ts
@@ -18,7 +18,7 @@ async function _localArticleExport(
   exportOptionsList: ExportWithInputOutput[],
   opts: Pick<ExportOptions, 'clean' | 'projectPath' | 'throwOnFailure' | 'glossaries'>,
 ) {
-  const { clean, projectPath, glossaries } = opts;
+  const { clean, projectPath } = opts;
   const errors = await resolveAndLogErrors(
     session,
     exportOptionsList.map(async (exportOptionsWithFile) => {
@@ -29,19 +29,37 @@ async function _localArticleExport(
         projectPath ??
         $project ??
         (await findCurrentProjectAndLoad(sessionClone, path.dirname($file)));
-      
+
       let exportResults: ExportResults | undefined;
       if (fileProjectPath) {
         await loadProjectFromDisk(sessionClone, fileProjectPath);
       }
       if (format === ExportFormats.tex) {
         if (path.extname(output) === '.zip') {
-          exportResults = await runTexZipExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
+          exportResults = await runTexZipExport(
+            sessionClone,
+            $file,
+            exportOptions,
+            fileProjectPath,
+            clean,
+          );
         } else {
-          exportResults = await runTexExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
+          exportResults = await runTexExport(
+            sessionClone,
+            $file,
+            exportOptions,
+            fileProjectPath,
+            clean,
+          );
         }
       } else if (format === ExportFormats.docx) {
-        exportResults = await runWordExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
+        exportResults = await runWordExport(
+          sessionClone,
+          $file,
+          exportOptions,
+          fileProjectPath,
+          clean,
+        );
       } else if (format === ExportFormats.xml) {
         await runJatsExport(sessionClone, exportOptions, fileProjectPath, clean);
       } else if (format === ExportFormats.md) {
@@ -56,7 +74,13 @@ async function _localArticleExport(
           keepTexAndLogs,
           clean,
         );
-        exportResults = await runTexExport(sessionClone, $file, texExportOptions, fileProjectPath, clean);
+        exportResults = await runTexExport(
+          sessionClone,
+          $file,
+          texExportOptions,
+          fileProjectPath,
+          clean,
+        );
         await createPdfGivenTexExport(
           sessionClone,
           texExportOptions,

--- a/packages/myst-cli/src/build/utils/localArticleExport.ts
+++ b/packages/myst-cli/src/build/utils/localArticleExport.ts
@@ -3,7 +3,7 @@ import { ExportFormats } from 'myst-frontmatter';
 import { findCurrentProjectAndLoad } from '../../config.js';
 import { loadProjectFromDisk } from '../../project/index.js';
 import type { ISession } from '../../session/index.js';
-import type { ExportOptions, ExportWithInputOutput } from '../types.js';
+import type { ExportOptions, ExportResults, ExportWithInputOutput } from '../types.js';
 import { resolveAndLogErrors } from './resolveAndLogErrors.js';
 import { runTexZipExport, runTexExport } from '../tex/single.js';
 import { runWordExport } from '../docx/single.js';
@@ -16,9 +16,9 @@ import { runMdExport } from '../md/index.js';
 async function _localArticleExport(
   session: ISession,
   exportOptionsList: ExportWithInputOutput[],
-  opts: Pick<ExportOptions, 'clean' | 'projectPath' | 'throwOnFailure'>,
+  opts: Pick<ExportOptions, 'clean' | 'projectPath' | 'throwOnFailure' | 'glossaries'>,
 ) {
-  const { clean, projectPath } = opts;
+  const { clean, projectPath, glossaries } = opts;
   const errors = await resolveAndLogErrors(
     session,
     exportOptionsList.map(async (exportOptionsWithFile) => {
@@ -29,17 +29,19 @@ async function _localArticleExport(
         projectPath ??
         $project ??
         (await findCurrentProjectAndLoad(sessionClone, path.dirname($file)));
+      
+      let exportResults: ExportResults | undefined;
       if (fileProjectPath) {
         await loadProjectFromDisk(sessionClone, fileProjectPath);
       }
       if (format === ExportFormats.tex) {
         if (path.extname(output) === '.zip') {
-          await runTexZipExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
+          exportResults = await runTexZipExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
         } else {
-          await runTexExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
+          exportResults = await runTexExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
         }
       } else if (format === ExportFormats.docx) {
-        await runWordExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
+        exportResults = await runWordExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
       } else if (format === ExportFormats.xml) {
         await runJatsExport(sessionClone, exportOptions, fileProjectPath, clean);
       } else if (format === ExportFormats.md) {
@@ -54,13 +56,14 @@ async function _localArticleExport(
           keepTexAndLogs,
           clean,
         );
-        await runTexExport(sessionClone, $file, texExportOptions, fileProjectPath, clean);
+        exportResults = await runTexExport(sessionClone, $file, texExportOptions, fileProjectPath, clean);
         await createPdfGivenTexExport(
           sessionClone,
           texExportOptions,
           output,
           keepTexAndLogs,
           clean,
+          exportResults.hasGlossaries,
         );
       }
     }),

--- a/packages/myst-common/src/index.ts
+++ b/packages/myst-common/src/index.ts
@@ -11,6 +11,7 @@ export {
   setTextAsChild,
   copyNode,
   mergeTextNodes,
+  label,
 } from './utils.js';
 export { selectBlockParts, extractPart } from './extractParts.js';
 export { TemplateKind, TemplateOptionType } from './templates.js';

--- a/packages/myst-common/src/index.ts
+++ b/packages/myst-common/src/index.ts
@@ -11,7 +11,7 @@ export {
   setTextAsChild,
   copyNode,
   mergeTextNodes,
-  label,
+  writeTexLabelledComment,
 } from './utils.js';
 export { selectBlockParts, extractPart } from './extractParts.js';
 export { TemplateKind, TemplateOptionType } from './templates.js';

--- a/packages/myst-common/src/utils.ts
+++ b/packages/myst-common/src/utils.ts
@@ -146,3 +146,12 @@ export function admonitionKindToTitle(kind: AdmonitionKind | string) {
   };
   return transform[kind] || `Unknown Admonition "${kind}"`;
 }
+
+export function label(title: string, commands: string[], commentLenth: number) {
+  if (!commands || commands?.length === 0) return '';
+  const len = (commentLenth - title.length - 4) / 2;
+  const start = ''.padEnd(Math.ceil(len), '%');
+  const end = ''.padEnd(Math.floor(len), '%');
+  const titleBlock = `${start}  ${title}  ${end}\n`;
+  return `${titleBlock}${commands.join('\n')}\n`;
+}

--- a/packages/myst-common/src/utils.ts
+++ b/packages/myst-common/src/utils.ts
@@ -58,7 +58,7 @@ export function normalizeLabel(
     .trim()
     .toLowerCase();
   const html_id = createHtmlId(identifier) as string;
-  return { identifier, label, html_id };
+  return { identifier, label: label, html_id };
 }
 
 export function createHtmlId(identifier?: string): string | undefined {
@@ -147,7 +147,7 @@ export function admonitionKindToTitle(kind: AdmonitionKind | string) {
   return transform[kind] || `Unknown Admonition "${kind}"`;
 }
 
-export function label(title: string, commands: string[], commentLenth: number) {
+export function writeTexLabelledComment(title: string, commands: string[], commentLenth: number) {
   if (!commands || commands?.length === 0) return '';
   const len = (commentLenth - title.length - 4) / 2;
   const start = ''.padEnd(Math.ceil(len), '%');

--- a/packages/myst-common/src/utils.ts
+++ b/packages/myst-common/src/utils.ts
@@ -147,9 +147,9 @@ export function admonitionKindToTitle(kind: AdmonitionKind | string) {
   return transform[kind] || `Unknown Admonition "${kind}"`;
 }
 
-export function writeTexLabelledComment(title: string, commands: string[], commentLenth: number) {
+export function writeTexLabelledComment(title: string, commands: string[], commentLength: number) {
   if (!commands || commands?.length === 0) return '';
-  const len = (commentLenth - title.length - 4) / 2;
+  const len = (commentLength - title.length - 4) / 2;
   const start = ''.padEnd(Math.ceil(len), '%');
   const end = ''.padEnd(Math.floor(len), '%');
   const titleBlock = `${start}  ${title}  ${end}\n`;

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -176,6 +176,11 @@ const handlers: Record<string, Handler> = {
     // https://www.overleaf.com/learn/latex/glossaries
     state.renderChildren(node, true);
   },
+  glossary(node, state) {
+    state.usePackages('glossaries');
+    console.log('GLOSSARY', JSON.stringify(node));
+    state.write('stuff');
+  },
   link(node, state) {
     state.usePackages('url', 'hyperref');
     const href = node.url;

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -217,6 +217,10 @@ const handlers: Record<string, Handler> = {
     // https://www.overleaf.com/learn/latex/glossaries
     state.renderChildren(node, true);
   },
+  glossary() {
+    // Glossary definitions are handled at once when constructing the serializer
+    // Nothing to do here
+  },
   link(node, state) {
     state.usePackages('url', 'hyperref');
     const href = node.url;

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -21,7 +21,14 @@ import { transformLegends } from './legends.js';
 export type { LatexResult } from './types.js';
 
 const glossaryReferenceHandler: Handler = (node, state) => {
-  if (!node.identifier) return;
+  if (!state.printGlossary) {
+    state.renderChildren(node);
+  }
+
+  if (!node.identifier) {
+    state.renderChildren(node);
+  }
+
   const entry = state.glossary[node.identifier];
   if (!entry) {
     fileError(state.file, `Unknown glossary entry identifier "${node.identifier}"`, {
@@ -368,8 +375,12 @@ class TexSerializer implements ITexSerializer {
     this.references = opts?.references ?? {};
     this.footnotes = createFootnoteDefinitions(tree);
     // Improve: render definition when encountering terms
-    this.glossary = createGlossaryDefinitions(tree);
+    this.glossary = opts?.printGlossaries ? createGlossaryDefinitions(tree) : [];
     this.renderChildren(tree);
+  }
+
+  get printGlossary(): boolean {
+    return this.options.printGlossaries === true;
   }
 
   get out(): string {

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -37,8 +37,11 @@ const glossaryReferenceHandler: Handler = (node, state) => {
       node,
       source: 'myst-to-tex',
     });
+    const gn = node as GenericNode;
+    state.write(toText(node).trim() || gn.label || '');
     return;
   }
+
   state.write('\\gls{');
   state.write(node.identifier);
   state.write('}');
@@ -295,6 +298,10 @@ const handlers: Record<string, Handler> = {
       glossaryReferenceHandler(node, state, parent);
       return;
     }
+    // Note: if the md doc references a term not defined in the glossary,
+    //       the mdast will not have kind=definitionTerm and the logic
+    //       will follow this branch
+
     // Look up reference and add the text
     const usedTemplate = node.template?.includes('%s') ? node.template : undefined;
     const text = (usedTemplate ?? toText(node))?.replace(/\s/g, '~') || '%s';

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -387,7 +387,7 @@ class TexGlossarySerializer {
   private renderGlossaryImports(
     directives: Record<string, [DefinitionTerm, DefinitionDescription]>,
   ): string {
-    if (!directives) return '';
+    if (!directives || Object.keys(directives).length === 0) return '';
     const block = writeTexLabelledComment(
       'glossary',
       this.createGlossaryDirectives(directives),

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -22,12 +22,12 @@ export type { LatexResult } from './types.js';
 
 const glossaryReferenceHandler: Handler = (node, state) => {
   if (!state.printGlossary) {
-    state.renderChildren(node);
+    state.renderChildren(node, true);
     return;
   }
 
   if (!node.identifier) {
-    state.renderChildren(node);
+    state.renderChildren(node, true);
     return;
   }
 

--- a/packages/myst-to-tex/src/types.ts
+++ b/packages/myst-to-tex/src/types.ts
@@ -1,6 +1,6 @@
 import type { References } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
-import type { DefinitionDescription, DefinitionTerm, FootnoteDefinition } from 'myst-spec-ext';
+import type { FootnoteDefinition } from 'myst-spec-ext';
 import type { VFile } from 'vfile';
 
 export const DEFAULT_IMAGE_WIDTH = 0.7;
@@ -43,7 +43,7 @@ export interface ITexSerializer<D extends Record<string, any> = StateData> {
   options: Options;
   references: References;
   footnotes: Record<string, FootnoteDefinition>;
-  glossary: Record<string, [DefinitionTerm, DefinitionDescription]>;
+  glossary: Record<string, [string, string]>;
   get printGlossary(): boolean;
   usePackages: (...packageNames: string[]) => void;
   write: (value: string) => void;

--- a/packages/myst-to-tex/src/types.ts
+++ b/packages/myst-to-tex/src/types.ts
@@ -8,16 +8,10 @@ export const DEFAULT_PAGE_WIDTH_PIXELS = 800;
 
 export type Handler = (node: any, state: ITexSerializer, parent: any) => void;
 
-export type GlossaryEntry = {
-  key: string;
-  name: string;
-  description: string;
-};
-
 export type LatexResult = {
   value: string;
   imports: string[];
-  glossary: GlossaryEntry[];
+  glossaryPreamble: string;
   commands: Record<string, string>;
 };
 

--- a/packages/myst-to-tex/src/types.ts
+++ b/packages/myst-to-tex/src/types.ts
@@ -1,6 +1,6 @@
 import type { References } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
-import type { FootnoteDefinition } from 'myst-spec-ext';
+import type { DefinitionDescription, DefinitionTerm, FootnoteDefinition } from 'myst-spec-ext';
 import type { VFile } from 'vfile';
 
 export const DEFAULT_IMAGE_WIDTH = 0.7;
@@ -8,9 +8,16 @@ export const DEFAULT_PAGE_WIDTH_PIXELS = 800;
 
 export type Handler = (node: any, state: ITexSerializer, parent: any) => void;
 
+export type GlossaryEntry = {
+  key: string;
+  name: string;
+  description: string;
+};
+
 export type LatexResult = {
   value: string;
   imports: string[];
+  glossary: GlossaryEntry[];
   commands: Record<string, string>;
 };
 
@@ -41,6 +48,7 @@ export interface ITexSerializer<D extends Record<string, any> = StateData> {
   options: Options;
   references: References;
   footnotes: Record<string, FootnoteDefinition>;
+  glossary: Record<string, [DefinitionTerm, DefinitionDescription]>;
   usePackages: (...packageNames: string[]) => void;
   write: (value: string) => void;
   text: (value: string, mathMode?: boolean) => void;

--- a/packages/myst-to-tex/src/types.ts
+++ b/packages/myst-to-tex/src/types.ts
@@ -28,6 +28,7 @@ export type Options = {
   beamer?: boolean;
   math?: MathPlugins;
   bibliography?: 'natbib' | 'biblatex';
+  printGlossaries?: boolean;
   citestyle?: 'numerical-only';
   references?: References;
 };
@@ -49,6 +50,7 @@ export interface ITexSerializer<D extends Record<string, any> = StateData> {
   references: References;
   footnotes: Record<string, FootnoteDefinition>;
   glossary: Record<string, [DefinitionTerm, DefinitionDescription]>;
+  get printGlossary(): boolean;
   usePackages: (...packageNames: string[]) => void;
   write: (value: string) => void;
   text: (value: string, mathMode?: boolean) => void;

--- a/packages/myst-to-tex/tests/glossaries.yml
+++ b/packages/myst-to-tex/tests/glossaries.yml
@@ -1,0 +1,373 @@
+title: myst-to-tex glossary-related features
+latexGlossary: |-
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  %%%%%%%%%%%%%%%%%%%  glossary  %%%%%%%%%%%%%%%%%%%
+  \printglossaries
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+cases:
+  - title: with no glossary refs
+    mdast:
+      type: root
+      children:
+        - type: block
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'A simple '
+                - type: crossReference
+                  label: PCA
+                  identifier: term-t1
+                  kind: definitionTerm
+                  template: '{name}'
+                  resolved: true
+                  children:
+                    - type: text
+                      value: 'PCA'
+                - type: text
+                  value: ' process'
+    latex: |-
+      A simple PCA process
+    printGlossaries: true
+  - title: one gls-ref in paragraph (glossary on)
+    mdast:
+      type: root
+      children:
+        - type: block
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'A simple '
+                - type: crossReference
+                  label: PCA
+                  identifier: term-t1
+                  kind: definitionTerm
+                  template: '{name}'
+                  resolved: true
+                  children:
+                    - type: text
+                      value: 'PCA'
+                - type: text
+                  value: ' process'
+            - type: glossary
+              children:
+                - type: definitionList
+                  children:
+                    - type: definitionTerm
+                      label: PCA
+                      identifier: term-t1
+                      children:
+                        - type: text
+                          value: PCA
+                    - type: definitionDescription
+                      children:
+                        - type: text
+                          value: Principal Component Analysis
+    latex: |-
+      A simple \gls{term-t1} process
+    printGlossaries: true
+  - title: one gls-ref in paragraph (glossary off)
+    mdast:
+      type: root
+      children:
+        - type: block
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'A simple '
+                - type: crossReference
+                  label: PCA
+                  identifier: term-t1
+                  kind: definitionTerm
+                  template: '{name}'
+                  resolved: true
+                  children:
+                    - type: text
+                      value: 'PCA'
+                - type: text
+                  value: ' process'
+            - type: glossary
+              children:
+                - type: definitionList
+                  children:
+                    - type: definitionTerm
+                      label: PCA
+                      identifier: term-t1
+                      children:
+                        - type: text
+                          value: PCA
+                    - type: definitionDescription
+                      children:
+                        - type: text
+                          value: Principal Component Analysis
+    latex: |-
+      A simple PCA process
+    printGlossaries: false
+  - title: two gls-refs in paragraph (glossary on)
+    mdast:
+      type: root
+      children:
+        - type: block
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'A simple '
+                - type: crossReference
+                  label: PCA
+                  identifier: term-t1
+                  kind: definitionTerm
+                  template: '{name}'
+                  resolved: true
+                  children:
+                    - type: text
+                      value: 'PCA'
+                - type: text
+                  value: ' process in the context of '
+                - type: crossReference
+                  label: MLR
+                  identifier: term-t2
+                  kind: definitionTerm
+                  template: '{name}'
+                  resolved: true
+                  children:
+                    - type: text
+                      value: 'MLR'
+            - type: glossary
+              children:
+                - type: definitionList
+                  children:
+                    - type: definitionTerm
+                      label: PCA
+                      identifier: term-t1
+                      children:
+                        - type: text
+                          value: PCA
+                    - type: definitionDescription
+                      children:
+                        - type: text
+                          value: Principal Component Analysis
+                    - type: definitionTerm
+                      label: MLR
+                      identifier: term-t2
+                      children:
+                        - type: text
+                          value: MLR
+                    - type: definitionDescription
+                      children:
+                        - type: text
+                          value: Multiple Linear Regression
+    latex: |-
+      A simple \gls{term-t1} process in the context of \gls{term-t2}
+    printGlossaries: true
+  - title: two gls-refs in paragraph (glossary off)
+    mdast:
+      type: root
+      children:
+        - type: block
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'A simple '
+                - type: crossReference
+                  label: PCA
+                  identifier: term-t1
+                  kind: definitionTerm
+                  template: '{name}'
+                  resolved: true
+                  children:
+                    - type: text
+                      value: 'PCA'
+                - type: text
+                  value: ' process in the context of '
+                - type: crossReference
+                  label: MLR
+                  identifier: term-t2
+                  kind: definitionTerm
+                  template: '{name}'
+                  resolved: true
+                  children:
+                    - type: text
+                      value: 'MLR'
+            - type: glossary
+              children:
+                - type: definitionList
+                  children:
+                    - type: definitionTerm
+                      label: PCA
+                      identifier: term-t1
+                      children:
+                        - type: text
+                          value: PCA
+                    - type: definitionDescription
+                      children:
+                        - type: text
+                          value: Principal Component Analysis
+                    - type: definitionTerm
+                      label: MLR
+                      identifier: term-t2
+                      children:
+                        - type: text
+                          value: MLR
+                    - type: definitionDescription
+                      children:
+                        - type: text
+                          value: Multiple Linear Regression
+    latex: |-
+      A simple PCA process in the context of MLR
+    printGlossaries: false
+  - title: with unused glossary defs
+    mdast:
+      type: root
+      children:
+        - type: block
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'A simple '
+                - type: crossReference
+                  label: PCA
+                  identifier: term-t1
+                  kind: definitionTerm
+                  template: '{name}'
+                  resolved: true
+                  children:
+                    - type: text
+                      value: 'PCA'
+                - type: text
+                  value: ' process'
+            - type: glossary
+              children:
+                - type: definitionList
+                  children:
+                    - type: definitionTerm
+                      label: PCA
+                      identifier: term-t1
+                      children:
+                        - type: text
+                          value: PCA
+                    - type: definitionDescription
+                      children:
+                        - type: text
+                          value: Principal Component Analysis
+                    - type: definitionTerm
+                      label: MLR
+                      identifier: term-t2
+                      children:
+                        - type: text
+                          value: MLR
+                    - type: definitionDescription
+                      children:
+                        - type: text
+                          value: Multiple Linear Regression
+    latex: |-
+      A simple \gls{term-t1} process
+    printGlossaries: true
+  - title: with missing glossary def
+    notes: |-
+      The parser will never generate this mdast in case
+      the original md has a ref to an element not present
+      in the glossary
+    mdast:
+      type: root
+      children:
+        - type: block
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'A simple '
+                - type: crossReference
+                  label: PCA
+                  identifier: term-t1
+                  kind: definitionTerm
+                  template: '{name}'
+                  resolved: true
+                  children:
+                    - type: text
+                      value: 'PCA'
+                - type: text
+                  value: ' process'
+            - type: glossary
+              children:
+                - type: definitionList
+                  children:
+                    - type: definitionTerm
+                      label: MLR
+                      identifier: term-t2
+                      children:
+                        - type: text
+                          value: MLR
+                    - type: definitionDescription
+                      children:
+                        - type: text
+                          value: Multiple Linear Regression
+    latex: |-
+      A simple PCA process
+    printGlossaries: true
+  - title: with missing glossary def and unresolved ref
+    notes: |-
+      The parser will never generate this mdast in case
+      the original md has a ref to an element not present
+      in the glossary
+    mdast:
+      type: root
+      children:
+        - type: block
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'A simple '
+                - type: crossReference
+                  label: PCA
+                  identifier: term-t1
+                  kind: definitionTerm
+                  template: '{name}'
+                - type: text
+                  value: ' process'
+            - type: glossary
+              children:
+                - type: definitionList
+                  children:
+                    - type: definitionTerm
+                      label: MLR
+                      identifier: term-t2
+                      children:
+                        - type: text
+                          value: MLR
+                    - type: definitionDescription
+                      children:
+                        - type: text
+                          value: Multiple Linear Regression
+    latex: |-
+      A simple PCA process
+    printGlossaries: true
+  - title: with missing glossary def and empty glossary
+    notes: |-
+      The parser will never generate this mdast in case
+      the original md has a ref to an element not present
+      in the glossary
+    mdast:
+      type: root
+      children:
+        - type: block
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'A simple '
+                - type: crossReference
+                  label: PCA
+                  identifier: term-t1
+                  kind: definitionTerm
+                  template: '{name}'
+                - type: text
+                  value: ' process'
+    latex: |-
+      A simple PCA process
+    printGlossaries: true

--- a/packages/myst-to-tex/tests/glossaries.yml
+++ b/packages/myst-to-tex/tests/glossaries.yml
@@ -371,3 +371,64 @@ cases:
     latex: |-
       A simple PCA process
     printGlossaries: true
+  - title: part with glossary reference (glossary off)
+    notes: |-
+      The parser will generate this structure when extracting
+      a part (glossary printing off)
+    mdast:
+      type: root
+      children:
+        - type: block
+          data:
+            - part: abstract
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'A simple '
+                - type: crossReference
+                  label: PCA
+                  identifier: term-t1
+                  kind: definitionTerm
+                  template: '{name}'
+                  resolved: true
+                  children:
+                    - type: text
+                      value: 'PCA'
+                - type: text
+                  value: ' process'
+    latex: |-
+      A simple PCA process
+    printGlossaries: false
+  - title: part with glossary reference (glossary on)
+    notes: |-
+      The parser will generate this structure when extracting
+      a part, and normally the parser will be called with the
+      print-glossary flag off; we have this test case to check
+      the parser is still resilient to the lack of glossary
+      definitions
+    mdast:
+      type: root
+      children:
+        - type: block
+          data:
+            - part: abstract
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'A simple '
+                - type: crossReference
+                  label: PCA
+                  identifier: term-t1
+                  kind: definitionTerm
+                  template: '{name}'
+                  resolved: true
+                  children:
+                    - type: text
+                      value: 'PCA'
+                - type: text
+                  value: ' process'
+    latex: |-
+      A simple PCA process
+    printGlossaries: on


### PR DESCRIPTION
This is an early review of the changes I made to add support to glossaries.

- Glossary definitions are added in the preamble regardless whether or not they will actually be used (room for improvement).
- Glossary references (cross-reference nodes) are rendered accordingly if a glossary definition is found.

### In progress
There is an issue. The rendered PDF will have the referred terms correctly rendered, however the final glossary, at the end of the page, will not be shown as explained at [Compiling the Glossary](https://www.overleaf.com/learn/latex/Glossaries) section. We need to trigger this sequence of build commands:

1. Invoke the PDF build command `pdflatex file.tex`
2. Invoke the glossary build command `makeglossaries file`, in the same folder
3. Invoke the PDF build command `pdflatex file.tex`

That is a problem I have not yet investigated how to solve.

### Note
The changes are not perfect and, since it is my first PR, I want to have some early feedback and guidance as soon as possible.

Fixes #584 