### PR TITLE
🎆 Clean up extra image processing

### DIFF
--- a/.changeset/four-spoons-approve.md
+++ b/.changeset/four-spoons-approve.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Only process thumbnails for site builds not static exports

--- a/.changeset/many-masks-jam.md
+++ b/.changeset/many-masks-jam.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Eliminate some extra unwanted webp transforms

--- a/packages/myst-cli/src/build/utils/getFileContent.ts
+++ b/packages/myst-cli/src/build/utils/getFileContent.ts
@@ -2,7 +2,6 @@ import { resolve } from 'node:path';
 import { tic } from 'myst-cli-utils';
 import type { LinkTransformer } from 'myst-transforms';
 import type { ISession } from '../../session/types.js';
-import type { TransformFn } from '../../process/index.js';
 import {
   selectPageReferenceStates,
   loadFile,
@@ -13,8 +12,7 @@ import {
   loadIntersphinx,
   combineProjectCitationRenderers,
 } from '../../process/index.js';
-import { transformWebp } from '../../transforms/index.js';
-import { ImageExtensions } from '../../utils/index.js';
+import type { ImageExtensions } from '../../utils/index.js';
 
 export async function getFileContent(
   session: ISession,
@@ -55,13 +53,6 @@ export async function getFileContent(
   // Consolidate all citations onto single project citation renderer
   combineProjectCitationRenderers(session, projectPath);
 
-  const extraTransforms: TransformFn[] = [];
-  if (imageExtensions.includes(ImageExtensions.webp)) {
-    extraTransforms.push(transformWebp);
-  }
-  // if (opts?.extraTransforms) {
-  //   extraTransforms.push(...opts.extraTransforms);
-  // }
   await Promise.all(
     allFiles.map(async (file) => {
       const pageSlug = pages.find((page) => page.file === file)?.slug;

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -100,6 +100,7 @@ export async function transformMdast(
     minifyMaxCharacters?: number;
     index?: string;
     simplifyFigures?: boolean;
+    processThumbnail?: boolean;
   },
 ) {
   const {
@@ -116,6 +117,7 @@ export async function transformMdast(
     minifyMaxCharacters,
     index,
     simplifyFigures,
+    processThumbnail,
   } = opts;
   const toc = tic();
   const { store, log } = session;
@@ -217,15 +219,17 @@ export async function transformMdast(
       altOutputFolder: imageAltOutputFolder,
       imageExtensions,
     });
-    // Note, the thumbnail transform must be **after** images, as it may read the images
-    await transformThumbnail(session, mdast, file, frontmatter, imageWriteFolder, {
-      altOutputFolder: imageAltOutputFolder,
-      webp: extraTransforms?.includes(transformWebp),
-    });
-    await transformBanner(session, file, frontmatter, imageWriteFolder, {
-      altOutputFolder: imageAltOutputFolder,
-      webp: extraTransforms?.includes(transformWebp),
-    });
+    if (processThumbnail) {
+      // Note, the thumbnail transform must be **after** images, as it may read the images
+      await transformThumbnail(session, mdast, file, frontmatter, imageWriteFolder, {
+        altOutputFolder: imageAltOutputFolder,
+        webp: extraTransforms?.includes(transformWebp),
+      });
+      await transformBanner(session, file, frontmatter, imageWriteFolder, {
+        altOutputFolder: imageAltOutputFolder,
+        webp: extraTransforms?.includes(transformWebp),
+      });
+    }
   }
   await transformDeleteBase64UrlSource(mdast);
   const sha256 = selectors.selectFileInfo(store.getState(), file).sha256 as string;

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -52,6 +52,7 @@ import {
   reduceOutputs,
   transformPlaceholderImages,
   transformDeleteBase64UrlSource,
+  transformWebp,
 } from '../transforms/index.js';
 import type { ImageExtensions } from '../utils/index.js';
 import { logMessagesFromVFile } from '../utils/index.js';
@@ -219,11 +220,11 @@ export async function transformMdast(
     // Note, the thumbnail transform must be **after** images, as it may read the images
     await transformThumbnail(session, mdast, file, frontmatter, imageWriteFolder, {
       altOutputFolder: imageAltOutputFolder,
-      webp: !simplifyFigures,
+      webp: extraTransforms?.includes(transformWebp),
     });
     await transformBanner(session, file, frontmatter, imageWriteFolder, {
       altOutputFolder: imageAltOutputFolder,
-      webp: !simplifyFigures,
+      webp: extraTransforms?.includes(transformWebp),
     });
   }
   await transformDeleteBase64UrlSource(mdast);

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -245,6 +245,7 @@ export async function fastProcessFile(
     watchMode: true,
     extraTransforms: [transformWebp, ...(extraTransforms ?? [])],
     index: project.index,
+    processThumbnail: true,
   });
   const pageReferenceStates = selectPageReferenceStates(session, pages);
   await postProcessMdast(session, {
@@ -324,6 +325,7 @@ export async function processProject(
         watchMode,
         extraTransforms,
         index: project.index,
+        processThumbnail: true,
       }),
     ),
   );


### PR DESCRIPTION
Thumbnails and webp-optimized images are only required for site builds. However, both of these were still processed in JATS/pdf/etc exports.

This PR cleans that up and turns off the webp/thumbnail processing where it is not needed.