### PR TITLE
📦 Add myst-common to myst-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13698,6 +13698,7 @@
         "markdown-it-myst": "1.0.2",
         "markdown-it-myst-extras": "0.2.0",
         "markdown-it-task-lists": "^2.1.1",
+        "myst-common": "^1.1.6",
         "myst-directives": "^1.0.7",
         "myst-roles": "^1.0.7",
         "myst-spec": "^0.0.4",

--- a/packages/myst-parser/package.json
+++ b/packages/myst-parser/package.json
@@ -51,6 +51,7 @@
     "markdown-it-myst": "1.0.2",
     "markdown-it-myst-extras": "0.2.0",
     "markdown-it-task-lists": "^2.1.1",
+    "myst-common": "^1.1.6",
     "myst-directives": "^1.0.7",
     "myst-roles": "^1.0.7",
     "myst-spec": "^0.0.4",


### PR DESCRIPTION
`myst-common` is now used in `myst-parser`. This adds it to the dependencies.

Coming from a warning in `jupyterlab-myst`:

![image](https://github.com/executablebooks/mystmd/assets/913249/89c163a9-f1af-4529-9d95-9d61eb5941bd)
