### PR TITLE
💵 Funding support in frontmatter (and other small JATS features)

### DIFF
--- a/.changeset/cool-squids-carry.md
+++ b/.changeset/cool-squids-carry.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Make institution an alias of name on Affiliation type rather than allowing both

--- a/.changeset/fuzzy-masks-relax.md
+++ b/.changeset/fuzzy-masks-relax.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Consume keywords in jats

--- a/.changeset/kind-baboons-yell.md
+++ b/.changeset/kind-baboons-yell.md
@@ -1,0 +1,6 @@
+---
+'myst-templates': patch
+'myst-cli': patch
+---
+
+Consume myst-frontmatter Author -> Contributor type change

--- a/.changeset/kind-melons-sit.md
+++ b/.changeset/kind-melons-sit.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Consume parsed name in jats

--- a/.changeset/smooth-rabbits-greet.md
+++ b/.changeset/smooth-rabbits-greet.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Support funding in jats export

--- a/.changeset/tender-cooks-laugh.md
+++ b/.changeset/tender-cooks-laugh.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Consume full structured affiliations in jats

--- a/.changeset/thick-hounds-greet.md
+++ b/.changeset/thick-hounds-greet.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Separate contributors from authors on processed frontmatter

--- a/.changeset/tidy-eels-wonder.md
+++ b/.changeset/tidy-eels-wonder.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Add funding to frontmatter

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -109,6 +109,9 @@ The following table lists the available frontmatter fields, a brief description 
 * - `license`
   - a license object or a string
   - page can override project
+* - `funding`
+  - a funding object
+  - page can override project
 * - `github`
   - a valid GitHub URL or `owner/reponame`
   - page can override project
@@ -180,7 +183,7 @@ The `authors` field is a list of `author` objects. Available fields in the autho
 * - field
   - description
 * - `name`
-  - a string - the author’s full name
+  - a string OR CSL-JSON author object - the author’s full name; if a string, this will be parsed automatically. Otherwise, the object may contain `given`, `surname`, `non_dropping_particle`, `dropping_particle`, `suffix`, and full name `literal`
 * - `orcid`
   - a string - a valid ORCID identifier with or without the URL
 * - `corresponding`
@@ -456,6 +459,67 @@ String values for licenses should be a valid “Identifier” string from the [S
 ```
 
 By using the correct SPDX Identifier, your website will automatically use the appropriate icon for the license and link to the license definition.
+
+## Funding
+
+Funding frontmatter is able to contain multiple funding and open access statements, as well as award info.
+
+It may be as simple as a single funding statement:
+
+```yaml
+funding: This work was supported by University.
+```
+
+Funding may also specify award id, name, sources ([affiliation object or reference](#affiliations)), investigators ([contributor objects or references](#authors)), and recipients ([contributor objects or references](#authors)).
+
+```yaml
+authors:
+  - id: auth0
+    name: Jane Doe
+funding:
+  statement: This work was supported by University.
+  id: award-id-000
+  name: My Award
+  sources:
+    - name: University
+  investigators:
+    - name: John Doe
+  recipients:
+    - auth0
+```
+
+Multiple funding objects with multiple awards are also possible:
+
+```yaml
+authors:
+  - id: auth0
+    name: Jane Doe
+funding:
+  - statement: This work was supported by University.
+    awards:
+      - id: award-id-000
+        name: My First Award
+        sources:
+          - name: University
+        investigators:
+          - name: John Doe
+        recipients:
+          - auth0
+      - id: award-id-001
+        name: My Second Award
+        sources:
+          - name: University
+        investigators:
+          - name: John Doe
+        recipients:
+          - auth0
+  - statement: Open access was supported by Consortium.
+    open_access: Users are allowed to reproduce without prior permission
+    awards:
+      - id: open-award-999
+        sources:
+          - name: Consortium
+```
 
 ## Venue
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13680,6 +13680,7 @@
       },
       "devDependencies": {
         "@types/spdx-correct": "^3.1.0",
+        "js-yaml": "^4.1.0",
         "moment": "^2.29.4"
       }
     },

--- a/packages/myst-cli/src/build/docx/titles.ts
+++ b/packages/myst-cli/src/build/docx/titles.ts
@@ -1,7 +1,7 @@
 import type { Heading } from 'myst-spec';
-import type { Author } from 'myst-frontmatter';
+import type { Contributor } from 'myst-frontmatter';
 
-export function createArticleTitle(blockTitle?: string, authors?: Author[]) {
+export function createArticleTitle(blockTitle?: string, authors?: Contributor[]) {
   const headings: Heading[] = [];
   if (blockTitle) {
     headings.push({

--- a/packages/myst-frontmatter/package.json
+++ b/packages/myst-frontmatter/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/spdx-correct": "^3.1.0",
+    "js-yaml": "^4.1.0",
     "moment": "^2.29.4"
   }
 }

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -805,6 +805,64 @@ describe('fillPageFrontmatter', () => {
     });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
+  it('relevant authors and contributors from project are persisted in place', async () => {
+    expect(
+      fillPageFrontmatter(
+        {},
+        {
+          authors: [
+            {
+              id: 'jd',
+              name: 'John Doe',
+              nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
+            },
+          ],
+          contributors: [
+            {
+              id: 'jn',
+              name: 'Just A. Name',
+              nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+            },
+          ],
+          funding: [
+            {
+              awards: [
+                {
+                  investigators: ['jn', 'jd'],
+                },
+              ],
+            },
+          ],
+        },
+        opts,
+      ),
+    ).toEqual({
+      authors: [
+        {
+          id: 'jd',
+          name: 'John Doe',
+          nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
+        },
+      ],
+      contributors: [
+        {
+          id: 'jn',
+          name: 'Just A. Name',
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+        },
+      ],
+      funding: [
+        {
+          awards: [
+            {
+              investigators: ['jn', 'jd'],
+            },
+          ],
+        },
+      ],
+    });
+    expect(opts.messages.warnings?.length).toBeFalsy();
+  });
   it('relevant authors from project are persisted when referenced in page', async () => {
     expect(
       fillPageFrontmatter(

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach } from 'vitest';
 import type { ValidationOptions } from 'simple-validators';
 import type {
   Affiliation,
-  Author,
+  Contributor,
   Biblio,
   Jupytext,
   KernelSpec,
@@ -17,7 +17,7 @@ import {
   unnestKernelSpec,
   validateAffiliation,
   validateAndStashObject,
-  validateAuthor,
+  validateContributor,
   validateBiblio,
   validateExport,
   validateJupytext,
@@ -30,7 +30,7 @@ import {
   validateVenue,
 } from './validators';
 
-const TEST_AUTHOR: Author = {
+const TEST_CONTRIBUTOR: Contributor = {
   userId: '',
   name: 'Test Author',
   nameParsed: { literal: 'Test Author', given: 'Test', family: 'Author' },
@@ -139,7 +139,6 @@ const TEST_SITE_FRONTMATTER: SiteFrontmatter = {
       nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
     },
   ],
-  authorsSource: ['jd'],
   github: 'https://github.com/example',
   keywords: ['example', 'test'],
 };
@@ -155,7 +154,6 @@ const TEST_PROJECT_FRONTMATTER: ProjectFrontmatter = {
       affiliations: ['univa'],
     },
   ],
-  authorsSource: ['jd'],
   affiliations: [{ id: 'univa', name: 'University A' }],
   date: '14 Dec 2021',
   name: 'example.md',
@@ -202,7 +200,6 @@ const TEST_PAGE_FRONTMATTER: PageFrontmatter = {
       affiliations: ['univb'],
     },
   ],
-  authorsSource: ['jd'],
   affiliations: [{ id: 'univb', name: 'University B' }],
   name: 'example.md',
   doi: '10.1000/abcd/efg012',
@@ -251,26 +248,26 @@ describe('validateVenue', () => {
   });
 });
 
-describe('validateAuthor', () => {
+describe('validateContributor', () => {
   it('empty object returns self', async () => {
-    expect(validateAuthor({}, {}, opts)).toEqual({});
+    expect(validateContributor({}, {}, opts)).toEqual({});
   });
   it('extra keys removed', async () => {
-    expect(validateAuthor({ extra: '' }, {}, opts)).toEqual({});
+    expect(validateContributor({ extra: '' }, {}, opts)).toEqual({});
   });
   it('full object returns self', async () => {
-    expect(validateAuthor(TEST_AUTHOR, {}, opts)).toEqual(TEST_AUTHOR);
+    expect(validateContributor(TEST_CONTRIBUTOR, {}, opts)).toEqual(TEST_CONTRIBUTOR);
   });
   it('invalid orcid errors', async () => {
-    expect(validateAuthor({ orcid: 'https://exampale.com/example' }, {}, opts)).toEqual({});
+    expect(validateContributor({ orcid: 'https://exampale.com/example' }, {}, opts)).toEqual({});
     expect(opts.messages.errors?.length).toEqual(1);
   });
   it('invalid email errors', async () => {
-    expect(validateAuthor({ email: 'https://example.com' }, {}, opts)).toEqual({});
+    expect(validateContributor({ email: 'https://example.com' }, {}, opts)).toEqual({});
     expect(opts.messages.errors?.length).toEqual(1);
   });
   it('unknown roles warn', async () => {
-    expect(validateAuthor({ name: 'my name', roles: ['example'] }, {}, opts)).toEqual({
+    expect(validateContributor({ name: 'my name', roles: ['example'] }, {}, opts)).toEqual({
       name: 'my name',
       nameParsed: { literal: 'my name', given: 'my', family: 'name' },
       roles: ['example'],
@@ -278,21 +275,23 @@ describe('validateAuthor', () => {
     expect(opts.messages.warnings?.length).toEqual(1);
   });
   it('invalid roles errors', async () => {
-    expect(validateAuthor({ roles: [1] }, {}, opts)).toEqual({ roles: [] });
+    expect(validateContributor({ roles: [1] }, {}, opts)).toEqual({ roles: [] });
     expect(opts.messages.errors?.length).toEqual(1);
   });
   it('corresponding with no email errors', async () => {
-    expect(validateAuthor({ corresponding: true }, {}, opts)).toEqual({ corresponding: false });
+    expect(validateContributor({ corresponding: true }, {}, opts)).toEqual({
+      corresponding: false,
+    });
     expect(opts.messages.errors?.length).toEqual(1);
   });
   it('website coerces to url', async () => {
-    expect(validateAuthor({ website: 'https://example.com' }, {}, opts)).toEqual({
+    expect(validateContributor({ website: 'https://example.com' }, {}, opts)).toEqual({
       url: 'https://example.com',
     });
   });
   it('collaborations warns', async () => {
     expect(
-      validateAuthor(
+      validateContributor(
         {
           collaborations: ['example collaboration'],
         },
@@ -699,7 +698,6 @@ describe('fillPageFrontmatter', () => {
               nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
             },
           ],
-          authorsSource: ['jd'],
         },
         {
           authors: [
@@ -709,7 +707,6 @@ describe('fillPageFrontmatter', () => {
               nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
             },
           ],
-          authorsSource: ['jn'],
         },
         opts,
       ),
@@ -721,7 +718,6 @@ describe('fillPageFrontmatter', () => {
           nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
         },
       ],
-      authorsSource: ['jd'],
     });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
@@ -737,7 +733,6 @@ describe('fillPageFrontmatter', () => {
               nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
             },
           ],
-          authorsSource: ['jd'],
         },
         opts,
       ),
@@ -749,7 +744,6 @@ describe('fillPageFrontmatter', () => {
           nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
         },
       ],
-      authorsSource: ['jd'],
     });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
@@ -764,7 +758,6 @@ describe('fillPageFrontmatter', () => {
               nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
             },
           ],
-          authorsSource: ['jd'],
         },
         {
           authors: [
@@ -774,7 +767,6 @@ describe('fillPageFrontmatter', () => {
               nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
             },
           ],
-          authorsSource: ['jn'],
           funding: [
             {
               awards: [
@@ -794,13 +786,14 @@ describe('fillPageFrontmatter', () => {
           name: 'John Doe',
           nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
         },
+      ],
+      contributors: [
         {
           id: 'jn',
           name: 'Just A. Name',
           nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
       ],
-      authorsSource: ['jd'],
       funding: [
         {
           awards: [
@@ -825,7 +818,6 @@ describe('fillPageFrontmatter', () => {
               affiliations: ['univa'],
             },
           ],
-          authorsSource: ['jd'],
           affiliations: [{ id: 'univa', name: 'University A' }],
           funding: [
             {
@@ -846,7 +838,6 @@ describe('fillPageFrontmatter', () => {
               affiliations: ['univb'],
             },
           ],
-          authorsSource: ['jn'],
           affiliations: [{ id: 'univb', name: 'University B' }],
         },
         opts,
@@ -859,6 +850,8 @@ describe('fillPageFrontmatter', () => {
           nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
           affiliations: ['univa'],
         },
+      ],
+      contributors: [
         {
           id: 'jn',
           name: 'Just A. Name',
@@ -866,7 +859,75 @@ describe('fillPageFrontmatter', () => {
           affiliations: ['univb'],
         },
       ],
-      authorsSource: ['jd'],
+      affiliations: [
+        { id: 'univa', name: 'University A' },
+        { id: 'univb', name: 'University B' },
+      ],
+      funding: [
+        {
+          awards: [
+            {
+              investigators: ['jn'],
+            },
+          ],
+        },
+      ],
+    });
+    expect(opts.messages.warnings?.length).toBeFalsy();
+  });
+  it('relevant contributors from project are persisted when referenced in page', async () => {
+    expect(
+      fillPageFrontmatter(
+        {
+          authors: [
+            {
+              id: 'jd',
+              name: 'John Doe',
+              nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
+              affiliations: ['univa'],
+            },
+          ],
+          affiliations: [{ id: 'univa', name: 'University A' }],
+          funding: [
+            {
+              awards: [
+                {
+                  investigators: ['jn'],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          contributors: [
+            {
+              id: 'jn',
+              name: 'Just A. Name',
+              nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+              affiliations: ['univb'],
+            },
+          ],
+          affiliations: [{ id: 'univb', name: 'University B' }],
+        },
+        opts,
+      ),
+    ).toEqual({
+      authors: [
+        {
+          id: 'jd',
+          name: 'John Doe',
+          nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
+          affiliations: ['univa'],
+        },
+      ],
+      contributors: [
+        {
+          id: 'jn',
+          name: 'Just A. Name',
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          affiliations: ['univb'],
+        },
+      ],
       affiliations: [
         { id: 'univa', name: 'University A' },
         { id: 'univb', name: 'University B' },
@@ -891,13 +952,13 @@ describe('validateAndStashObject', () => {
     const out = validateAndStashObject(
       'Just A. Name',
       stash,
-      'authors',
-      (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+      'contributors',
+      (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
       opts,
     );
     expect(out).toEqual('Just A. Name');
     expect(stash).toEqual({
-      authors: [
+      contributors: [
         {
           id: 'Just A. Name',
           name: 'Just A. Name',
@@ -909,7 +970,7 @@ describe('validateAndStashObject', () => {
   });
   it('string returns itself when in stash', async () => {
     const stash = {
-      authors: [
+      contributors: [
         {
           id: 'auth1',
           name: 'Just A. Name',
@@ -920,13 +981,13 @@ describe('validateAndStashObject', () => {
     const out = validateAndStashObject(
       'auth1',
       stash,
-      'authors',
-      (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+      'contributors',
+      (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
       opts,
     );
     expect(out).toEqual('auth1');
     expect(stash).toEqual({
-      authors: [
+      contributors: [
         {
           id: 'auth1',
           name: 'Just A. Name',
@@ -941,15 +1002,15 @@ describe('validateAndStashObject', () => {
     const out = validateAndStashObject(
       { name: 'Just A. Name' },
       stash,
-      'authors',
-      (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+      'contributors',
+      (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
       { ...opts, file: 'folder/test.file.yml' },
     );
-    expect(out).toEqual('authors-test-file-generated-uid-0');
+    expect(out).toEqual('contributors-test-file-generated-uid-0');
     expect(stash).toEqual({
-      authors: [
+      contributors: [
         {
-          id: 'authors-test-file-generated-uid-0',
+          id: 'contributors-test-file-generated-uid-0',
           name: 'Just A. Name',
           nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
@@ -962,22 +1023,22 @@ describe('validateAndStashObject', () => {
     validateAndStashObject(
       { name: 'Just A. Name' },
       stash,
-      'authors',
-      (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+      'contributors',
+      (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
       { ...opts, file: 'folder\\my_file' },
     );
     const out = validateAndStashObject(
       { name: 'Just A. Name' },
       stash,
-      'authors',
-      (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+      'contributors',
+      (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
       { ...opts, file: 'folder\\my_file' },
     );
-    expect(out).toEqual('authors-my_file-generated-uid-0');
+    expect(out).toEqual('contributors-my_file-generated-uid-0');
     expect(stash).toEqual({
-      authors: [
+      contributors: [
         {
-          id: 'authors-my_file-generated-uid-0',
+          id: 'contributors-my_file-generated-uid-0',
           name: 'Just A. Name',
           nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
         },
@@ -987,7 +1048,7 @@ describe('validateAndStashObject', () => {
   });
   it('object with id added to stash', async () => {
     const stash = {
-      authors: [
+      contributors: [
         {
           id: 'auth1',
           name: 'Just A. Name',
@@ -998,13 +1059,13 @@ describe('validateAndStashObject', () => {
     const out = validateAndStashObject(
       { id: 'auth2', name: 'A. Nother Name' },
       stash,
-      'authors',
-      (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+      'contributors',
+      (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
       opts,
     );
     expect(out).toEqual('auth2');
     expect(stash).toEqual({
-      authors: [
+      contributors: [
         {
           id: 'auth1',
           name: 'Just A. Name',
@@ -1021,7 +1082,7 @@ describe('validateAndStashObject', () => {
   });
   it('object with id replaces simple object', async () => {
     const stash = {
-      authors: [
+      contributors: [
         {
           id: 'auth1',
           name: 'auth1',
@@ -1034,13 +1095,13 @@ describe('validateAndStashObject', () => {
         name: 'Just A. Name',
       },
       stash,
-      'authors',
-      (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+      'contributors',
+      (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
       opts,
     );
     expect(out).toEqual('auth1');
     expect(stash).toEqual({
-      authors: [
+      contributors: [
         {
           id: 'auth1',
           name: 'Just A. Name',
@@ -1052,7 +1113,7 @@ describe('validateAndStashObject', () => {
   });
   it('object with id warns on duplicate', async () => {
     const stash = {
-      authors: [
+      contributors: [
         {
           id: 'auth1',
           name: 'Just A. Name',
@@ -1066,13 +1127,13 @@ describe('validateAndStashObject', () => {
         name: 'A. Nother Name',
       },
       stash,
-      'authors',
-      (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+      'contributors',
+      (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
       opts,
     );
     expect(out).toEqual('auth1');
     expect(stash).toEqual({
-      authors: [
+      contributors: [
         {
           id: 'auth1',
           name: 'Just A. Name',

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -52,7 +52,6 @@ const TEST_AFFILIATION: Affiliation = {
   postal_code: '00000',
   country: 'USA',
   name: 'Example University',
-  institution: 'Example University',
   department: 'Example department',
   collaboration: true,
   isni: '0000000000000000',

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -180,7 +180,6 @@ export type SiteFrontmatter = {
   github?: string;
   keywords?: string[];
   funding?: Funding[];
-  /** Computed property for now; holds people referenced from non-author fields, e.g. funding */
   contributors?: Contributor[];
 };
 

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -1,4 +1,5 @@
 import type { CreditRole } from 'credit-roles';
+import type { Funding } from '../funding/types.js';
 import type { Licenses } from '../licenses/types.js';
 
 export interface Affiliation {
@@ -32,9 +33,6 @@ export type Name = {
   suffix?: string;
 };
 
-/**
- * Au
- */
 export interface Author {
   id?: string;
   name?: string; // may be set to Name object
@@ -179,6 +177,17 @@ export type SiteFrontmatter = {
   venue?: Venue;
   github?: string;
   keywords?: string[];
+  funding?: Funding[];
+  /**
+   * Computed property; holds references to list of original "authors"
+   *
+   * The "authors" field may be augmented with funding recipients/investigators, etc.
+   *
+   * Potentially, we could modify this so the authors list only contains the
+   * original authors, and instead have a new field like contributors that has
+   * all the people referenced anywhere...
+   */
+  authorsSource?: string[];
 };
 
 export type ProjectFrontmatter = SiteFrontmatter & {

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -22,7 +22,7 @@ export interface Affiliation {
   fax?: string;
 }
 
-export type AuthorRoles = CreditRole | string;
+export type ContributorRole = CreditRole | string;
 
 export type Name = {
   literal?: string;
@@ -33,7 +33,7 @@ export type Name = {
   suffix?: string;
 };
 
-export interface Author {
+export interface Contributor {
   id?: string;
   name?: string; // may be set to Name object
   userId?: string;
@@ -42,7 +42,7 @@ export interface Author {
   equal_contributor?: boolean;
   deceased?: boolean;
   email?: string;
-  roles?: AuthorRoles[];
+  roles?: ContributorRole[];
   affiliations?: string[];
   twitter?: string;
   github?: string;
@@ -60,8 +60,10 @@ export interface Author {
  * These will be normalized to the top level and replaced with ids elsewhere
  */
 export type ReferenceStash = {
-  affiliations?: Affiliation[];
-  authors?: Author[];
+  affiliations?: (Affiliation & { id: string })[];
+  contributors?: (Contributor & { id: string })[];
+  // Used to on resolution differentiate authors from other contributors
+  authorIds?: string[];
 };
 
 export type Biblio = {
@@ -172,22 +174,14 @@ export type SiteFrontmatter = {
   thumbnailOptimized?: string;
   banner?: string | null;
   bannerOptimized?: string;
-  authors?: Author[];
+  authors?: Contributor[];
   affiliations?: Affiliation[];
   venue?: Venue;
   github?: string;
   keywords?: string[];
   funding?: Funding[];
-  /**
-   * Computed property; holds references to list of original "authors"
-   *
-   * The "authors" field may be augmented with funding recipients/investigators, etc.
-   *
-   * Potentially, we could modify this so the authors list only contains the
-   * original authors, and instead have a new field like contributors that has
-   * all the people referenced anywhere...
-   */
-  authorsSource?: string[];
+  /** Computed property for now; holds people referenced from non-author fields, e.g. funding */
+  contributors?: Contributor[];
 };
 
 export type ProjectFrontmatter = SiteFrontmatter & {

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -1084,14 +1084,14 @@ export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: Va
       return validateFunding(fund, stash, incrementOptions(`funding.${index}`, opts));
     });
   }
-  const stashAuthors = stash.contributors?.filter(
+  const stashContribAuthors = stash.contributors?.filter(
     (contrib) => stash.authorIds?.includes(contrib.id),
   );
-  const stashContributors = stash.contributors?.filter(
+  const stashContribNonAuthors = stash.contributors?.filter(
     (contrib) => !stash.authorIds?.includes(contrib.id),
   );
-  if (stashAuthors?.length) {
-    output.authors = stashAuthors;
+  if (stashContribAuthors?.length) {
+    output.authors = stashContribAuthors;
     // Ensure there is a corresponding author if an email is provided
     const corresponding = output.authors?.find((a) => a.corresponding !== undefined);
     const email = output.authors?.find((a) => a.email);
@@ -1099,8 +1099,8 @@ export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: Va
       email.corresponding = true;
     }
   }
-  if (stashContributors?.length) {
-    output.contributors = stashContributors;
+  if (stashContribNonAuthors?.length) {
+    output.contributors = stashContribNonAuthors;
   }
   if (stash.affiliations?.length) {
     output.affiliations = stash.affiliations;

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -515,7 +515,7 @@ export function validateName(input: any, opts: ValidationOptions) {
 }
 
 /**
- * Validate Conributor object against the schema
+ * Validate Contributor object against the schema
  */
 export function validateContributor(input: any, stash: ReferenceStash, opts: ValidationOptions) {
   if (typeof input === 'string') {

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -117,7 +117,6 @@ const AFFILIATION_KEYS = [
   'postal_code',
   'country',
   'name',
-  'institution',
   'department',
   'collaboration',
   'isni',
@@ -177,6 +176,7 @@ const AFFILIATION_ALIASES = {
   region: 'state',
   province: 'state',
   website: 'url',
+  institution: 'name',
 };
 
 const BIBLIO_KEYS = ['volume', 'issue', 'first_page', 'last_page'];
@@ -394,9 +394,6 @@ export function validateAffiliation(input: any, opts: ValidationOptions) {
   if (defined(value.name)) {
     output.name = validateString(value.name, incrementOptions('name', opts));
   }
-  if (defined(value.institution)) {
-    output.institution = validateString(value.institution, incrementOptions('institution', opts));
-  }
   if (defined(value.department)) {
     output.department = validateString(value.department, incrementOptions('department', opts));
   }
@@ -451,8 +448,8 @@ export function validateAffiliation(input: any, opts: ValidationOptions) {
   // where a simple string is provided as an affiliation.
   if (Object.keys(output).length === 1 && output.id) {
     return stashPlaceholder(output.id);
-  } else if (!output.name && !output.institution) {
-    validationWarning('affiliation should include name or institution', opts);
+  } else if (!output.name) {
+    validationWarning('affiliation should include name/institution', opts);
   }
   return output;
 }

--- a/packages/myst-frontmatter/src/funding/index.ts
+++ b/packages/myst-frontmatter/src/funding/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js';
+export * from './validators.js';

--- a/packages/myst-frontmatter/src/funding/types.ts
+++ b/packages/myst-frontmatter/src/funding/types.ts
@@ -1,0 +1,16 @@
+export type Award = {
+  id?: string;
+  name?: string;
+  description?: string;
+  sources?: string[]; // These are affiliation ids
+  /** Recipients and investigators are added to author list; these are references */
+  recipients?: string[];
+  investigators?: string[];
+};
+
+export type Funding = {
+  statement?: string;
+  /** Open access statement */
+  open_access?: string;
+  awards?: Award[];
+};

--- a/packages/myst-frontmatter/src/funding/validators.ts
+++ b/packages/myst-frontmatter/src/funding/validators.ts
@@ -1,0 +1,152 @@
+import {
+  defined,
+  incrementOptions,
+  validateKeys,
+  validateList,
+  validateObject,
+  validateObjectKeys,
+  validateString,
+} from 'simple-validators';
+import type { ValidationOptions } from 'simple-validators';
+import type { ReferenceStash } from '../frontmatter/types.js';
+import type { Award, Funding } from './types.js';
+import { validateAffiliation, validateAndStashObject, validateAuthor } from '../index.js';
+
+const AWARD_KEYS = ['id', 'name', 'description', 'sources', 'recipients', 'investigators'];
+const AWARD_ALIASES = { source: 'sources', recipient: 'recipients', investigator: 'investigators' };
+const FUNDING_KEYS = ['statement', 'open_access', 'awards'];
+const FUNDING_ALIASES = { award: 'awards' };
+
+/**
+ * Validate Award object against the schema
+ *
+ * Award sources (institutions) get added to affiliations list and
+ * award recipients/investigators get added to authors list.
+ */
+export function validateAward(input: any, stash: ReferenceStash, opts: ValidationOptions) {
+  const value = validateObjectKeys(input, { optional: AWARD_KEYS, alias: AWARD_ALIASES }, opts);
+  if (value === undefined) return undefined;
+  const output: Award = {};
+  if (defined(value.id)) {
+    output.id = validateString(value.id, incrementOptions('id', opts));
+  }
+  if (defined(value.name)) {
+    output.name = validateString(value.name, incrementOptions('name', opts));
+  }
+  if (defined(value.description)) {
+    output.description = validateString(value.description, incrementOptions('description', opts));
+  }
+  if (defined(value.sources)) {
+    const sources = Array.isArray(value.sources) ? value.sources : [value.sources];
+    output.sources = validateList(sources, incrementOptions('sources', opts), (source, index) => {
+      return validateAndStashObject(
+        source,
+        stash,
+        'affiliations',
+        validateAffiliation,
+        incrementOptions(`sources.${index}`, opts),
+      );
+    });
+  }
+  if (defined(value.recipients)) {
+    const recipients = Array.isArray(value.recipients) ? value.recipients : [value.recipients];
+    output.recipients = validateList(
+      recipients,
+      incrementOptions('recipients', opts),
+      (recipient, index) => {
+        return validateAndStashObject(
+          recipient,
+          stash,
+          'authors',
+          (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+          incrementOptions(`recipients.${index}`, opts),
+        );
+      },
+    );
+  }
+  if (defined(value.investigators)) {
+    const investigators = Array.isArray(value.investigators)
+      ? value.investigators
+      : [value.investigators];
+    output.investigators = validateList(
+      investigators,
+      incrementOptions('investigators', opts),
+      (investigator, index) => {
+        return validateAndStashObject(
+          investigator,
+          stash,
+          'authors',
+          (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+          incrementOptions(`investigators.${index}`, opts),
+        );
+      },
+    );
+  }
+  return output;
+}
+
+/**
+ * Validate Funding object against the schema
+ *
+ * Valid input may be:
+ * - a string (which becomes funding statement)
+ * - an award
+ * - a full funding object
+ */
+export function validateFunding(input: any, stash: ReferenceStash, opts: ValidationOptions) {
+  if (typeof input === 'string') {
+    input = { statement: input };
+  }
+  const valueAsObj = validateObject(input, opts);
+  if (valueAsObj === undefined) return undefined;
+  const value = validateKeys(
+    valueAsObj,
+    { optional: FUNDING_KEYS, alias: FUNDING_ALIASES },
+    { ...opts, suppressErrors: true, suppressWarnings: true },
+  );
+  if (value === undefined) return undefined;
+  if (!value.awards) {
+    // Handle case where award fields are defined directly on funding.
+    // Do not warn on funding OR award keys.
+    validateKeys(
+      valueAsObj,
+      {
+        optional: [...FUNDING_KEYS, ...AWARD_KEYS],
+        alias: { ...FUNDING_ALIASES, ...AWARD_ALIASES },
+      },
+      opts,
+    );
+    const valueAsAward = validateObjectKeys(
+      input,
+      { optional: AWARD_KEYS, alias: AWARD_ALIASES },
+      { ...opts, suppressErrors: true, suppressWarnings: true },
+    );
+    if (valueAsAward && Object.keys(valueAsAward).length > 0) {
+      value.awards = [
+        validateObjectKeys(
+          input,
+          { optional: AWARD_KEYS, alias: AWARD_ALIASES },
+          { ...opts, suppressErrors: true, suppressWarnings: true },
+        ),
+      ];
+    }
+  } else {
+    // Handle case where award fields are defined directly on funding.
+    // Only do not warn on funding keys.
+    validateKeys(valueAsObj, { optional: FUNDING_KEYS, alias: FUNDING_ALIASES }, opts);
+  }
+  const output: Funding = {};
+  if (defined(value.statement)) {
+    output.statement = validateString(value.statement, incrementOptions('statement', opts));
+  }
+  if (defined(value.open_access)) {
+    output.open_access = validateString(value.open_access, incrementOptions('open_access', opts));
+  }
+  if (defined(value.awards)) {
+    const awards = Array.isArray(value.awards) ? value.awards : [value.awards];
+    output.awards = validateList(awards, incrementOptions('awards', opts), (award, index) => {
+      return validateAward(award, stash, incrementOptions(`awards.${index}`, opts));
+    });
+  }
+  return output;
+}

--- a/packages/myst-frontmatter/src/funding/validators.ts
+++ b/packages/myst-frontmatter/src/funding/validators.ts
@@ -10,7 +10,7 @@ import {
 import type { ValidationOptions } from 'simple-validators';
 import type { ReferenceStash } from '../frontmatter/types.js';
 import type { Award, Funding } from './types.js';
-import { validateAffiliation, validateAndStashObject, validateAuthor } from '../index.js';
+import { validateAffiliation, validateAndStashObject, validateContributor } from '../index.js';
 
 const AWARD_KEYS = ['id', 'name', 'description', 'sources', 'recipients', 'investigators'];
 const AWARD_ALIASES = { source: 'sources', recipient: 'recipients', investigator: 'investigators' };
@@ -57,8 +57,8 @@ export function validateAward(input: any, stash: ReferenceStash, opts: Validatio
         return validateAndStashObject(
           recipient,
           stash,
-          'authors',
-          (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+          'contributors',
+          (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
           incrementOptions(`recipients.${index}`, opts),
         );
       },
@@ -75,8 +75,8 @@ export function validateAward(input: any, stash: ReferenceStash, opts: Validatio
         return validateAndStashObject(
           investigator,
           stash,
-          'authors',
-          (v: any, o: ValidationOptions) => validateAuthor(v, stash, o),
+          'contributors',
+          (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
           incrementOptions(`investigators.${index}`, opts),
         );
       },

--- a/packages/myst-frontmatter/tests/affiliations.yml
+++ b/packages/myst-frontmatter/tests/affiliations.yml
@@ -49,11 +49,13 @@ cases:
   - title: Support QMD style affiliations (ref)
     raw:
       author:
-        - name: Norah Jones
+        - id: nj
+          name: Norah Jones
           affiliation:
             - ref: cmu
             - ref: chicago
-        - name: John Hamm
+        - id: jh
+          name: John Hamm
           affiliation:
             - ref: cmu
       affiliation:
@@ -63,18 +65,23 @@ cases:
           name: University of Chicago
     normalized:
       authors:
-        - name: Norah Jones
+        - id: nj
+          name: Norah Jones
           nameParsed:
             literal: Norah Jones
             given: Norah
             family: Jones
           affiliations: [cmu, chicago]
-        - name: John Hamm
+        - id: jh
+          name: John Hamm
           nameParsed:
             literal: John Hamm
             given: John
             family: Hamm
           affiliations: [cmu]
+      authorsSource:
+        - nj
+        - jh
       affiliations:
         - id: cmu
           name: Carnegie Mellon University
@@ -83,29 +90,36 @@ cases:
   - title: Support QMD style affiliations (inline reference)
     raw:
       author:
-        - name: Norah Jones
+        - id: nj
+          name: Norah Jones
           affiliation:
             - id: cmu
               name: Carnegie Mellon University
             - id: chicago
               name: University of Chicago
-        - name: John Hamm
+        - id: jh
+          name: John Hamm
           affiliation:
             - ref: cmu
     normalized:
       authors:
-        - name: Norah Jones
+        - id: nj
+          name: Norah Jones
           nameParsed:
             literal: Norah Jones
             given: Norah
             family: Jones
           affiliations: [cmu, chicago]
-        - name: John Hamm
+        - id: jh
+          name: John Hamm
           nameParsed:
             literal: John Hamm
             given: John
             family: Hamm
           affiliations: [cmu]
+      authorsSource:
+        - nj
+        - jh
       affiliations:
         - id: cmu
           name: Carnegie Mellon University
@@ -123,7 +137,8 @@ cases:
   - title: Author with reference to existing affiliation
     raw:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           affiliations:
             - univa
       affiliations:
@@ -131,57 +146,69 @@ cases:
           name: University A
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
             - univa
+      authorsSource:
+        - jn
       affiliations:
         - id: univa
           name: University A
   - title: Author with string affiliation resolves to top level
     raw:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           affiliations:
             - University A
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
             - University A
+      authorsSource:
+        - jn
       affiliations:
         - id: University A
           name: University A
   - title: Author with affiliation object resolves to top level
     raw:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           affiliations:
             - id: univa
               name: University A
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
             - univa
+      authorsSource:
+        - jn
       affiliations:
         - id: univa
           name: University A
   - title: Duplicate affiliation ids warn
     raw:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           affiliations:
             - id: univa
               name: University A
@@ -190,13 +217,16 @@ cases:
           name: University B
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
             - univa
+      authorsSource:
+        - jn
       affiliations:
         - id: univa
           name: University B
@@ -204,58 +234,72 @@ cases:
   - title: Duplicate affiliation strings resolve
     raw:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           affiliations:
             - University A
-        - name: A. Nother Name
+        - id: an
+          name: A. Nother Name
           affiliations:
             - University A
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
             - University A
-        - name: A. Nother Name
+        - id: an
+          name: A. Nother Name
           nameParsed:
             literal: A. Nother Name
             given: A. Nother
             family: Name
           affiliations:
             - University A
+      authorsSource:
+        - jn
+        - an
       affiliations:
         - id: University A
           name: University A
   - title: Duplicate affiliation objects resolve
     raw:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           affiliations:
             - name: University A
               url: https://example.com
-        - name: A. Nother Name
+        - id: an
+          name: A. Nother Name
           affiliations:
             - url: https://example.com
               name: University A
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
             - affiliations-generated-uid-0
-        - name: A. Nother Name
+        - id: an
+          name: A. Nother Name
           nameParsed:
             literal: A. Nother Name
             given: A. Nother
             family: Name
           affiliations:
             - affiliations-generated-uid-0
+      authorsSource:
+        - jn
+        - an
       affiliations:
         - id: affiliations-generated-uid-0
           name: University A
@@ -263,7 +307,8 @@ cases:
   - title: Author with affiliation object replaces id at top level
     raw:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           affiliations:
             - id: univa
               name: University A
@@ -271,13 +316,16 @@ cases:
         - univa
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           affiliations:
             - univa
+      authorsSource:
+        - jn
       affiliations:
         - id: univa
           name: University A

--- a/packages/myst-frontmatter/tests/affiliations.yml
+++ b/packages/myst-frontmatter/tests/affiliations.yml
@@ -42,7 +42,7 @@ cases:
         - id: affiliations-generated-uid-0
           name: University A
         - id: affiliations-generated-uid-1
-          institution: University B
+          name: University B
         - id: affiliations-generated-uid-2
           email: universityc@example.com
     warnings: 1

--- a/packages/myst-frontmatter/tests/affiliations.yml
+++ b/packages/myst-frontmatter/tests/affiliations.yml
@@ -79,9 +79,6 @@ cases:
             given: John
             family: Hamm
           affiliations: [cmu]
-      authorsSource:
-        - nj
-        - jh
       affiliations:
         - id: cmu
           name: Carnegie Mellon University
@@ -117,9 +114,6 @@ cases:
             given: John
             family: Hamm
           affiliations: [cmu]
-      authorsSource:
-        - nj
-        - jh
       affiliations:
         - id: cmu
           name: Carnegie Mellon University
@@ -154,8 +148,6 @@ cases:
             family: Name
           affiliations:
             - univa
-      authorsSource:
-        - jn
       affiliations:
         - id: univa
           name: University A
@@ -176,8 +168,6 @@ cases:
             family: Name
           affiliations:
             - University A
-      authorsSource:
-        - jn
       affiliations:
         - id: University A
           name: University A
@@ -199,8 +189,6 @@ cases:
             family: Name
           affiliations:
             - univa
-      authorsSource:
-        - jn
       affiliations:
         - id: univa
           name: University A
@@ -225,8 +213,6 @@ cases:
             family: Name
           affiliations:
             - univa
-      authorsSource:
-        - jn
       affiliations:
         - id: univa
           name: University B
@@ -260,9 +246,6 @@ cases:
             family: Name
           affiliations:
             - University A
-      authorsSource:
-        - jn
-        - an
       affiliations:
         - id: University A
           name: University A
@@ -297,9 +280,6 @@ cases:
             family: Name
           affiliations:
             - affiliations-generated-uid-0
-      authorsSource:
-        - jn
-        - an
       affiliations:
         - id: affiliations-generated-uid-0
           name: University A
@@ -324,8 +304,6 @@ cases:
             family: Name
           affiliations:
             - univa
-      authorsSource:
-        - jn
       affiliations:
         - id: univa
           name: University A

--- a/packages/myst-frontmatter/tests/authors.yml
+++ b/packages/myst-frontmatter/tests/authors.yml
@@ -12,8 +12,6 @@ cases:
             literal: Just A. Name
             given: Just A.
             family: Name
-      authorsSource:
-        - Just A. Name
   - title: Simple Authors String
     raw:
       authors: Just A. Name
@@ -25,8 +23,6 @@ cases:
             literal: Just A. Name
             given: Just A.
             family: Name
-      authorsSource:
-        - Just A. Name
   - title: Use Author rather than author`s`
     raw:
       author: Just A. Name
@@ -38,8 +34,6 @@ cases:
             literal: Just A. Name
             given: Just A.
             family: Name
-      authorsSource:
-        - Just A. Name
   - title: Using both author and author`s` shows a warning
     raw:
       author: nope
@@ -52,8 +46,6 @@ cases:
             literal: Just A. Name
             given: Just A.
             family: Name
-      authorsSource:
-        - Just A. Name
     warnings: 1
   - title: Affiliations unpack semicolon-delimited lists
     raw:
@@ -72,8 +64,6 @@ cases:
           affiliations:
             - University
             - Company
-      authorsSource:
-        - jn
       affiliations:
         - id: University
           name: University
@@ -95,8 +85,6 @@ cases:
             family: Name
           email: example@example.com
           corresponding: true
-      authorsSource:
-        - jn
   - title: First email is corresponding (unless false)
     raw:
       author:
@@ -114,8 +102,6 @@ cases:
             family: Name
           email: example@example.com
           corresponding: false
-      authorsSource:
-        - jn
   - title: Respect corresponding flag
     raw:
       authors:
@@ -143,9 +129,6 @@ cases:
             family: Name
           email: example@example.com
           corresponding: true
-      authorsSource:
-        - jn
-        - an
   - title: Warn if author has no name
     raw:
       authors:
@@ -163,12 +146,9 @@ cases:
             given: Just A.
             family: Name
           email: example@example.com
-        - id: authors-generated-uid-1
+        - id: contributors-generated-uid-1
           email: example@example.com
           corresponding: true
-      authorsSource:
-        - jn
-        - authors-generated-uid-1
     warnings: 1
   - title: Warn if author has no family name
     raw:
@@ -177,13 +157,11 @@ cases:
             given: Someone
     normalized:
       authors:
-        - id: authors-generated-uid-0
+        - id: contributors-generated-uid-0
           name: ', Someone'
           nameParsed:
             literal: ', Someone'
             given: Someone
-      authorsSource:
-        - authors-generated-uid-0
     warnings: 1
   - title: Warn if author has no given name
     raw:
@@ -191,13 +169,11 @@ cases:
         - name: Someone
     normalized:
       authors:
-        - id: authors-generated-uid-0
+        - id: contributors-generated-uid-0
           name: 'Someone'
           nameParsed:
             literal: 'Someone'
             family: Someone
-      authorsSource:
-        - authors-generated-uid-0
     warnings: 1
   - title: Parsed name is maintained
     raw:
@@ -219,8 +195,6 @@ cases:
             non_dropping_particle: von
             family: Junior
             suffix: Jr.
-      authorsSource:
-        - jn
   - title: Name object with lots of commas warns
     raw:
       authors:
@@ -232,7 +206,7 @@ cases:
             suffix: warnings,
     normalized:
       authors:
-        - id: authors-generated-uid-0
+        - id: contributors-generated-uid-0
           name: Commas, here, are, great,
           nameParsed:
             literal: Commas, here, are, great,
@@ -240,8 +214,6 @@ cases:
             non_dropping_particle: here,
             family: are,
             suffix: warnings,
-      authorsSource:
-        - authors-generated-uid-0
     warnings: 4
   - title: Name string with extra comma warns
     raw:
@@ -249,15 +221,13 @@ cases:
         - name: A, B, C, D
     normalized:
       authors:
-        - id: authors-generated-uid-0
+        - id: contributors-generated-uid-0
           name: A, B, C, D
           nameParsed:
             literal: A, B, C, D
             given: D
             family: A, B
             suffix: C
-      authorsSource:
-        - authors-generated-uid-0
     warnings: 1
   - title: Display name expands
     raw:
@@ -273,8 +243,6 @@ cases:
             literal: Just A. Name
             given: Just A.
             family: Name
-      authorsSource:
-        - jn
   - title: Display name expands
     raw:
       authors:
@@ -289,8 +257,6 @@ cases:
             literal: Just A. Name
             given: Just A.
             family: Name
-      authorsSource:
-        - jn
   - title: Complex name renders
     raw:
       authors:
@@ -302,7 +268,7 @@ cases:
             suffix: E
     normalized:
       authors:
-        - id: authors-generated-uid-0
+        - id: contributors-generated-uid-0
           name: c D, E, A b
           nameParsed:
             literal: c D, E, A b
@@ -311,5 +277,3 @@ cases:
             non_dropping_particle: c
             family: D
             suffix: E
-      authorsSource:
-        - authors-generated-uid-0

--- a/packages/myst-frontmatter/tests/authors.yml
+++ b/packages/myst-frontmatter/tests/authors.yml
@@ -277,3 +277,36 @@ cases:
             non_dropping_particle: c
             family: D
             suffix: E
+  - title: Author that defines name and nameParsed still passes
+    raw:
+      authors:
+        - name: Just A. Name
+          nameParsed:
+            literal: Just A. Name
+            given: Just A.
+            family: Name
+    normalized:
+      authors:
+        - id: contributors-generated-uid-0
+          name: Just A. Name
+          nameParsed:
+            literal: Just A. Name
+            given: Just A.
+            family: Name
+  - title: Mismatch between name and nameParsed warns
+    raw:
+      authors:
+        - name: Different Name
+          nameParsed:
+            literal: Just A. Name
+            given: Just A.
+            family: Name
+    normalized:
+      authors:
+        - id: contributors-generated-uid-0
+          name: Different Name
+          nameParsed:
+            literal: Just A. Name
+            given: Just A.
+            family: Name
+    warnings: 1

--- a/packages/myst-frontmatter/tests/authors.yml
+++ b/packages/myst-frontmatter/tests/authors.yml
@@ -12,6 +12,8 @@ cases:
             literal: Just A. Name
             given: Just A.
             family: Name
+      authorsSource:
+        - Just A. Name
   - title: Simple Authors String
     raw:
       authors: Just A. Name
@@ -23,6 +25,8 @@ cases:
             literal: Just A. Name
             given: Just A.
             family: Name
+      authorsSource:
+        - Just A. Name
   - title: Use Author rather than author`s`
     raw:
       author: Just A. Name
@@ -34,6 +38,8 @@ cases:
             literal: Just A. Name
             given: Just A.
             family: Name
+      authorsSource:
+        - Just A. Name
   - title: Using both author and author`s` shows a warning
     raw:
       author: nope
@@ -46,15 +52,19 @@ cases:
             literal: Just A. Name
             given: Just A.
             family: Name
+      authorsSource:
+        - Just A. Name
     warnings: 1
   - title: Affiliations unpack semicolon-delimited lists
     raw:
       author:
+        id: jn
         name: Just A. Name
         affiliation: University; Company
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
@@ -62,6 +72,8 @@ cases:
           affiliations:
             - University
             - Company
+      authorsSource:
+        - jn
       affiliations:
         - id: University
           name: University
@@ -70,72 +82,93 @@ cases:
   - title: First email is corresponding
     raw:
       author:
+        id: jn
         name: Just A. Name
         email: example@example.com
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           email: example@example.com
           corresponding: true
+      authorsSource:
+        - jn
   - title: First email is corresponding (unless false)
     raw:
       author:
+        id: jn
         name: Just A. Name
         email: example@example.com
         corresponding: false
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           email: example@example.com
           corresponding: false
+      authorsSource:
+        - jn
   - title: Respect corresponding flag
     raw:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           email: example@example.com
-        - name: A. Nother Name
+        - id: an
+          name: A. Nother Name
           email: example@example.com
           corresponding: true
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           email: example@example.com
-        - name: A. Nother Name
+        - id: an
+          name: A. Nother Name
           nameParsed:
             literal: A. Nother Name
             given: A. Nother
             family: Name
           email: example@example.com
           corresponding: true
+      authorsSource:
+        - jn
+        - an
   - title: Warn if author has no name
     raw:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           email: example@example.com
         - email: example@example.com
           corresponding: true
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           email: example@example.com
-        - email: example@example.com
+        - id: authors-generated-uid-1
+          email: example@example.com
           corresponding: true
+      authorsSource:
+        - jn
+        - authors-generated-uid-1
     warnings: 1
   - title: Warn if author has no family name
     raw:
@@ -144,10 +177,13 @@ cases:
             given: Someone
     normalized:
       authors:
-        - name: ', Someone'
+        - id: authors-generated-uid-0
+          name: ', Someone'
           nameParsed:
             literal: ', Someone'
             given: Someone
+      authorsSource:
+        - authors-generated-uid-0
     warnings: 1
   - title: Warn if author has no given name
     raw:
@@ -155,15 +191,19 @@ cases:
         - name: Someone
     normalized:
       authors:
-        - name: 'Someone'
+        - id: authors-generated-uid-0
+          name: 'Someone'
           nameParsed:
             literal: 'Someone'
             family: Someone
+      authorsSource:
+        - authors-generated-uid-0
     warnings: 1
   - title: Parsed name is maintained
     raw:
       authors:
-        - name:
+        - id: jn
+          name:
             literal: Just A. Name
             given: Little
             non_dropping_particle: von
@@ -171,13 +211,16 @@ cases:
             suffix: Jr.
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Little
             non_dropping_particle: von
             family: Junior
             suffix: Jr.
+      authorsSource:
+        - jn
   - title: Name object with lots of commas warns
     raw:
       authors:
@@ -189,13 +232,16 @@ cases:
             suffix: warnings,
     normalized:
       authors:
-        - name: Commas, here, are, great,
+        - id: authors-generated-uid-0
+          name: Commas, here, are, great,
           nameParsed:
             literal: Commas, here, are, great,
             given: Commas,
             non_dropping_particle: here,
             family: are,
             suffix: warnings,
+      authorsSource:
+        - authors-generated-uid-0
     warnings: 4
   - title: Name string with extra comma warns
     raw:
@@ -203,37 +249,48 @@ cases:
         - name: A, B, C, D
     normalized:
       authors:
-        - name: A, B, C, D
+        - id: authors-generated-uid-0
+          name: A, B, C, D
           nameParsed:
             literal: A, B, C, D
             given: D
             family: A, B
             suffix: C
+      authorsSource:
+        - authors-generated-uid-0
     warnings: 1
   - title: Display name expands
     raw:
       authors:
-        - name:
+        - id: jn
+          name:
             literal: Just A. Name
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
+      authorsSource:
+        - jn
   - title: Display name expands
     raw:
       authors:
-        - name:
+        - id: jn
+          name:
             literal: Just A. Name
     normalized:
       authors:
-        - name: Just A. Name
+        - id: jn
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
+      authorsSource:
+        - jn
   - title: Complex name renders
     raw:
       authors:
@@ -245,7 +302,8 @@ cases:
             suffix: E
     normalized:
       authors:
-        - name: c D, E, A b
+        - id: authors-generated-uid-0
+          name: c D, E, A b
           nameParsed:
             literal: c D, E, A b
             given: A
@@ -253,3 +311,5 @@ cases:
             non_dropping_particle: c
             family: D
             suffix: E
+      authorsSource:
+        - authors-generated-uid-0

--- a/packages/myst-frontmatter/tests/credit.yml
+++ b/packages/myst-frontmatter/tests/credit.yml
@@ -7,7 +7,7 @@ cases:
           role: conceptualiSation
     normalized:
       authors:
-        - id: authors-generated-uid-0
+        - id: contributors-generated-uid-0
           name: Just A. Name
           nameParsed:
             literal: Just A. Name
@@ -15,8 +15,6 @@ cases:
             family: Name
           roles:
             - Conceptualization
-      authorsSource:
-        - authors-generated-uid-0
   - title: String list
     raw:
       authors:
@@ -24,7 +22,7 @@ cases:
           roles: conceptualiSation, supervision
     normalized:
       authors:
-        - id: authors-generated-uid-0
+        - id: contributors-generated-uid-0
           name: Just A. Name
           nameParsed:
             literal: Just A. Name
@@ -33,8 +31,6 @@ cases:
           roles:
             - Conceptualization
             - Supervision
-      authorsSource:
-        - authors-generated-uid-0
   - title: Coerces common actions into full roles
     raw:
       authors:
@@ -42,7 +38,7 @@ cases:
           role: Editing
     normalized:
       authors:
-        - id: authors-generated-uid-0
+        - id: contributors-generated-uid-0
           name: Just A. Name
           nameParsed:
             literal: Just A. Name
@@ -50,8 +46,6 @@ cases:
             family: Name
           roles:
             - Writing – review & editing
-      authorsSource:
-        - authors-generated-uid-0
   - title: Any role, but raise a warning
     raw:
       authors:
@@ -59,7 +53,7 @@ cases:
           role: Hustling for grants
     normalized:
       authors:
-        - id: authors-generated-uid-0
+        - id: contributors-generated-uid-0
           name: Just A. Name
           nameParsed:
             literal: Just A. Name
@@ -67,6 +61,4 @@ cases:
             family: Name
           roles:
             - Hustling for grants
-      authorsSource:
-        - authors-generated-uid-0
     warnings: 1

--- a/packages/myst-frontmatter/tests/credit.yml
+++ b/packages/myst-frontmatter/tests/credit.yml
@@ -7,13 +7,16 @@ cases:
           role: conceptualiSation
     normalized:
       authors:
-        - name: Just A. Name
+        - id: authors-generated-uid-0
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           roles:
             - Conceptualization
+      authorsSource:
+        - authors-generated-uid-0
   - title: String list
     raw:
       authors:
@@ -21,7 +24,8 @@ cases:
           roles: conceptualiSation, supervision
     normalized:
       authors:
-        - name: Just A. Name
+        - id: authors-generated-uid-0
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
@@ -29,6 +33,8 @@ cases:
           roles:
             - Conceptualization
             - Supervision
+      authorsSource:
+        - authors-generated-uid-0
   - title: Coerces common actions into full roles
     raw:
       authors:
@@ -36,13 +42,16 @@ cases:
           role: Editing
     normalized:
       authors:
-        - name: Just A. Name
+        - id: authors-generated-uid-0
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           roles:
             - Writing – review & editing
+      authorsSource:
+        - authors-generated-uid-0
   - title: Any role, but raise a warning
     raw:
       authors:
@@ -50,11 +59,14 @@ cases:
           role: Hustling for grants
     normalized:
       authors:
-        - name: Just A. Name
+        - id: authors-generated-uid-0
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           roles:
             - Hustling for grants
+      authorsSource:
+        - authors-generated-uid-0
     warnings: 1

--- a/packages/myst-frontmatter/tests/examples.spec.ts
+++ b/packages/myst-frontmatter/tests/examples.spec.ts
@@ -26,10 +26,11 @@ const files = [
   'affiliations.yml',
   'authors.yml',
   'credit.yml',
-  'orcid.yml',
-  'licenses.yml',
   'exports.yml',
+  'funding.yml',
   'keywords.yml',
+  'licenses.yml',
+  'orcid.yml',
   'thebe.yml',
 ];
 

--- a/packages/myst-frontmatter/tests/examples.spec.ts
+++ b/packages/myst-frontmatter/tests/examples.spec.ts
@@ -77,6 +77,9 @@ casesList.forEach(({ title, frontmatter, cases }) => {
         }
         expect(opts.messages.warnings?.length ?? 0).toBe(warnings ?? 0);
         expect(opts.messages.errors?.length ?? 0).toBe(errors ?? 0);
+
+        // Test that normalized frontmatter is idempotent
+        expect(validator(normalized, opts)).toEqual(normalized);
       },
     );
   });

--- a/packages/myst-frontmatter/tests/funding.yml
+++ b/packages/myst-frontmatter/tests/funding.yml
@@ -29,7 +29,7 @@ cases:
               recipients:
                 - John Doe
         - open_access: my statement 2
-      authors:
+      contributors:
         - id: John Doe
           name: John Doe
           nameParsed:
@@ -97,7 +97,7 @@ cases:
             - id: abc-123
               investigators:
                 - John Doe
-      authors:
+      contributors:
         - id: John Doe
           name: John Doe
           nameParsed:
@@ -118,7 +118,7 @@ cases:
             - id: abc-123
               recipients:
                 - John Doe
-      authors:
+      contributors:
         - id: John Doe
           name: John Doe
           nameParsed:
@@ -148,20 +148,20 @@ cases:
               sources:
                 - University A
               recipients:
-                - authors-generated-uid-0
+                - contributors-generated-uid-0
               investigators:
-                - authors-generated-uid-1
+                - contributors-generated-uid-1
       affiliations:
         - id: University A
           name: University A
-      authors:
-        - id: authors-generated-uid-0
+      contributors:
+        - id: contributors-generated-uid-0
           name: Jane Doe
           nameParsed:
             literal: Jane Doe
             given: Jane
             family: Doe
-        - id: authors-generated-uid-1
+        - id: contributors-generated-uid-1
           name: John Doe
           nameParsed:
             literal: John Doe
@@ -192,23 +192,61 @@ cases:
               sources:
                 - University A
               recipients:
-                - authors-generated-uid-0
+                - contributors-generated-uid-0
               investigators:
-                - authors-generated-uid-1
+                - contributors-generated-uid-1
       affiliations:
         - id: University A
           name: University A
-      authors:
-        - id: authors-generated-uid-0
+      contributors:
+        - id: contributors-generated-uid-0
           name: Jane Doe
           nameParsed:
             literal: Jane Doe
             given: Jane
             family: Doe
-        - id: authors-generated-uid-1
+        - id: contributors-generated-uid-1
           name: John Doe
           nameParsed:
             literal: John Doe
             given: John
             family: Doe
     warnings: 1
+  - title: Funding contributor and author is persisted in authors
+    raw:
+      funding:
+        - statement: my statement 1
+          awards:
+            - id: abc-123
+              name: Award
+              description: my award
+              sources:
+                - University A
+              investigators:
+                - John Doe
+              recipients:
+                - John Doe
+      author: John Doe
+    normalized:
+      funding:
+        - statement: my statement 1
+          awards:
+            - id: abc-123
+              name: Award
+              description: my award
+              sources:
+                - University A
+              investigators:
+                - John Doe
+              recipients:
+                - John Doe
+      authors:
+        - id: John Doe
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            family: Doe
+            given: John
+      affiliations:
+        - id: University A
+          name: University A

--- a/packages/myst-frontmatter/tests/funding.yml
+++ b/packages/myst-frontmatter/tests/funding.yml
@@ -1,0 +1,214 @@
+title: Funding
+cases:
+  - title: Full funding object passes
+    raw:
+      funding:
+        - statement: my statement 1
+          awards:
+            - id: abc-123
+              name: Award
+              description: my award
+              sources:
+                - University A
+              investigators:
+                - John Doe
+              recipients:
+                - John Doe
+        - open_access: my statement 2
+    normalized:
+      funding:
+        - statement: my statement 1
+          awards:
+            - id: abc-123
+              name: Award
+              description: my award
+              sources:
+                - University A
+              investigators:
+                - John Doe
+              recipients:
+                - John Doe
+        - open_access: my statement 2
+      authors:
+        - id: John Doe
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            family: Doe
+            given: John
+      affiliations:
+        - id: University A
+          name: University A
+  - title: String coerces to statement
+    raw:
+      funding: my statement
+    normalized:
+      funding:
+        - statement: my statement
+  - title: Funding object coerces to list
+    raw:
+      funding:
+        statement: my statement
+    normalized:
+      funding:
+        - statement: my statement
+  - title: Award object coerces to list
+    raw:
+      funding:
+        statement: my statement
+        award:
+          id: abc-123
+    normalized:
+      funding:
+        - statement: my statement
+          awards:
+            - id: abc-123
+  - title: Source object coerces to list
+    raw:
+      funding:
+        - statement: my statement
+          award:
+            - id: abc-123
+              source: univa
+      affiliations:
+        - id: univa
+          name: University A
+    normalized:
+      funding:
+        - statement: my statement
+          awards:
+            - id: abc-123
+              sources:
+                - univa
+      affiliations:
+        - id: univa
+          name: University A
+  - title: Investigator object coerces to list
+    raw:
+      funding:
+        - statement: my statement
+          award:
+            - id: abc-123
+              investigator: John Doe
+    normalized:
+      funding:
+        - statement: my statement
+          awards:
+            - id: abc-123
+              investigators:
+                - John Doe
+      authors:
+        - id: John Doe
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            given: John
+            family: Doe
+  - title: Recipient object coerces to list
+    raw:
+      funding:
+        - statement: my statement
+          award:
+            - id: abc-123
+              recipient: John Doe
+    normalized:
+      funding:
+        - statement: my statement
+          awards:
+            - id: abc-123
+              recipients:
+                - John Doe
+      authors:
+        - id: John Doe
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            given: John
+            family: Doe
+  - title: Award fields on funding coerce to object
+    raw:
+      funding:
+        statement: my statement 1
+        id: abc-123
+        name: Award
+        description: my award
+        sources:
+          - University A
+        investigators:
+          - name: John Doe
+        recipients:
+          - name: Jane Doe
+    normalized:
+      funding:
+        - statement: my statement 1
+          awards:
+            - id: abc-123
+              name: Award
+              description: my award
+              sources:
+                - University A
+              recipients:
+                - authors-generated-uid-0
+              investigators:
+                - authors-generated-uid-1
+      affiliations:
+        - id: University A
+          name: University A
+      authors:
+        - id: authors-generated-uid-0
+          name: Jane Doe
+          nameParsed:
+            literal: Jane Doe
+            given: Jane
+            family: Doe
+        - id: authors-generated-uid-1
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            given: John
+            family: Doe
+  - title: Award fields on funding warn if 'awards' is also present
+    raw:
+      funding:
+        statement: my statement 1
+        source: University B
+        award:
+          id: abc-123
+          name: Award
+          description: my award
+          sources:
+            - University A
+          investigators:
+            - name: John Doe
+          recipients:
+            - name: Jane Doe
+    normalized:
+      funding:
+        - statement: my statement 1
+          awards:
+            - id: abc-123
+              name: Award
+              description: my award
+              sources:
+                - University A
+              recipients:
+                - authors-generated-uid-0
+              investigators:
+                - authors-generated-uid-1
+      affiliations:
+        - id: University A
+          name: University A
+      authors:
+        - id: authors-generated-uid-0
+          name: Jane Doe
+          nameParsed:
+            literal: Jane Doe
+            given: Jane
+            family: Doe
+        - id: authors-generated-uid-1
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            given: John
+            family: Doe
+    warnings: 1

--- a/packages/myst-frontmatter/tests/funding.yml
+++ b/packages/myst-frontmatter/tests/funding.yml
@@ -250,3 +250,56 @@ cases:
       affiliations:
         - id: University A
           name: University A
+  - title: Non-funding contributors remain
+    raw:
+      funding:
+        - statement: my statement 1
+          awards:
+            - id: abc-123
+              name: Award
+              description: my award
+              sources:
+                - University A
+              investigators:
+                - John Doe
+              recipients:
+                - Jane Doe
+      author: John Doe
+      contributor: Doe, Jr., John
+    normalized:
+      funding:
+        - statement: my statement 1
+          awards:
+            - id: abc-123
+              name: Award
+              description: my award
+              sources:
+                - University A
+              investigators:
+                - John Doe
+              recipients:
+                - Jane Doe
+      authors:
+        - id: John Doe
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            family: Doe
+            given: John
+      contributors:
+        - id: Doe, Jr., John
+          name: Doe, Jr., John
+          nameParsed:
+            literal: Doe, Jr., John
+            family: Doe
+            given: John
+            suffix: Jr.
+        - id: Jane Doe
+          name: Jane Doe
+          nameParsed:
+            literal: Jane Doe
+            family: Doe
+            given: Jane
+      affiliations:
+        - id: University A
+          name: University A

--- a/packages/myst-frontmatter/tests/orcid.yml
+++ b/packages/myst-frontmatter/tests/orcid.yml
@@ -7,15 +7,13 @@ cases:
           orcid: 0000-0000-0000-0000
     normalized:
       authors:
-        - id: authors-generated-uid-0
+        - id: contributors-generated-uid-0
           name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           orcid: 0000-0000-0000-0000
-      authorsSource:
-        - authors-generated-uid-0
   - title: Using http
     raw:
       authors:
@@ -23,15 +21,13 @@ cases:
           orcid: https://orcid.org/0000-0000-0000-000X
     normalized:
       authors:
-        - id: authors-generated-uid-0
+        - id: contributors-generated-uid-0
           name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           orcid: 0000-0000-0000-000X
-      authorsSource:
-        - authors-generated-uid-0
   - title: Not a valid ORCID
     raw:
       authors:
@@ -39,12 +35,10 @@ cases:
           orcid: nope
     normalized:
       authors:
-        - id: authors-generated-uid-0
+        - id: contributors-generated-uid-0
           name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
-      authorsSource:
-        - authors-generated-uid-0
     errors: 1

--- a/packages/myst-frontmatter/tests/orcid.yml
+++ b/packages/myst-frontmatter/tests/orcid.yml
@@ -7,12 +7,15 @@ cases:
           orcid: 0000-0000-0000-0000
     normalized:
       authors:
-        - name: Just A. Name
+        - id: authors-generated-uid-0
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           orcid: 0000-0000-0000-0000
+      authorsSource:
+        - authors-generated-uid-0
   - title: Using http
     raw:
       authors:
@@ -20,12 +23,15 @@ cases:
           orcid: https://orcid.org/0000-0000-0000-000X
     normalized:
       authors:
-        - name: Just A. Name
+        - id: authors-generated-uid-0
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
           orcid: 0000-0000-0000-000X
+      authorsSource:
+        - authors-generated-uid-0
   - title: Not a valid ORCID
     raw:
       authors:
@@ -33,9 +39,12 @@ cases:
           orcid: nope
     normalized:
       authors:
-        - name: Just A. Name
+        - id: authors-generated-uid-0
+          name: Just A. Name
           nameParsed:
             literal: Just A. Name
             given: Just A.
             family: Name
+      authorsSource:
+        - authors-generated-uid-0
     errors: 1

--- a/packages/myst-templates/src/frontmatter.ts
+++ b/packages/myst-templates/src/frontmatter.ts
@@ -1,4 +1,4 @@
-import type { Author, PageFrontmatter } from 'myst-frontmatter';
+import type { Contributor, PageFrontmatter } from 'myst-frontmatter';
 import type { RendererAuthor, RendererDoc, ValueAndIndex } from './types.js';
 
 const ALPHA = 'ABCDEFGHIJKLMNOPQURSUVWXYZ';
@@ -15,7 +15,7 @@ function undefinedIfEmpty<T>(array?: T[]): T[] | undefined {
 }
 
 function addIndicesToAuthors(
-  authors: Author[],
+  authors: Contributor[],
   affiliationList: RendererDoc['affiliations'],
   collaborationList: RendererDoc['collaborations'],
 ): RendererAuthor[] {

--- a/packages/myst-templates/src/types.ts
+++ b/packages/myst-templates/src/types.ts
@@ -1,6 +1,6 @@
 import type { ISession as BaseISession } from 'myst-cli-utils';
 import type { TemplateKind, TemplateOptionType } from 'myst-common';
-import type { Affiliation, Author, Licenses, PageFrontmatter } from 'myst-frontmatter';
+import type { Affiliation, Contributor, Licenses, PageFrontmatter } from 'myst-frontmatter';
 import { PAGE_FRONTMATTER_KEYS } from 'myst-frontmatter';
 
 export interface ISession extends BaseISession {
@@ -14,7 +14,7 @@ export type ValueAndIndex = {
 };
 
 export type RendererAuthor = Omit<
-  Author,
+  Contributor,
   'affiliations' | 'collaborations' | 'corresponding' | 'orcid'
 > & {
   affiliations?: ValueAndIndex[];
@@ -84,7 +84,7 @@ type TemplateYmlListPartial = {
   title?: string;
   description?: string;
   version?: string;
-  authors?: Author[];
+  authors?: Contributor[];
   affiliations?: Affiliation[];
   license?: Licenses;
   tags?: string[];

--- a/packages/myst-templates/src/validators.ts
+++ b/packages/myst-templates/src/validators.ts
@@ -9,7 +9,7 @@ import {
   RESERVED_EXPORT_KEYS,
   validateAffiliation,
   validateAndStashObject,
-  validateAuthor,
+  validateContributor,
   validateGithubUrl,
   validateLicenses,
   validatePageFrontmatter,
@@ -505,7 +505,7 @@ export function validateTemplateYml(
       value.authors,
       incrementOptions('authors', opts),
       (author, index) => {
-        return validateAuthor(author, stash, incrementOptions(`authors.${index}`, opts));
+        return validateContributor(author, stash, incrementOptions(`authors.${index}`, opts));
       },
     );
   }

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -379,6 +379,110 @@ export function getKwdGroup(frontmatter: ProjectFrontmatter): Element[] {
   return kwds ? [{ type: 'element', name: 'kwd-group', elements: kwds }] : [];
 }
 
+export function getFundingGroup(frontmatter: ProjectFrontmatter): Element[] {
+  const fundingGroups = frontmatter.funding?.map((fund): Element => {
+    const elements: Element[] = [];
+    if (fund.awards?.length) {
+      elements.push(
+        ...fund.awards.map((award): Element => {
+          const awardElements: Element[] = [];
+          if (award.sources?.length) {
+            awardElements.push(
+              ...award.sources.map((source): Element => {
+                return {
+                  type: 'element',
+                  name: 'funding-source',
+                  elements: [
+                    {
+                      type: 'element',
+                      name: 'xref',
+                      attributes: { 'ref-type': 'aff', rid: source },
+                    },
+                  ],
+                };
+              }),
+            );
+          }
+          if (award.id) {
+            awardElements.push({
+              type: 'element',
+              name: 'award-id',
+              elements: [{ type: 'text', text: award.id }],
+            });
+          }
+          if (award.name) {
+            awardElements.push({
+              type: 'element',
+              name: 'award-name',
+              elements: [{ type: 'text', text: award.name }],
+            });
+          }
+          if (award.description) {
+            awardElements.push({
+              type: 'element',
+              name: 'award-desc',
+              elements: [{ type: 'text', text: award.description }],
+            });
+          }
+          if (award.recipients?.length) {
+            awardElements.push(
+              ...award.recipients.map((recipient): Element => {
+                return {
+                  type: 'element',
+                  name: 'principal-award-recipient',
+                  elements: [
+                    {
+                      type: 'element',
+                      name: 'xref',
+                      attributes: { 'ref-type': 'contrib', rid: recipient },
+                    },
+                  ],
+                };
+              }),
+            );
+          }
+          if (award.investigators?.length) {
+            awardElements.push(
+              ...award.investigators.map((investigator): Element => {
+                return {
+                  type: 'element',
+                  name: 'principal-investigator',
+                  elements: [
+                    {
+                      type: 'element',
+                      name: 'xref',
+                      attributes: { 'ref-type': 'contrib', rid: investigator },
+                    },
+                  ],
+                };
+              }),
+            );
+          }
+          return { type: 'element', name: 'award-group', elements: awardElements };
+        }),
+      );
+    }
+    if (fund.statement) {
+      elements.push({
+        type: 'element',
+        name: 'funding-statement',
+        elements: [{ type: 'text', text: fund.statement }],
+      });
+    }
+    if (fund.open_access) {
+      elements.push({
+        type: 'element',
+        name: 'open-access',
+        elements: [
+          { type: 'element', name: 'p', elements: [{ type: 'text', text: fund.open_access }] },
+        ],
+      });
+    }
+    return { type: 'element', name: 'funding-group', elements };
+  });
+  return fundingGroups ? fundingGroups : [];
+}
+
 export function getArticleVolume(frontmatter: ProjectFrontmatter): Element[] {
   const text = frontmatter.biblio?.volume;
   return text
@@ -450,7 +554,7 @@ export function getArticleMeta(frontmatter?: ProjectFrontmatter, state?: IJatsSe
       // related-article, related-object
       // trans-abstract
       ...getKwdGroup(frontmatter),
-      // funding-group
+      ...getFundingGroup(frontmatter),
       // support-group
       // conference
       // counts

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -86,9 +86,6 @@ export function getArticleTitle(frontmatter: ProjectFrontmatter): Element[] {
 }
 
 export function getArticleAuthors(frontmatter: ProjectFrontmatter): Element[] {
-  // For now this just uses affiliations directly on each <contrib>, as they are defined in ProjectFrontmatter.
-  // This should be changed to deduplicate / improve affiliations in frontmatter.
-  // contrib-group, aff, aff-alternatives, x
   const contribs = frontmatter.authors?.map((author): Element => {
     const attributes: Record<string, any> = {};
     const elements: Element[] = [];
@@ -199,38 +196,131 @@ export function getArticleAuthors(frontmatter: ProjectFrontmatter): Element[] {
 }
 
 export function getArticleAffiliations(frontmatter: ProjectFrontmatter): Element[] {
+  console.log(JSON.stringify(frontmatter, null, 2));
   const affs = frontmatter.affiliations?.map((affiliation): Element => {
     const elements: Element[] = [];
     const attributes: Record<string, any> = {};
     if (affiliation.id) {
       attributes.id = affiliation.id;
     }
-    if (affiliation.institution ?? affiliation.name) {
-      elements.push({
+    const instWrapElements: Element[] = [];
+    if (affiliation.name) {
+      instWrapElements.push({
         type: 'element',
         name: 'institution',
-        elements: [{ type: 'text', text: affiliation.institution ?? affiliation.name }],
+        elements: [{ type: 'text', text: affiliation.name }],
       });
     }
-    // department
-    // address
-    // city
-    // state
-    // postal_code
-    // country
-    // collaboration
-    // isni
-    // ringgold
-    // ror
-    // url
-    // email
-    // phone
-    // fax
+    if (affiliation.isni) {
+      instWrapElements.push({
+        type: 'element',
+        name: 'institution-id',
+        attributes: { 'institution-id-type': 'isni' },
+        elements: [{ type: 'text', text: affiliation.isni }],
+      });
+    }
+    if (affiliation.ringgold) {
+      instWrapElements.push({
+        type: 'element',
+        name: 'institution-id',
+        attributes: { 'institution-id-type': 'ringgold' },
+        elements: [{ type: 'text', text: `${affiliation.ringgold}` }],
+      });
+    }
+    if (affiliation.ror) {
+      instWrapElements.push({
+        type: 'element',
+        name: 'institution-id',
+        attributes: { 'institution-id-type': 'ror' },
+        elements: [{ type: 'text', text: affiliation.ror }],
+      });
+    }
+    if (instWrapElements.length) {
+      elements.push({ type: 'element', name: 'institution-wrap', elements: instWrapElements });
+    }
+    if (affiliation.department) {
+      elements.push({
+        type: 'element',
+        name: 'institution-wrap',
+        elements: [
+          {
+            type: 'element',
+            name: 'institution',
+            attributes: { 'content-type': 'dept' },
+            elements: [{ type: 'text', text: affiliation.department }],
+          },
+        ],
+      });
+    }
+    if (affiliation.address) {
+      elements.push({
+        type: 'element',
+        name: 'addr-line',
+        elements: [{ type: 'text', text: affiliation.address }],
+      });
+    }
+    if (affiliation.city) {
+      elements.push({
+        type: 'element',
+        name: 'city',
+        elements: [{ type: 'text', text: affiliation.city }],
+      });
+    }
+    if (affiliation.state) {
+      elements.push({
+        type: 'element',
+        name: 'state',
+        elements: [{ type: 'text', text: affiliation.state }],
+      });
+    }
+    if (affiliation.postal_code) {
+      elements.push({
+        type: 'element',
+        name: 'postal-code',
+        elements: [{ type: 'text', text: affiliation.postal_code }],
+      });
+    }
+    if (affiliation.country) {
+      elements.push({
+        type: 'element',
+        name: 'country',
+        elements: [{ type: 'text', text: affiliation.country }],
+      });
+    }
+    if (affiliation.phone) {
+      elements.push({
+        type: 'element',
+        name: 'phone',
+        elements: [{ type: 'text', text: affiliation.phone }],
+      });
+    }
+    if (affiliation.fax) {
+      elements.push({
+        type: 'element',
+        name: 'fax',
+        elements: [{ type: 'text', text: affiliation.fax }],
+      });
+    }
+    if (affiliation.email) {
+      elements.push({
+        type: 'element',
+        name: 'email',
+        elements: [{ type: 'text', text: affiliation.email }],
+      });
+    }
+    if (affiliation.url) {
+      elements.push({
+        type: 'element',
+        name: 'ext-link',
+        attributes: { 'ext-link-type': 'uri', 'xlink:href': affiliation.url },
+        elements: [{ type: 'text', text: affiliation.url }],
+      });
+    }
     return {
       type: 'element',
       name: 'aff',
       attributes,
-      elements: [{ type: 'element', name: 'institution-wrap', elements }],
+      elements,
     };
   });
   return affs ? affs : [];
@@ -238,6 +328,7 @@ export function getArticleAffiliations(frontmatter: ProjectFrontmatter): Element
 
 export function getArticlePermissions(frontmatter: ProjectFrontmatter): Element[] {
   // copyright-statement, -year, -holder
+  if (frontmatter.authors) console.log(JSON.stringify(frontmatter, null, 2));
   const text = frontmatter.license?.content?.url ?? frontmatter.license?.code?.url;
   // Add `<ali:free_to_read />` to the permissions
   const freeToRead: Element[] = frontmatter.open_access

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -376,7 +376,7 @@ export function getKwdGroup(frontmatter: ProjectFrontmatter): Element[] {
   const kwds = frontmatter.keywords?.map((keyword): Element => {
     return { type: 'element', name: 'kwd', elements: [{ type: 'text', text: keyword }] };
   });
-  return kwds ? [{ type: 'element', name: 'kwd-group', elements: kwds }] : [];
+  return kwds?.length ? [{ type: 'element', name: 'kwd-group', elements: kwds }] : [];
 }
 
 export function getFundingGroup(frontmatter: ProjectFrontmatter): Element[] {

--- a/packages/myst-to-jats/tests/affiliations.yml
+++ b/packages/myst-to-jats/tests/affiliations.yml
@@ -1,0 +1,65 @@
+cases:
+  - title: Affiliation frontmatter
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    frontmatter:
+      affiliations:
+        - id: univa
+          name: University A
+        - id: univb
+          institution: University B
+          department: Department of Science
+          address: 123 Main St.
+          city: NYC
+          state: New York
+          postal_code: '10001'
+          country: USA
+          isni: '0000000000000000'
+          ringgold: 120000
+          ror: https://ror.edu/00abcd000
+          url: https://example.edu
+          email: example@example.edu
+          phone: 123-456-7890
+          fax: 123-456-7891
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <aff id="univa">
+              <institution-wrap>
+                <institution>University A</institution>
+              </institution-wrap>
+            </aff>
+            <aff id="univb">
+              <institution-wrap>
+                <institution>University B</institution>
+                <institution-id institution-id-type="isni">0000000000000000</institution-id>
+                <institution-id institution-id-type="ringgold">120000</institution-id>
+                <institution-id institution-id-type="ror">https://ror.edu/00abcd000</institution-id>
+              </institution-wrap>
+              <institution-wrap>
+                <institution content-type="dept">Department of Science</institution>
+              </institution-wrap>
+              <addr-line>123 Main St.</addr-line>
+              <city>NYC</city>
+              <state>New York</state>
+              <postal-code>10001</postal-code>
+              <country>USA</country>
+              <phone>123-456-7890</phone>
+              <fax>123-456-7891</fax>
+              <email>example@example.edu</email>
+              <ext-link ext-link-type="uri" xlink:href="https://example.edu">https://example.edu</ext-link>
+            </aff>
+          </article-meta>
+        </front>
+        <body>
+          <p>text</p>
+        </body>
+      </article>

--- a/packages/myst-to-jats/tests/article.yml
+++ b/packages/myst-to-jats/tests/article.yml
@@ -159,59 +159,6 @@ cases:
           <p>text</p>
         </body>
       </article>
-  - title: Author frontmatter
-    tree:
-      type: root
-      children:
-        - type: paragraph
-          children:
-            - type: text
-              value: text
-    frontmatter:
-      authors:
-        - name: Jane Doe
-          corresponding: true
-          orcid: abc-123
-          roles:
-            - credit role 1
-            - credit role 2
-          affiliations:
-            - University One
-            - University Two
-          email: example@example.com
-          url: https://example.com
-        - name: John Doe
-    jats: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
-      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
-        <front>
-          <article-meta>
-            <contrib-group>
-              <contrib contrib-type="author" corresp="yes">
-                <contrib-id contrib-id-type="orcid">abc-123</contrib-id>
-                <string-name>Jane Doe</string-name>
-                <role vocab="CRediT" vocab-identifier="http://credit.niso.org/" vocab-term="credit role 1">credit role 1</role>
-                <role vocab="CRediT" vocab-identifier="http://credit.niso.org/" vocab-term="credit role 2">credit role 2</role>
-                <aff>
-                  <institution>University One</institution>
-                </aff>
-                <aff>
-                  <institution>University Two</institution>
-                </aff>
-                <email>example@example.com</email>
-                <ext-link ext-link-type="uri" xlink:href="https://example.com">https://example.com</ext-link>
-              </contrib>
-              <contrib contrib-type="author">
-                <string-name>John Doe</string-name>
-              </contrib>
-            </contrib-group>
-          </article-meta>
-        </front>
-        <body>
-          <p>text</p>
-        </body>
-      </article>
   - title: Footnotes
     tree:
       type: root
@@ -285,5 +232,33 @@ cases:
         </front>
         <body>
           <p>My content.</p>
+        </body>
+      </article>
+  - title: Keywords frontmatter
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    frontmatter:
+      keywords:
+        - one
+        - two
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <kwd-group>
+              <kwd>one</kwd>
+              <kwd>two</kwd>
+            </kwd-group>
+          </article-meta>
+        </front>
+        <body>
+          <p>text</p>
         </body>
       </article>

--- a/packages/myst-to-jats/tests/article.yml
+++ b/packages/myst-to-jats/tests/article.yml
@@ -260,3 +260,24 @@ cases:
           <p>text</p>
         </body>
       </article>
+  - title: Empty keywords
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    frontmatter:
+      keywords: []
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta/>
+        </front>
+        <body>
+          <p>text</p>
+        </body>
+      </article>

--- a/packages/myst-to-jats/tests/article.yml
+++ b/packages/myst-to-jats/tests/article.yml
@@ -109,8 +109,7 @@ cases:
               value: text
     frontmatter:
       license:
-        content:
-          url: https://creativecommons.org/licenses/by/4.0
+        content: CC-BY-4.0
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
@@ -119,7 +118,7 @@ cases:
           <article-meta>
             <permissions>
               <license>
-                <ali:license_ref>https://creativecommons.org/licenses/by/4.0</ali:license_ref>
+                <ali:license_ref>https://creativecommons.org/licenses/by/4.0/</ali:license_ref>
               </license>
             </permissions>
           </article-meta>
@@ -139,8 +138,7 @@ cases:
     frontmatter:
       open_access: true
       license:
-        content:
-          url: https://creativecommons.org/licenses/by/4.0
+        content: CC-BY-4.0
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
@@ -150,7 +148,7 @@ cases:
             <permissions>
               <ali:free_to_read/>
               <license>
-                <ali:license_ref>https://creativecommons.org/licenses/by/4.0</ali:license_ref>
+                <ali:license_ref>https://creativecommons.org/licenses/by/4.0/</ali:license_ref>
               </license>
             </permissions>
           </article-meta>

--- a/packages/myst-to-jats/tests/authors.yml
+++ b/packages/myst-to-jats/tests/authors.yml
@@ -37,7 +37,7 @@ cases:
         <front>
           <article-meta>
             <contrib-group>
-              <contrib contrib-type="author" corresp="yes">
+              <contrib contrib-type="author" corresp="yes" id="contributors-generated-uid-0">
                 <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
                 <name>
                   <surname>Doe</surname>
@@ -50,7 +50,7 @@ cases:
                 <email>example@example.com</email>
                 <ext-link ext-link-type="uri" xlink:href="https://example.com">https://example.com</ext-link>
               </contrib>
-              <contrib contrib-type="author">
+              <contrib contrib-type="author" id="contributors-generated-uid-1">
                 <name>
                   <surname>Doe</surname>
                   <given-names>John</given-names>

--- a/packages/myst-to-jats/tests/authors.yml
+++ b/packages/myst-to-jats/tests/authors.yml
@@ -1,0 +1,108 @@
+cases:
+  - title: Author frontmatter
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    frontmatter:
+      authors:
+        - name: Jane Doe
+          nameParsed:
+            given: Jane
+            family: Doe
+          corresponding: true
+          orcid: abc-123
+          roles:
+            - credit role 1
+            - credit role 2
+          affiliations:
+            - univa
+          email: example@example.com
+          url: https://example.com
+        - name: John Doe Jr.
+          nameParsed:
+            given: John
+            family: Doe
+            suffix: Jr.
+      affiliations:
+        - id: univa
+          name: University A
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <contrib-group>
+              <contrib contrib-type="author" corresp="yes">
+                <contrib-id contrib-id-type="orcid">abc-123</contrib-id>
+                <name>
+                  <surname>Doe</surname>
+                  <given-names>Jane</given-names>
+                </name>
+                <string-name>Jane Doe</string-name>
+                <role vocab="CRediT" vocab-identifier="http://credit.niso.org/" vocab-term="credit role 1">credit role 1</role>
+                <role vocab="CRediT" vocab-identifier="http://credit.niso.org/" vocab-term="credit role 2">credit role 2</role>
+                <xref ref-type="aff" rid="univa"/>
+                <email>example@example.com</email>
+                <ext-link ext-link-type="uri" xlink:href="https://example.com">https://example.com</ext-link>
+              </contrib>
+              <contrib contrib-type="author">
+                <name>
+                  <surname>Doe</surname>
+                  <given-names>John</given-names>
+                  <suffix>Jr.</suffix>
+                </name>
+                <string-name>John Doe Jr.</string-name>
+              </contrib>
+            </contrib-group>
+            <aff id="univa">
+              <institution-wrap>
+                <institution>University A</institution>
+              </institution-wrap>
+            </aff>
+          </article-meta>
+        </front>
+        <body>
+          <p>text</p>
+        </body>
+      </article>
+  - title: Affiliation frontmatter
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    frontmatter:
+      affiliations:
+        - id: univa
+          name: University A
+        - id: univb
+          institution: University B
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <aff id="univa">
+              <institution-wrap>
+                <institution>University A</institution>
+              </institution-wrap>
+            </aff>
+            <aff id="univb">
+              <institution-wrap>
+                <institution>University B</institution>
+              </institution-wrap>
+            </aff>
+          </article-meta>
+        </front>
+        <body>
+          <p>text</p>
+        </body>
+      </article>

--- a/packages/myst-to-jats/tests/authors.yml
+++ b/packages/myst-to-jats/tests/authors.yml
@@ -14,7 +14,7 @@ cases:
             given: Jane
             family: Doe
           corresponding: true
-          orcid: abc-123
+          orcid: 0000-0000-0000-0000
           roles:
             - credit role 1
             - credit role 2
@@ -22,8 +22,8 @@ cases:
             - univa
           email: example@example.com
           url: https://example.com
-        - name: John Doe Jr.
-          nameParsed:
+        - name:
+            literal: John Doe Jr.
             given: John
             family: Doe
             suffix: Jr.
@@ -38,7 +38,7 @@ cases:
           <article-meta>
             <contrib-group>
               <contrib contrib-type="author" corresp="yes">
-                <contrib-id contrib-id-type="orcid">abc-123</contrib-id>
+                <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
                 <name>
                   <surname>Doe</surname>
                   <given-names>Jane</given-names>
@@ -62,42 +62,6 @@ cases:
             <aff id="univa">
               <institution-wrap>
                 <institution>University A</institution>
-              </institution-wrap>
-            </aff>
-          </article-meta>
-        </front>
-        <body>
-          <p>text</p>
-        </body>
-      </article>
-  - title: Affiliation frontmatter
-    tree:
-      type: root
-      children:
-        - type: paragraph
-          children:
-            - type: text
-              value: text
-    frontmatter:
-      affiliations:
-        - id: univa
-          name: University A
-        - id: univb
-          institution: University B
-    jats: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
-      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
-        <front>
-          <article-meta>
-            <aff id="univa">
-              <institution-wrap>
-                <institution>University A</institution>
-              </institution-wrap>
-            </aff>
-            <aff id="univb">
-              <institution-wrap>
-                <institution>University B</institution>
               </institution-wrap>
             </aff>
           </article-meta>

--- a/packages/myst-to-jats/tests/basic.spec.ts
+++ b/packages/myst-to-jats/tests/basic.spec.ts
@@ -89,6 +89,7 @@ describe('JATS full article', () => {
     ...loadCases('article.yml'),
     ...loadCases('authors.yml'),
     ...loadCases('citations.yml'),
+    ...loadCases('funding.yml'),
   ];
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
     '%s',

--- a/packages/myst-to-jats/tests/basic.spec.ts
+++ b/packages/myst-to-jats/tests/basic.spec.ts
@@ -118,6 +118,9 @@ describe('JATS multi-article', () => {
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
     '%s',
     async (_, { tree, jats, frontmatter, citations, subArticles }) => {
+      subArticles.forEach((subArticle) => {
+        subArticle.frontmatter = validateProjectFrontmatter(subArticle.frontmatter, opts);
+      });
       const vfile = writeJats(
         new VFile(),
         {

--- a/packages/myst-to-jats/tests/basic.spec.ts
+++ b/packages/myst-to-jats/tests/basic.spec.ts
@@ -1,8 +1,10 @@
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test } from 'vitest';
 import { unified } from 'unified';
 import fs from 'node:fs';
 import { Session, silentLogger } from 'myst-cli-utils';
+import { validateProjectFrontmatter } from 'myst-frontmatter';
 import { SourceFileKind } from 'myst-spec-ext';
+import type { ValidationOptions } from 'simple-validators';
 import path from 'node:path';
 import { validateJatsAgainstDtd } from 'jats-xml';
 import yaml from 'js-yaml';
@@ -64,8 +66,14 @@ async function writeValidateDelete(data: string) {
   return valid;
 }
 
+let opts: ValidationOptions;
+
+beforeEach(() => {
+  opts = { property: 'test', messages: {} };
+});
+
 describe('Basic JATS body', () => {
-  const cases = loadCases('basic.yml');
+  const cases = [...loadCases('basic.yml'), ...loadCases('siunit.yml')];
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))('%s', async (_, { tree, jats }) => {
     const pipe = unified().use(mystToJats, SourceFileKind.Article);
     pipe.runSync(tree as any);
@@ -77,6 +85,7 @@ describe('Basic JATS body', () => {
 
 describe('JATS full article', () => {
   const cases = [
+    ...loadCases('affiliations.yml'),
     ...loadCases('article.yml'),
     ...loadCases('authors.yml'),
     ...loadCases('citations.yml'),
@@ -87,7 +96,7 @@ describe('JATS full article', () => {
       const pipe = unified().use(
         mystToJats,
         SourceFileKind.Article,
-        frontmatter,
+        validateProjectFrontmatter(frontmatter, opts),
         citations,
         undefined,
         {
@@ -110,7 +119,12 @@ describe('JATS multi-article', () => {
     async (_, { tree, jats, frontmatter, citations, subArticles }) => {
       const vfile = writeJats(
         new VFile(),
-        { mdast: tree as any, kind: SourceFileKind.Article, frontmatter, citations },
+        {
+          mdast: tree as any,
+          kind: SourceFileKind.Article,
+          frontmatter: validateProjectFrontmatter(frontmatter, opts),
+          citations,
+        },
         {
           subArticles: subArticles as any,
           writeFullArticle: true,
@@ -123,26 +137,6 @@ describe('JATS multi-article', () => {
   );
 });
 
-describe('JATS SI units', () => {
-  const cases = loadCases('siunit.yml');
-  test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
-    '%s',
-    async (_, { tree, jats, frontmatter, citations }) => {
-      const vfile = writeJats(
-        new VFile(),
-        { mdast: tree as any, kind: SourceFileKind.Article, frontmatter, citations },
-        {
-          writeFullArticle: false,
-        },
-      );
-      expect(vfile.result).toEqual(jats);
-      if (TEST_DTD) {
-        expect(await writeValidateDelete(addHeader(vfile.result as string))).toBeTruthy();
-      }
-    },
-  );
-});
-
 describe('JATS full notebook', () => {
   const cases = loadCases('notebooks.yml');
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
@@ -151,7 +145,7 @@ describe('JATS full notebook', () => {
       const pipe = unified().use(
         mystToJats,
         SourceFileKind.Notebook,
-        frontmatter,
+        validateProjectFrontmatter(frontmatter, opts),
         citations,
         undefined,
         {

--- a/packages/myst-to-jats/tests/basic.spec.ts
+++ b/packages/myst-to-jats/tests/basic.spec.ts
@@ -76,31 +76,11 @@ describe('Basic JATS body', () => {
 });
 
 describe('JATS full article', () => {
-  const cases = loadCases('article.yml');
-  test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
-    '%s',
-    async (_, { tree, jats, frontmatter, citations }) => {
-      const pipe = unified().use(
-        mystToJats,
-        SourceFileKind.Article,
-        frontmatter,
-        citations,
-        undefined,
-        {
-          writeFullArticle: true,
-          spaces: 2,
-        },
-      );
-      pipe.runSync(tree as any);
-      const vfile = pipe.stringify(tree as any);
-      expect(vfile.result).toEqual(jats);
-      if (TEST_DTD) expect(await writeValidateDelete(vfile.result as string)).toBeTruthy();
-    },
-  );
-});
-
-describe('JATS full article with bibliography', () => {
-  const cases = loadCases('citations.yml');
+  const cases = [
+    ...loadCases('article.yml'),
+    ...loadCases('authors.yml'),
+    ...loadCases('citations.yml'),
+  ];
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
     '%s',
     async (_, { tree, jats, frontmatter, citations }) => {

--- a/packages/myst-to-jats/tests/funding.yml
+++ b/packages/myst-to-jats/tests/funding.yml
@@ -108,10 +108,18 @@ cases:
                 <award-name>Award</award-name>
                 <award-desc>my test award</award-desc>
                 <principal-award-recipient>
-                  <xref ref-type="contrib" rid="Jane Doe"/>
+                  <name>
+                    <surname>Doe</surname>
+                    <given-names>Jane</given-names>
+                  </name>
+                  <string-name>Jane Doe</string-name>
                 </principal-award-recipient>
                 <principal-investigator>
-                  <xref ref-type="contrib" rid="John Doe"/>
+                  <name>
+                    <surname>Doe</surname>
+                    <given-names>John</given-names>
+                  </name>
+                  <string-name>John Doe</string-name>
                 </principal-investigator>
               </award-group>
               <funding-statement>my funding statement</funding-statement>
@@ -134,6 +142,7 @@ cases:
       authors:
         - id: jd
           name: John Doe
+          orcid: 0000-0000-0000-0000
           affiliations:
             - id: univa
               name: University A
@@ -172,6 +181,7 @@ cases:
           <article-meta>
             <contrib-group>
               <contrib contrib-type="author" id="jd">
+                <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
                 <name>
                   <surname>Doe</surname>
                   <given-names>John</given-names>
@@ -214,13 +224,27 @@ cases:
                 <award-name>Award</award-name>
                 <award-desc>my test award</award-desc>
                 <principal-award-recipient>
-                  <xref ref-type="contrib" rid="contributors-generated-uid-1"/>
+                  <name>
+                    <surname>Doe</surname>
+                    <given-names>Jane</given-names>
+                  </name>
+                  <string-name>Jane Doe</string-name>
                 </principal-award-recipient>
                 <principal-award-recipient>
-                  <xref ref-type="contrib" rid="jd"/>
+                  <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
+                  <name>
+                    <surname>Doe</surname>
+                    <given-names>John</given-names>
+                  </name>
+                  <string-name>John Doe</string-name>
                 </principal-award-recipient>
                 <principal-investigator>
-                  <xref ref-type="contrib" rid="jd"/>
+                  <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
+                  <name>
+                    <surname>Doe</surname>
+                    <given-names>John</given-names>
+                  </name>
+                  <string-name>John Doe</string-name>
                 </principal-investigator>
               </award-group>
               <award-group>
@@ -237,7 +261,12 @@ cases:
                 <award-id>ghi-789</award-id>
                 <award-desc>open access support</award-desc>
                 <principal-investigator>
-                  <xref ref-type="contrib" rid="jd"/>
+                  <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
+                  <name>
+                    <surname>Doe</surname>
+                    <given-names>John</given-names>
+                  </name>
+                  <string-name>John Doe</string-name>
                 </principal-investigator>
               </award-group>
               <open-access>

--- a/packages/myst-to-jats/tests/funding.yml
+++ b/packages/myst-to-jats/tests/funding.yml
@@ -1,0 +1,252 @@
+cases:
+  - title: Funding statement
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    frontmatter:
+      funding: my funding statement
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <funding-group>
+              <funding-statement>my funding statement</funding-statement>
+            </funding-group>
+          </article-meta>
+        </front>
+        <body>
+          <p>text</p>
+        </body>
+      </article>
+  - title: Funding statement and open access
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    frontmatter:
+      funding:
+        statement: my funding statement
+        open_access: my open access statement
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <funding-group>
+              <funding-statement>my funding statement</funding-statement>
+              <open-access>
+                <p>my open access statement</p>
+              </open-access>
+            </funding-group>
+          </article-meta>
+        </front>
+        <body>
+          <p>text</p>
+        </body>
+      </article>
+  - title: Funding award
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    frontmatter:
+      author: John Doe
+      funding:
+        id: abc-123
+        name: Award
+        description: my test award
+        statement: my funding statement
+        source: University A
+        investigator: John Doe
+        recipient: Jane Doe
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <contrib-group>
+              <contrib contrib-type="author" id="John Doe">
+                <name>
+                  <surname>Doe</surname>
+                  <given-names>John</given-names>
+                </name>
+                <string-name>John Doe</string-name>
+              </contrib>
+              <contrib id="Jane Doe">
+                <name>
+                  <surname>Doe</surname>
+                  <given-names>Jane</given-names>
+                </name>
+                <string-name>Jane Doe</string-name>
+              </contrib>
+            </contrib-group>
+            <aff id="University A">
+              <institution-wrap>
+                <institution>University A</institution>
+              </institution-wrap>
+            </aff>
+            <funding-group>
+              <award-group>
+                <funding-source>
+                  <xref ref-type="aff" rid="University A"/>
+                </funding-source>
+                <award-id>abc-123</award-id>
+                <award-name>Award</award-name>
+                <award-desc>my test award</award-desc>
+                <principal-award-recipient>
+                  <xref ref-type="contrib" rid="Jane Doe"/>
+                </principal-award-recipient>
+                <principal-investigator>
+                  <xref ref-type="contrib" rid="John Doe"/>
+                </principal-investigator>
+              </award-group>
+              <funding-statement>my funding statement</funding-statement>
+            </funding-group>
+          </article-meta>
+        </front>
+        <body>
+          <p>text</p>
+        </body>
+      </article>
+  - title: Funding with multiple values/awards/sources/etc.
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    frontmatter:
+      authors:
+        - id: jd
+          name: John Doe
+          affiliations:
+            - id: univa
+              name: University A
+      affiliations:
+        - id: univb
+          name: University B
+      funding:
+        - statement: my funding statement
+          awards:
+            - id: abc-123
+              name: Award
+              description: my test award
+              sources:
+                - univa
+                - univb
+              investigators:
+                - jd
+              recipient:
+                - name: Jane Doe
+                - jd
+            - id: def-456
+              name: Another Award
+        - open_access: my open access statement
+          awards:
+            - id: ghi-789
+              description: open access support
+              investigators:
+                - jd
+              sources:
+                - University C
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <contrib-group>
+              <contrib contrib-type="author" id="jd">
+                <name>
+                  <surname>Doe</surname>
+                  <given-names>John</given-names>
+                </name>
+                <string-name>John Doe</string-name>
+                <xref ref-type="aff" rid="univa"/>
+              </contrib>
+              <contrib id="contributors-generated-uid-1">
+                <name>
+                  <surname>Doe</surname>
+                  <given-names>Jane</given-names>
+                </name>
+                <string-name>Jane Doe</string-name>
+              </contrib>
+            </contrib-group>
+            <aff id="univb">
+              <institution-wrap>
+                <institution>University B</institution>
+              </institution-wrap>
+            </aff>
+            <aff id="univa">
+              <institution-wrap>
+                <institution>University A</institution>
+              </institution-wrap>
+            </aff>
+            <aff id="University C">
+              <institution-wrap>
+                <institution>University C</institution>
+              </institution-wrap>
+            </aff>
+            <funding-group>
+              <award-group>
+                <funding-source>
+                  <xref ref-type="aff" rid="univa"/>
+                </funding-source>
+                <funding-source>
+                  <xref ref-type="aff" rid="univb"/>
+                </funding-source>
+                <award-id>abc-123</award-id>
+                <award-name>Award</award-name>
+                <award-desc>my test award</award-desc>
+                <principal-award-recipient>
+                  <xref ref-type="contrib" rid="contributors-generated-uid-1"/>
+                </principal-award-recipient>
+                <principal-award-recipient>
+                  <xref ref-type="contrib" rid="jd"/>
+                </principal-award-recipient>
+                <principal-investigator>
+                  <xref ref-type="contrib" rid="jd"/>
+                </principal-investigator>
+              </award-group>
+              <award-group>
+                <award-id>def-456</award-id>
+                <award-name>Another Award</award-name>
+              </award-group>
+              <funding-statement>my funding statement</funding-statement>
+            </funding-group>
+            <funding-group>
+              <award-group>
+                <funding-source>
+                  <xref ref-type="aff" rid="University C"/>
+                </funding-source>
+                <award-id>ghi-789</award-id>
+                <award-desc>open access support</award-desc>
+                <principal-investigator>
+                  <xref ref-type="contrib" rid="jd"/>
+                </principal-investigator>
+              </award-group>
+              <open-access>
+                <p>my open access statement</p>
+              </open-access>
+            </funding-group>
+          </article-meta>
+        </front>
+        <body>
+          <p>text</p>
+        </body>
+      </article>

--- a/packages/myst-to-jats/tests/multi.yml
+++ b/packages/myst-to-jats/tests/multi.yml
@@ -129,3 +129,89 @@ cases:
           </body>
         </sub-article>
       </article>
+  - title: Authors deduplicate
+    frontmatter:
+      title: Top title
+      authors:
+        - Author One
+      funding:
+        investigators:
+          - Author Two
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    subArticles:
+      - frontmatter:
+          title: Top title
+          authors:
+            - Author One
+            - Author Three
+        mdast:
+          type: root
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: article 1
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <title-group>
+              <article-title>Top title</article-title>
+            </title-group>
+            <contrib-group>
+              <contrib contrib-type="author" id="Author One">
+                <name>
+                  <surname>One</surname>
+                  <given-names>Author</given-names>
+                </name>
+                <string-name>Author One</string-name>
+              </contrib>
+              <contrib id="Author Two">
+                <name>
+                  <surname>Two</surname>
+                  <given-names>Author</given-names>
+                </name>
+                <string-name>Author Two</string-name>
+              </contrib>
+            </contrib-group>
+            <funding-group>
+              <award-group>
+                <principal-investigator>
+                  <name>
+                    <surname>Two</surname>
+                    <given-names>Author</given-names>
+                  </name>
+                  <string-name>Author Two</string-name>
+                </principal-investigator>
+              </award-group>
+            </funding-group>
+          </article-meta>
+        </front>
+        <body>
+          <p>text</p>
+        </body>
+        <sub-article>
+          <front-stub>
+            <contrib-group>
+              <contrib contrib-type="author" id="Author Three">
+                <name>
+                  <surname>Three</surname>
+                  <given-names>Author</given-names>
+                </name>
+                <string-name>Author Three</string-name>
+              </contrib>
+            </contrib-group>
+          </front-stub>
+          <body>
+            <p>article 1</p>
+          </body>
+        </sub-article>
+      </article>

--- a/packages/myst-to-jats/tests/siunit.yml
+++ b/packages/myst-to-jats/tests/siunit.yml
@@ -1,5 +1,5 @@
 cases:
-  - title: Basic Units
+  - title: Basic SI Units
     tree:
       type: root
       children:


### PR DESCRIPTION
Replacement for https://github.com/executablebooks/mystmd/pull/591

In Frontmatter:

- Add funding field
- Split out authors and contributors to support referencing contributors by id in funding object

In JATS:

- support funding
- support parsed names
- support keywords
- support contributors (in addition to authors)
- support full affiliation objects