### PR TITLE
＠Add pandoc-style citations

### DIFF
--- a/.changeset/cyan-ligers-hope.md
+++ b/.changeset/cyan-ligers-hope.md
@@ -1,0 +1,6 @@
+---
+'markdown-it-myst': patch
+'myst-parser': patch
+---
+
+Add column information to citations and roles

--- a/.changeset/fresh-rivers-think.md
+++ b/.changeset/fresh-rivers-think.md
@@ -1,0 +1,5 @@
+---
+'myst-spec-ext': patch
+---
+
+Add partial to Cite node to allow for year or author only.

--- a/.changeset/old-guests-live.md
+++ b/.changeset/old-guests-live.md
@@ -1,0 +1,5 @@
+---
+'citation-js-utils': patch
+---
+
+Replace &amp; with & in rendered html

--- a/.changeset/purple-apples-happen.md
+++ b/.changeset/purple-apples-happen.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Search for unmatched citations and use them as cross references or warn.

--- a/.changeset/rare-snakes-sin.md
+++ b/.changeset/rare-snakes-sin.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Do not add unknown citations to the bibliography.

--- a/.changeset/slimy-books-argue.md
+++ b/.changeset/slimy-books-argue.md
@@ -1,0 +1,5 @@
+---
+'citation-js-utils': patch
+---
+
+Support partial author or year

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -6,8 +6,6 @@ thumbnail: ./thumbnails/citations.png
 
 Citations automatically show up in your site, including a references section at the bottom of the page. These citations are able to be clicked on to see more information, like the abstract. There are two different ways to add citations to your documents: (1) adding a markdown link to a [DOI](wiki:Digital_object_identifier); and (2) by adding a BibTeX file, which can be exported from any reference manager, and adding a `cite` role to your content.
 
-+++
-
 (doi-links)=
 
 ## Simple Referencing with a DOI Link
@@ -24,13 +22,59 @@ which will insert the citation text in the correct format (e.g. adding an italic
 
 Providing your DOIs as full links has the advantage that on other rendering platforms (e.g. GitHub), your citation will still be shown as a link. If you have many citations, however, this will slow down the build process as the citation information is fetched dynamically.
 
-+++
-
 ## Including BibTeX
 
 A standard way of including references for $\LaTeX$ is using <wiki:BibTeX>, you can include a `*.bib` file or files in the same directory as your content directory for the project. These will provide the reference keys for that project.
 
-To create a citation in Markdown, use either a parenthetical or textual citation:
+If you want to explicitly reference which BibTeX files to use, as well as what order to resolve them in, you can use the `bibliography` field in your frontmatter, which is a string array of local or remote files. This will load the files in order specified.
+
+```yaml
+bibliography:
+  - my_references.bib
+  - https://example.com/my/remote/bibtex.bib
+```
+
+The remote BibTeX can be helpful for working with reference managers that support remote links to your references.
+
+## Markdown Citations
+
+You can add citations to any BibTeX entry using the citation key preceded by an `@`, for example, `@author2023`.
+This syntax follows the [pandoc citation syntax](https://pandoc.org/MANUAL.html#citation-syntax). Multiple citations can be grouped together with square brackets, separated with semi-colons. It is also possible to add a prefix or suffix to parenthetical citations, for example, `[e.g. @author2023, chap. 3; @author1995]`. To add a suffix to a narrative citation, follow the citation with the suffix in square brackets, for example, `@author2023 [chap. 3]`. As with a link to a DOI, you can also use the DOI directly instead of the BibTeX key.
+
+```{list-table} Examples of Markdown citations
+:header-rows: 1
+:name: table-pandoc-citations
+* - Markdown
+  - Rendered
+  - Explanation
+* - `@cockett2015`
+  - @cockett2015
+  - Narrative citation
+* - `[@cockett2015]`
+  - [@cockett2015]
+  - Parenthetical citation
+* - `[@cockett2015; @heagy2017]`
+  - [@cockett2015; @heagy2017]
+  - Multiple parenthetical citations
+* - `[-@cockett2015]`
+  - [-@cockett2015]
+  - Show citation year
+* - `[e.g. @cockett2015, pg. 22]`
+  - [e.g. @cockett2015, pg. 22]
+  - Prefix and suffix
+* - `@cockett2015 [pg. 22]`
+  - @cockett2015 [pg. 22]
+  - Suffix for narrative citations
+* - `@10.1093/nar/22.22.4673`
+  - @10.1093/nar/22.22.4673
+  - Citation using a DOI directly
+```
+
+Note that it is also possible to use the `@ref` syntax to link to other cross-references in addition to the link syntax.
+
+## Citation Roles
+
+MyST also provides a number of roles for compatibility with Sphinx and JupyterBook. To create a citation role in Markdown, use either a parenthetical or textual citation:
 
 ```md
 This is a parenthetical citation {cite:p}`cockett2015`.
@@ -47,15 +91,3 @@ This will be a citation: {cite}`10.1093/nar/22.22.4673`.
 ```
 
 This will show as: {cite}`10.1093/nar/22.22.4673`.
-
-## Specifying BibTeX
-
-If you want to explicitly reference which BibTeX files to use, as well as what order to resolve them in, you can use the `bibliography` field in your frontmatter, which is a string array of local or remote files. This will load the files in order specified.
-
-```yaml
-bibliography:
-  - my_references.bib
-  - https://example.com/my/remote/bibtex.bib
-```
-
-The remote BibTeX can be helpful for working with reference managers that support remote links to your references.

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -4,7 +4,7 @@ description: Add academic citations to your documents easily, have hover-referen
 thumbnail: ./thumbnails/citations.png
 ---
 
-Citations automatically show up in your site, including a references section at the bottom of the page. These citations are able to be clicked on to see more information, like the abstract. There are two different ways to add citations to your documents: (1) adding a markdown link to a [DOI](wiki:Digital_object_identifier); and (2) by adding a bibtex file, which can be exported from any reference manager, and adding a `cite` role to your content.
+Citations automatically show up in your site, including a references section at the bottom of the page. These citations are able to be clicked on to see more information, like the abstract. There are two different ways to add citations to your documents: (1) adding a markdown link to a [DOI](wiki:Digital_object_identifier); and (2) by adding a BibTeX file, which can be exported from any reference manager, and adding a `cite` role to your content.
 
 +++
 
@@ -48,9 +48,9 @@ This will be a citation: {cite}`10.1093/nar/22.22.4673`.
 
 This will show as: {cite}`10.1093/nar/22.22.4673`.
 
-## Specififying BibTeX
+## Specifying BibTeX
 
-If you want to explicitly reference which bibtex files to use, as well as what order to resolve them in, you can use the `bibliography` field in your frontmatter, which is a string array of local or remote files. This will load the files in order specified.
+If you want to explicitly reference which BibTeX files to use, as well as what order to resolve them in, you can use the `bibliography` field in your frontmatter, which is a string array of local or remote files. This will load the files in order specified.
 
 ```yaml
 bibliography:
@@ -58,4 +58,4 @@ bibliography:
   - https://example.com/my/remote/bibtex.bib
 ```
 
-The remote bibtex can be helpful for working with reference managers that support remote links to your references.
+The remote BibTeX can be helpful for working with reference managers that support remote links to your references.

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -70,8 +70,6 @@ This syntax follows the [pandoc citation syntax](https://pandoc.org/MANUAL.html#
   - Citation using a DOI directly
 ```
 
-Note that it is also possible to use the `@ref` syntax to link to other cross-references in addition to the link syntax.
-
 ## Citation Roles
 
 MyST also provides a number of roles for compatibility with Sphinx and JupyterBook. To create a citation role in Markdown, use either a parenthetical or textual citation:

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -173,6 +173,8 @@ banner: banner.png
 Example of a banner in a site using the `article-theme`.
 :::
 
+(authors)=
+
 ## Authors
 
 The `authors` field is a list of `author` objects. Available fields in the author object are:

--- a/packages/citation-js-utils/src/index.ts
+++ b/packages/citation-js-utils/src/index.ts
@@ -39,7 +39,7 @@ export function createSanitizer() {
 function cleanRef(citation: string) {
   const sanitizer = createSanitizer();
   const cleanHtml = sanitizer.cleanCitationHtml(citation).trim();
-  return cleanHtml.replace(/^1\./g, '').replace('&amp;', '&').trim();
+  return cleanHtml.replace(/^1\./g, '').replace(/&amp;/g, '&').trim();
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/citation-js-utils/src/index.ts
+++ b/packages/citation-js-utils/src/index.ts
@@ -39,7 +39,7 @@ export function createSanitizer() {
 function cleanRef(citation: string) {
   const sanitizer = createSanitizer();
   const cleanHtml = sanitizer.cleanCitationHtml(citation).trim();
-  return cleanHtml.replace(/^1\./g, '').trim();
+  return cleanHtml.replace(/^1\./g, '').replace('&amp;', '&').trim();
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/citation-js-utils/src/index.ts
+++ b/packages/citation-js-utils/src/index.ts
@@ -76,7 +76,13 @@ export function getInlineCitation(data: CitationJson, kind: InlineCite, opts?: I
   const year = data.issued?.['date-parts']?.[0]?.[0];
   const prefix = opts?.prefix ? `${opts.prefix} ` : '';
   const suffix = opts?.suffix ? `, ${opts.suffix}` : '';
-  const yearPart = kind === InlineCite.t ? ` (${year}${suffix})` : `, ${year}${suffix}`;
+  let yearPart = kind === InlineCite.t ? ` (${year}${suffix})` : `, ${year}${suffix}`;
+
+  if (opts?.partial === 'author') yearPart = '';
+  if (opts?.partial === 'year') {
+    const onlyYear = kind === InlineCite.t ? `(${year}${suffix})` : `${year}${suffix}`;
+    return [{ type: 'text', value: onlyYear }];
+  }
 
   if (!authors || authors.length === 0) {
     const text = data.publisher || data.title;
@@ -101,7 +107,7 @@ export function getInlineCitation(data: CitationJson, kind: InlineCite, opts?: I
   throw new Error('Unknown number of authors for citation');
 }
 
-export type InlineOptions = { prefix?: string; suffix?: string };
+export type InlineOptions = { prefix?: string; suffix?: string; partial?: 'author' | 'year' };
 
 export type CitationRenderer = Record<
   string,

--- a/packages/citation-js-utils/tests/fixtures.ts
+++ b/packages/citation-js-utils/tests/fixtures.ts
@@ -25,9 +25,9 @@ export const FORMATED_CONTENT_VANCOUVER =
 
 // sanitized
 export const TEST_APA_HTML =
-  'Cockett, R., Kang, S., Heagy, L. J., Pidlisecky, A., &amp; Oldenburg, D. W. (2015). SimPEG: An open source framework for simulation and gradient based parameter estimation in geophysical applications. <i>Computers &amp; Geosciences</i>, <i>85</i>, 142–154. <a target="_blank" rel="noreferrer" href="https://doi.org/10.1016/j.cageo.2015.09.015">10.1016/j.cageo.2015.09.015</a>';
+  'Cockett, R., Kang, S., Heagy, L. J., Pidlisecky, A., & Oldenburg, D. W. (2015). SimPEG: An open source framework for simulation and gradient based parameter estimation in geophysical applications. <i>Computers & Geosciences</i>, <i>85</i>, 142–154. <a target="_blank" rel="noreferrer" href="https://doi.org/10.1016/j.cageo.2015.09.015">10.1016/j.cageo.2015.09.015</a>';
 export const TEST_VANCOUVER_HTML =
-  'Cockett R, Kang S, Heagy LJ, Pidlisecky A, Oldenburg DW. SimPEG: An open source framework for simulation and gradient based parameter estimation in geophysical applications. Computers &amp; Geosciences [Internet]. 2015 Dec;85:142–54. Available from: <a target="_blank" rel="noreferrer" href="https://doi.org/10.1016/j.cageo.2015.09.015">10.1016/j.cageo.2015.09.015</a>';
+  'Cockett R, Kang S, Heagy LJ, Pidlisecky A, Oldenburg DW. SimPEG: An open source framework for simulation and gradient based parameter estimation in geophysical applications. Computers & Geosciences [Internet]. 2015 Dec;85:142–54. Available from: <a target="_blank" rel="noreferrer" href="https://doi.org/10.1016/j.cageo.2015.09.015">10.1016/j.cageo.2015.09.015</a>';
 // straight outta citation-js
 export const TEST_DATA_HTML_DIRTY =
   'Cockett, R., Kang, S., Heagy, L. J., Pidlisecky, A., &#38; Oldenburg, D. W. (2015). SimPEG: An open source framework for simulation and gradient based parameter estimation in geophysical applications. <i>Computers &#38; Geosciences</i>, <i>85</i>, 142–154. <a href="https://doi.org/10.1016/j.cageo.2015.09.015" target="_blank">10.1016/j.cageo.2015.09.015</a>';

--- a/packages/markdown-it-myst/src/citations.ts
+++ b/packages/markdown-it-myst/src/citations.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * citations.js file is adapted from `markdown-it-citations` (Sept 2023)
+ * MIT License - Martin Ring <@martinring>
+ * https://github.com/martinring/markdown-it-citations
+ */
+
+import type { PluginWithOptions } from 'markdown-it';
+import type Token from 'markdown-it/lib/token.js';
+
+type CiteKind = 'narrative' | 'parenthetical';
+type CitePartial = 'author' | 'year';
+
+export interface Citation {
+  label: string;
+  kind: CiteKind;
+  partial?: CitePartial;
+  prefix?: Token[];
+  suffix?: Token[];
+}
+
+export const citationsPlugin: PluginWithOptions = (md) => {
+  const regexes = {
+    citation: /^([^^-]|[^^].+?)?(-)?@([\w][\w:.#$%&\-+?<>~/]*)(.+)?$/,
+    inText: /^@([\w][\w:.#$%&\-+?<>~/]*)(\s*)(\[)?/,
+    allowedBefore: /^[^a-zA-Z.0-9]$/,
+  };
+
+  md.inline.ruler.after('emphasis', 'citation', (state, silent) => {
+    // const max = state.posMax;
+    const char = state.src.charCodeAt(state.pos);
+    if (
+      char == 0x40 /* @ */ &&
+      (state.pos == 0 || regexes.allowedBefore.test(state.src.slice(state.pos - 1, state.pos)))
+    ) {
+      // in-text
+      const match = state.src.slice(state.pos).match(regexes.inText);
+      if (match) {
+        const citation: Citation = {
+          label: match[1],
+          kind: 'narrative',
+        };
+        let token: Token | undefined;
+        if (!silent) {
+          token = state.push('cite', 'cite', 0);
+          token.meta = citation;
+          (token as any).col = [state.pos];
+        }
+        if (match[3]) {
+          // suffix is there
+          const suffixStart = state.pos + match[0].length;
+          const suffixEnd = state.md.helpers.parseLinkLabel(state, suffixStart);
+          const charAfter = state.src.codePointAt(suffixEnd + 1);
+          if (suffixEnd > 0 && charAfter != 0x28 && charAfter != 0x5b /* ( or [ */) {
+            const suffix = state.src.slice(suffixStart, suffixEnd);
+            citation.suffix = state.md.parseInline(suffix, state.env);
+            state.pos += match[0].length + suffixEnd - suffixStart + 1;
+            if (token) token.content = match[0] + suffix + ']';
+          } else {
+            state.pos += match[0].length - match[2].length - match[3].length;
+            if (token) {
+              token.content = match[0];
+              (token as any).col.push(state.pos);
+            }
+          }
+        } else {
+          state.pos += match[0].length - match[2].length;
+          if (token) {
+            token.content = match[0];
+            (token as any).col.push(state.pos);
+          }
+        }
+        return true;
+      }
+    } else if (char == 0x5b /* [ */) {
+      const end = state.md.helpers.parseLinkLabel(state, state.pos);
+      const charAfter = state.src.codePointAt(end + 1);
+      if (end > 0 && charAfter != 0x28 && charAfter != 0x5b) {
+        const str = state.src.slice(state.pos + 1, end);
+        const parts = str.split(';').map((x) => x.match(regexes.citation));
+        if (parts.indexOf(null) >= 0) return false;
+        let curCol = state.pos + 1;
+        const cites = (parts as RegExpMatchArray[]).map(
+          (x): Citation & { content: string; col: number[] } => {
+            // remove the punctuation from the suffix if it exists
+            const suffix = x[4] ? x[4].trim().replace(/^,[\s]*/, '') : undefined;
+            const colEnd = curCol + x[0].length;
+            const meta = {
+              label: x[3],
+              kind: 'parenthetical' as CiteKind,
+              prefix: x[1]?.trim() ? state.md.parseInline(x[1]?.trim(), state.env) : undefined,
+              suffix: suffix ? state.md.parseInline(suffix, state.env) : undefined,
+              partial: x[2] ? ('year' as CitePartial) : undefined,
+              content: x[0].trim(),
+              col: [curCol, colEnd],
+            };
+            curCol = colEnd + 1;
+            return meta;
+          },
+        );
+        if (!silent) {
+          const token = state.push('cite_group_open', 'span', 1);
+          token.content = '[';
+          token.meta = { kind: 'parenthetical' };
+          cites.forEach((citation) => {
+            const { content, col, ...meta } = citation;
+            const cite = state.push('cite', 'cite', 0);
+            cite.content = content;
+            (cite as any).col = col;
+            cite.meta = meta;
+          });
+          const close = state.push('cite_group_close', 'span', -1);
+          close.content = ']';
+        }
+        state.pos = end + 1;
+        return true;
+      }
+      return false;
+    }
+    return false;
+  });
+};

--- a/packages/markdown-it-myst/src/index.ts
+++ b/packages/markdown-it-myst/src/index.ts
@@ -1,9 +1,9 @@
 import type MarkdownIt from 'markdown-it/lib';
 import { rolePlugin } from './roles.js';
 import { directivePlugin } from './directives.js';
+import { citationsPlugin } from './citations.js';
 
-export { rolePlugin };
-export { directivePlugin };
+export { rolePlugin, directivePlugin, citationsPlugin };
 
 /**
  * A markdown-it plugin for parsing MyST roles and directives to structured data

--- a/packages/markdown-it-myst/src/roles.ts
+++ b/packages/markdown-it-myst/src/roles.ts
@@ -31,13 +31,13 @@ function roleRule(state: StateInline, silent: boolean): boolean {
   const match = ROLE_PATTERN.exec(state.src.slice(state.pos));
   if (match == null) return false;
   const [str, name, , content] = match;
-  state.pos += str.length;
-
   if (!silent) {
     const token = state.push('role', '', 0);
     token.meta = { name };
     token.content = content;
+    (token as any).col = [state.pos, state.pos + str.length];
   }
+  state.pos += str.length;
   return true;
 }
 
@@ -63,13 +63,14 @@ function runRoles(state: StateCore): boolean {
         if (child.type === 'role') {
           try {
             const { map } = token;
-            const { content } = child;
+            const { content, col } = child as any;
             const roleOpen = new state.Token('parsed_role_open', '', 1);
             roleOpen.content = content;
             roleOpen.hidden = true;
             roleOpen.info = child.meta.name;
             roleOpen.block = false;
             roleOpen.map = map;
+            (roleOpen as any).col = col;
             const contentTokens = roleContentToTokens(content, map ? map[0] : 0, state);
             const roleClose = new state.Token('parsed_role_close', '', -1);
             roleClose.block = false;

--- a/packages/markdown-it-myst/tests/citations.spec.ts
+++ b/packages/markdown-it-myst/tests/citations.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import MarkdownIt from 'markdown-it';
+import { citationsPlugin } from '../src/citations';
+
+describe('parses citations', () => {
+  it('basic in-text citation', () => {
+    const mdit = MarkdownIt().use(citationsPlugin);
+    const tokens = mdit.parse('In @simpeg2015, the authors...', {});
+    expect(tokens.map((t) => t.type)).toEqual(['paragraph_open', 'inline', 'paragraph_close']);
+    expect(tokens[1].children?.map((t) => t.type)).toEqual(['text', 'cite', 'text']);
+    expect(tokens[1].content).toEqual('In @simpeg2015, the authors...');
+    expect(tokens[1].children?.[0].content).toEqual('In ');
+    expect(tokens[1].children?.[1].content).toEqual('@simpeg2015');
+    expect(tokens[1].children?.[2].content).toEqual(', the authors...');
+    const citation = tokens[1].children?.[1];
+    expect(citation?.meta.label).toEqual('simpeg2015');
+    expect(citation?.meta.kind).toEqual('narrative');
+    expect(citation?.meta.prefix).toEqual(undefined);
+    expect(citation?.meta.suffix).toEqual(undefined);
+  });
+  it('complex in-text citation', () => {
+    const mdit = MarkdownIt().use(citationsPlugin);
+    const tokens = mdit.parse('In @simpeg2015 [pg 23], the authors...', {});
+    expect(tokens.map((t) => t.type)).toEqual(['paragraph_open', 'inline', 'paragraph_close']);
+    expect(tokens[1].children?.map((t) => t.type)).toEqual(['text', 'cite', 'text']);
+    expect(tokens[1].content).toEqual('In @simpeg2015 [pg 23], the authors...');
+    expect(tokens[1].children?.[0].content).toEqual('In ');
+    expect(tokens[1].children?.[1].content).toEqual('@simpeg2015 [pg 23]');
+    expect(tokens[1].children?.[2].content).toEqual(', the authors...');
+    const citation = tokens[1].children?.[1];
+    expect(citation?.meta.label).toEqual('simpeg2015');
+    expect(citation?.meta.kind).toEqual('narrative');
+    expect(citation?.meta.prefix).toEqual(undefined);
+    expect(citation?.meta.suffix[0].content).toEqual('pg 23');
+  });
+  it('basic cite-group', () => {
+    const mdit = MarkdownIt().use(citationsPlugin);
+    const tokens = mdit.parse('...geophysical inversions [@simpeg2015; @heagy2017].', {});
+    expect(tokens.map((t) => t.type)).toEqual(['paragraph_open', 'inline', 'paragraph_close']);
+    expect(tokens[1].children?.map((t) => t.type)).toEqual([
+      'text',
+      'cite_group_open',
+      'cite',
+      'cite',
+      'cite_group_close',
+      'text',
+    ]);
+    expect(tokens[1].content).toEqual('...geophysical inversions [@simpeg2015; @heagy2017].');
+    expect(tokens[1].children?.[0].content).toEqual('...geophysical inversions ');
+    expect(tokens[1].children?.[1].content).toEqual('[');
+    expect(tokens[1].children?.[2].content).toEqual('@simpeg2015');
+    expect(tokens[1].children?.[3].content).toEqual('@heagy2017');
+    expect(tokens[1].children?.[4].content).toEqual(']');
+    expect(tokens[1].children?.[5].content).toEqual('.');
+    const citeGroup = tokens[1].children?.[1];
+    expect(citeGroup?.meta.kind).toEqual('parenthetical');
+    const citation1 = tokens[1].children?.[2];
+    expect(citation1?.meta.label).toEqual('simpeg2015');
+    expect(citation1?.meta.kind).toEqual('parenthetical');
+    expect(citation1?.meta.prefix).toEqual(undefined);
+    expect(citation1?.meta.suffix).toEqual(undefined);
+    expect((citation1 as any)?.col).toEqual([27, 38]);
+    const citation2 = tokens[1].children?.[3];
+    expect(citation2?.meta.label).toEqual('heagy2017');
+    expect(citation2?.meta.kind).toEqual('parenthetical');
+    expect(citation2?.meta.prefix).toEqual(undefined);
+    expect(citation2?.meta.suffix).toEqual(undefined);
+    expect((citation2 as any)?.col).toEqual([39, 50]);
+  });
+  it('complex cite-group', () => {
+    const mdit = MarkdownIt().use(citationsPlugin);
+    const tokens = mdit.parse(
+      '...geophysical inversions [@simpeg2015, pg 23; see -@heagy2017].',
+      {},
+    );
+    expect(tokens.map((t) => t.type)).toEqual(['paragraph_open', 'inline', 'paragraph_close']);
+    expect(tokens[1].children?.map((t) => t.type)).toEqual([
+      'text',
+      'cite_group_open',
+      'cite',
+      'cite',
+      'cite_group_close',
+      'text',
+    ]);
+    expect(tokens[1].content).toEqual(
+      '...geophysical inversions [@simpeg2015, pg 23; see -@heagy2017].',
+    );
+    expect(tokens[1].children?.[0].content).toEqual('...geophysical inversions ');
+    expect(tokens[1].children?.[1].content).toEqual('[');
+    expect(tokens[1].children?.[2].content).toEqual('@simpeg2015, pg 23');
+    expect(tokens[1].children?.[3].content).toEqual('see -@heagy2017');
+    expect(tokens[1].children?.[4].content).toEqual(']');
+    expect(tokens[1].children?.[5].content).toEqual('.');
+    const citeGroup = tokens[1].children?.[1];
+    expect(citeGroup?.meta.kind).toEqual('parenthetical');
+    const citation1 = tokens[1].children?.[2];
+    expect(citation1?.meta.label).toEqual('simpeg2015');
+    expect(citation1?.meta.kind).toEqual('parenthetical');
+    expect(citation1?.meta.prefix).toEqual(undefined);
+    expect(citation1?.meta.suffix[0].content).toEqual('pg 23');
+    const citation2 = tokens[1].children?.[3];
+    expect(citation2?.meta.label).toEqual('heagy2017');
+    expect(citation2?.meta.kind).toEqual('parenthetical');
+    expect(citation2?.meta.partial).toEqual('year');
+    expect(citation2?.meta.prefix[0].content).toEqual('see');
+    expect(citation2?.meta.suffix).toEqual(undefined);
+  });
+});

--- a/packages/markdown-it-myst/tests/roles.spec.ts
+++ b/packages/markdown-it-myst/tests/roles.spec.ts
@@ -5,19 +5,22 @@ import plugin from '../src';
 describe('parses roles', () => {
   it('basic role parses', () => {
     const mdit = MarkdownIt().use(plugin);
-    const tokens = mdit.parse('{abc}`hello`', {});
+    const tokens = mdit.parse('ok {abc}`hello`', {});
     expect(tokens.map((t) => t.type)).toEqual(['paragraph_open', 'inline', 'paragraph_close']);
     expect(tokens[1].children?.map((t) => t.type)).toEqual([
+      'text',
       'parsed_role_open',
       'role_body_open',
       'inline',
       'role_body_close',
       'parsed_role_close',
     ]);
-    expect(tokens[1].content).toEqual('{abc}`hello`');
-    expect(tokens[1].children?.[0].info).toEqual('abc');
-    expect(tokens[1].children?.[0].content).toEqual('hello');
-    expect(tokens[1].children?.[2].content).toEqual('hello');
+    expect(tokens[1].content).toEqual('ok {abc}`hello`');
+    // Pass the column information for the role
+    expect((tokens[1].children?.[1] as any).col).toEqual([3, 15]);
+    expect(tokens[1].children?.[1].info).toEqual('abc');
+    expect(tokens[1].children?.[1].content).toEqual('hello');
+    expect(tokens[1].children?.[3].content).toEqual('hello');
   });
   it('header role parses', () => {
     const mdit = MarkdownIt().use(plugin);

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -185,7 +185,13 @@ export async function transformMdast(
   linksTransform(mdast, vfile, { transformers, selector: LINKS_SELECTOR });
 
   // Initialize citation renderers for this (non-bib) file
-  cache.$citationRenderers[file] = await transformLinkedDOIs(log, mdast, cache.$doiRenderers, file);
+  cache.$citationRenderers[file] = await transformLinkedDOIs(
+    log,
+    vfile,
+    mdast,
+    cache.$doiRenderers,
+    file,
+  );
   const rendererFiles = [file];
   if (projectPath) {
     rendererFiles.unshift(projectPath);
@@ -200,7 +206,7 @@ export async function transformMdast(
     altOutputFolder: simplifyFigures ? undefined : imageAltOutputFolder,
     minifyMaxCharacters,
   });
-  transformCitations(log, mdast, fileCitationRenderer, references, file);
+  transformCitations(mdast, fileCitationRenderer, references);
   await unified()
     .use(codePlugin, { lang: frontmatter?.kernelspec?.language })
     .use(footnotesPlugin) // Needs to happen near the end

--- a/packages/myst-cli/src/utils/addWarningForFile.ts
+++ b/packages/myst-cli/src/utils/addWarningForFile.ts
@@ -11,15 +11,15 @@ export function addWarningForFile(
   kind: WarningKind = 'warn',
   opts?: { note?: string | null; url?: string | null; position?: VFileMessage['position'] },
 ) {
-  const specific = opts?.position?.start.line
-    ? `:${opts?.position.start.line}${
-        opts?.position.start.column ? `:${opts?.position.start.column}` : ''
-      }`
-    : '';
+  const line = opts?.position?.start.line ? `:${opts?.position.start.line}` : '';
+  const column =
+    opts?.position?.start.column && opts?.position?.start.column > 1
+      ? `:${opts?.position.start.column}`
+      : '';
 
   const note = opts?.note ? `\n   ${chalk.reset.dim(opts.note)}` : '';
   const url = opts?.url ? chalk.reset.dim(`\n   See also: ${opts.url}\n`) : '';
-  const prefix = file ? `${file}${specific} ` : '';
+  const prefix = file ? `${file}${line}${column} ` : '';
   const formatted = `${message}${note}${url}`;
   switch (kind) {
     case 'info':

--- a/packages/myst-ext-card/tests/card.spec.ts
+++ b/packages/myst-ext-card/tests/card.spec.ts
@@ -15,12 +15,12 @@ describe('card directive', () => {
           value: 'Header\n^^^\n\nCard content\n+++\nFooter',
           position: {
             start: {
-              line: 0,
-              column: 0,
+              line: 1,
+              column: 1,
             },
             end: {
               line: 8,
-              column: 0,
+              column: 1,
             },
           },
           children: [
@@ -40,12 +40,12 @@ describe('card directive', () => {
                       ],
                       position: {
                         end: {
-                          column: 0,
+                          column: 1,
                           line: 3,
                         },
                         start: {
-                          column: 0,
-                          line: 1,
+                          column: 1,
+                          line: 2,
                         },
                       },
                     },
@@ -57,6 +57,16 @@ describe('card directive', () => {
                     {
                       type: 'text',
                       value: 'Card Title',
+                      position: {
+                        end: {
+                          column: 1,
+                          line: 1,
+                        },
+                        start: {
+                          column: 1,
+                          line: 1,
+                        },
+                      },
                     },
                   ],
                 },
@@ -66,16 +76,26 @@ describe('card directive', () => {
                     {
                       type: 'text',
                       value: 'Card content',
+                      position: {
+                        end: {
+                          column: 1,
+                          line: 5,
+                        },
+                        start: {
+                          column: 1,
+                          line: 5,
+                        },
+                      },
                     },
                   ],
                   position: {
                     end: {
-                      column: 0,
+                      column: 1,
                       line: 5,
                     },
                     start: {
-                      column: 0,
-                      line: 4,
+                      column: 1,
+                      line: 5,
                     },
                   },
                 },
@@ -88,16 +108,26 @@ describe('card directive', () => {
                         {
                           type: 'text',
                           value: 'Footer',
+                          position: {
+                            end: {
+                              column: 1,
+                              line: 7,
+                            },
+                            start: {
+                              column: 1,
+                              line: 7,
+                            },
+                          },
                         },
                       ],
                       position: {
                         end: {
-                          column: 0,
+                          column: 1,
                           line: 7,
                         },
                         start: {
-                          column: 0,
-                          line: 6,
+                          column: 1,
+                          line: 7,
                         },
                       },
                     },
@@ -132,12 +162,12 @@ describe('card directive', () => {
           value: 'Card\n^^^\ncontent',
           position: {
             start: {
-              line: 0,
-              column: 0,
+              line: 1,
+              column: 1,
             },
             end: {
               line: 8,
-              column: 0,
+              column: 1,
             },
           },
           children: [
@@ -154,6 +184,16 @@ describe('card directive', () => {
                         {
                           type: 'text',
                           value: 'Header',
+                          position: {
+                            end: {
+                              column: 1,
+                              line: 2,
+                            },
+                            start: {
+                              column: 1,
+                              line: 2,
+                            },
+                          },
                         },
                       ],
                     },
@@ -165,6 +205,16 @@ describe('card directive', () => {
                     {
                       type: 'text',
                       value: 'Card Title',
+                      position: {
+                        end: {
+                          column: 1,
+                          line: 1,
+                        },
+                        start: {
+                          column: 1,
+                          line: 1,
+                        },
+                      },
                     },
                   ],
                 },
@@ -174,16 +224,26 @@ describe('card directive', () => {
                     {
                       type: 'text',
                       value: 'Card\n^^^\ncontent',
+                      position: {
+                        end: {
+                          column: 1,
+                          line: 5,
+                        },
+                        start: {
+                          column: 1,
+                          line: 5,
+                        },
+                      },
                     },
                   ],
                   position: {
                     end: {
-                      column: 0,
+                      column: 1,
                       line: 7,
                     },
                     start: {
-                      column: 0,
-                      line: 4,
+                      column: 1,
+                      line: 5,
                     },
                   },
                 },
@@ -196,6 +256,16 @@ describe('card directive', () => {
                         {
                           type: 'text',
                           value: 'Footer',
+                          position: {
+                            end: {
+                              column: 1,
+                              line: 3,
+                            },
+                            start: {
+                              column: 1,
+                              line: 3,
+                            },
+                          },
                         },
                       ],
                     },
@@ -223,12 +293,12 @@ describe('card directive', () => {
           value: 'Card content',
           position: {
             start: {
-              line: 0,
-              column: 0,
+              line: 1,
+              column: 1,
             },
             end: {
               line: 3,
-              column: 0,
+              column: 1,
             },
           },
           children: [
@@ -241,16 +311,26 @@ describe('card directive', () => {
                     {
                       type: 'text',
                       value: 'Card content',
+                      position: {
+                        end: {
+                          column: 1,
+                          line: 2,
+                        },
+                        start: {
+                          column: 1,
+                          line: 2,
+                        },
+                      },
                     },
                   ],
                   position: {
                     end: {
-                      column: 0,
+                      column: 1,
                       line: 2,
                     },
                     start: {
-                      column: 0,
-                      line: 1,
+                      column: 1,
+                      line: 2,
                     },
                   },
                 },

--- a/packages/myst-ext-exercise/tests/exercise.spec.ts
+++ b/packages/myst-ext-exercise/tests/exercise.spec.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { mystParse } from 'myst-parser';
 import { exerciseDirective } from '../src';
+import { selectAll } from 'unist-util-select';
+
+function deletePositions(tree: any) {
+  selectAll('*', tree).forEach((n) => {
+    delete n.position;
+  });
+  return tree;
+}
 
 describe('exercise directive', () => {
   it('exercise directive parses', async () => {
@@ -16,16 +24,6 @@ describe('exercise directive', () => {
           },
           args: 'Exercise Title',
           value: 'Exercise content',
-          position: {
-            start: {
-              line: 0,
-              column: 0,
-            },
-            end: {
-              line: 4,
-              column: 0,
-            },
-          },
           children: [
             {
               type: 'exercise',
@@ -50,16 +48,6 @@ describe('exercise directive', () => {
                       value: 'Exercise content',
                     },
                   ],
-                  position: {
-                    end: {
-                      column: 0,
-                      line: 3,
-                    },
-                    start: {
-                      column: 0,
-                      line: 2,
-                    },
-                  },
                 },
               ],
             },
@@ -70,6 +58,6 @@ describe('exercise directive', () => {
     const output = mystParse(content, {
       directives: [exerciseDirective],
     });
-    expect(output).toEqual(expected);
+    expect(deletePositions(output)).toEqual(expected);
   });
 });

--- a/packages/myst-ext-grid/tests/grid.spec.ts
+++ b/packages/myst-ext-grid/tests/grid.spec.ts
@@ -17,12 +17,12 @@ describe('grid directive', () => {
             '```{grid-item-card}\nText content\n^^^\nStructure books with text files and Jupyter Notebooks with minimal configuration.\n```\n\n```{grid-item-card}\nMyST Markdown\n^^^\nWrite MyST Markdown to create enriched documents with publication-quality features.\n```\n\n```{grid-item-card}\nExecutable content\n^^^\nExecute notebook cells, store results, and insert outputs across pages.\n```',
           position: {
             end: {
-              column: 0,
+              column: 1,
               line: 20,
             },
             start: {
-              column: 0,
-              line: 0,
+              column: 1,
+              line: 1,
             },
           },
           children: [
@@ -37,12 +37,12 @@ describe('grid directive', () => {
                     'Text content\n^^^\nStructure books with text files and Jupyter Notebooks with minimal configuration.',
                   position: {
                     end: {
-                      column: 0,
+                      column: 1,
                       line: 7,
                     },
                     start: {
-                      column: 0,
-                      line: 2,
+                      column: 1,
+                      line: 3,
                     },
                   },
                 },
@@ -53,12 +53,12 @@ describe('grid directive', () => {
                     'MyST Markdown\n^^^\nWrite MyST Markdown to create enriched documents with publication-quality features.',
                   position: {
                     end: {
-                      column: 0,
+                      column: 1,
                       line: 13,
                     },
                     start: {
-                      column: 0,
-                      line: 8,
+                      column: 1,
+                      line: 9,
                     },
                   },
                 },
@@ -69,12 +69,12 @@ describe('grid directive', () => {
                     'Executable content\n^^^\nExecute notebook cells, store results, and insert outputs across pages.',
                   position: {
                     end: {
-                      column: 0,
+                      column: 1,
                       line: 19,
                     },
                     start: {
-                      column: 0,
-                      line: 14,
+                      column: 1,
+                      line: 15,
                     },
                   },
                 },

--- a/packages/myst-ext-proof/tests/proof.spec.ts
+++ b/packages/myst-ext-proof/tests/proof.spec.ts
@@ -15,12 +15,12 @@ describe('proof directive', () => {
           value: 'Proof content',
           position: {
             start: {
-              line: 0,
-              column: 0,
+              line: 1,
+              column: 1,
             },
             end: {
               line: 3,
-              column: 0,
+              column: 1,
             },
           },
           children: [
@@ -35,6 +35,16 @@ describe('proof directive', () => {
                     {
                       type: 'text',
                       value: 'Proof Title',
+                      position: {
+                        start: {
+                          line: 1,
+                          column: 1,
+                        },
+                        end: {
+                          line: 1,
+                          column: 1,
+                        },
+                      },
                     },
                   ],
                 },
@@ -44,16 +54,26 @@ describe('proof directive', () => {
                     {
                       type: 'text',
                       value: 'Proof content',
+                      position: {
+                        start: {
+                          line: 2,
+                          column: 1,
+                        },
+                        end: {
+                          line: 2,
+                          column: 1,
+                        },
+                      },
                     },
                   ],
                   position: {
                     end: {
-                      column: 0,
+                      column: 1,
                       line: 2,
                     },
                     start: {
-                      column: 0,
-                      line: 1,
+                      column: 1,
+                      line: 2,
                     },
                   },
                 },

--- a/packages/myst-ext-reactive/tests/reactive.spec.ts
+++ b/packages/myst-ext-reactive/tests/reactive.spec.ts
@@ -26,11 +26,11 @@ describe('reactive tests', () => {
           ],
           position: {
             start: {
-              column: 0,
-              line: 0,
+              column: 1,
+              line: 1,
             },
             end: {
-              column: 0,
+              column: 1,
               line: 5,
             },
           },
@@ -43,7 +43,7 @@ describe('reactive tests', () => {
     });
     expect(output).toEqual(expected);
   });
-  it('r:dynamic role parses', async () => {
+  it.only('r:dynamic role parses', async () => {
     const content = '{r:dynamic}`rValue="visitors", rChange="{visitors: value}", value="5"`';
     const expected = {
       type: 'root',
@@ -52,11 +52,11 @@ describe('reactive tests', () => {
           type: 'paragraph',
           position: {
             start: {
-              column: 0,
-              line: 0,
+              column: 1,
+              line: 1,
             },
             end: {
-              column: 0,
+              column: 1,
               line: 1,
             },
           },
@@ -75,11 +75,11 @@ describe('reactive tests', () => {
               ],
               position: {
                 start: {
-                  column: 0,
-                  line: 0,
+                  column: 1,
+                  line: 1,
                 },
                 end: {
-                  column: 0,
+                  column: 71,
                   line: 1,
                 },
               },

--- a/packages/myst-ext-reactive/tests/reactive.spec.ts
+++ b/packages/myst-ext-reactive/tests/reactive.spec.ts
@@ -43,7 +43,7 @@ describe('reactive tests', () => {
     });
     expect(output).toEqual(expected);
   });
-  it.only('r:dynamic role parses', async () => {
+  it('r:dynamic role parses', async () => {
     const content = '{r:dynamic}`rValue="visitors", rChange="{visitors: value}", value="5"`';
     const expected = {
       type: 'root',

--- a/packages/myst-ext-tabs/tests/tabs.spec.ts
+++ b/packages/myst-ext-tabs/tests/tabs.spec.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { mystParse } from 'myst-parser';
 import { tabDirectives } from '../src';
+import { selectAll } from 'unist-util-select';
+
+function deletePositions(tree: any) {
+  selectAll('*', tree).forEach((n) => {
+    delete n.position;
+  });
+  return tree;
+}
 
 describe('tab directives', () => {
   it.each(['tab-set', 'tabSet'])('empty %s parses', async (name: string) => {
@@ -11,16 +19,6 @@ describe('tab directives', () => {
         {
           type: 'mystDirective',
           name,
-          position: {
-            start: {
-              line: 0,
-              column: 0,
-            },
-            end: {
-              line: 2,
-              column: 0,
-            },
-          },
           children: [
             {
               type: 'tabSet',
@@ -33,7 +31,7 @@ describe('tab directives', () => {
     const output = mystParse(content, {
       directives: [...tabDirectives],
     });
-    expect(output).toEqual(expected);
+    expect(deletePositions(output)).toEqual(expected);
   });
   it('tabSet class option parses', async () => {
     const content = '```{tab-set}\n:class: my-class\n```';
@@ -45,16 +43,6 @@ describe('tab directives', () => {
           name: 'tab-set',
           options: {
             class: 'my-class',
-          },
-          position: {
-            start: {
-              line: 0,
-              column: 0,
-            },
-            end: {
-              line: 3,
-              column: 0,
-            },
           },
           children: [
             {
@@ -69,7 +57,7 @@ describe('tab directives', () => {
     const output = mystParse(content, {
       directives: [...tabDirectives],
     });
-    expect(output).toEqual(expected);
+    expect(deletePositions(output)).toEqual(expected);
   });
   it.each(['tab-item', 'tabItem'])('%s with title parses', async (name: string) => {
     const content = `\`\`\`{${name}} Tab One\n\`\`\``;
@@ -80,16 +68,6 @@ describe('tab directives', () => {
           type: 'mystDirective',
           name,
           args: 'Tab One',
-          position: {
-            start: {
-              line: 0,
-              column: 0,
-            },
-            end: {
-              line: 2,
-              column: 0,
-            },
-          },
           children: [
             {
               type: 'tabItem',
@@ -103,7 +81,7 @@ describe('tab directives', () => {
     const output = mystParse(content, {
       directives: [...tabDirectives],
     });
-    expect(output).toEqual(expected);
+    expect(deletePositions(output)).toEqual(expected);
   });
   it('tabItem sync and selected options parse', async () => {
     const content = '```{tab-item} Tab One\n:sync: tab1\n:selected:\n```';
@@ -117,16 +95,6 @@ describe('tab directives', () => {
           options: {
             sync: 'tab1',
             selected: true,
-          },
-          position: {
-            start: {
-              line: 0,
-              column: 0,
-            },
-            end: {
-              line: 4,
-              column: 0,
-            },
           },
           children: [
             {
@@ -143,7 +111,7 @@ describe('tab directives', () => {
     const output = mystParse(content, {
       directives: [...tabDirectives],
     });
-    expect(output).toEqual(expected);
+    expect(deletePositions(output)).toEqual(expected);
   });
   // TODO: enable when we have a better required/fallback/default pattern
   it.skip('tabItem without title errors', async () => {
@@ -164,16 +132,7 @@ describe('tab directives', () => {
           name: 'tab-set',
           value:
             '```{tab-item} Tab 1\n:sync: tab1\nTab one\n```\n\n```{tab-item} Tab 2\n:sync: tab2\nTab two\n```',
-          position: {
-            start: {
-              line: 0,
-              column: 0,
-            },
-            end: {
-              line: 13,
-              column: 0,
-            },
-          },
+
           children: [
             {
               type: 'tabSet',
@@ -186,16 +145,7 @@ describe('tab directives', () => {
                     sync: 'tab1',
                   },
                   value: 'Tab one',
-                  position: {
-                    start: {
-                      line: 2,
-                      column: 0,
-                    },
-                    end: {
-                      line: 6,
-                      column: 0,
-                    },
-                  },
+
                   children: [
                     {
                       type: 'tabItem',
@@ -210,16 +160,6 @@ describe('tab directives', () => {
                               value: 'Tab one',
                             },
                           ],
-                          position: {
-                            start: {
-                              line: 4,
-                              column: 0,
-                            },
-                            end: {
-                              line: 5,
-                              column: 0,
-                            },
-                          },
                         },
                       ],
                     },
@@ -233,16 +173,7 @@ describe('tab directives', () => {
                     sync: 'tab2',
                   },
                   value: 'Tab two',
-                  position: {
-                    start: {
-                      line: 7,
-                      column: 0,
-                    },
-                    end: {
-                      line: 11,
-                      column: 0,
-                    },
-                  },
+
                   children: [
                     {
                       type: 'tabItem',
@@ -257,16 +188,6 @@ describe('tab directives', () => {
                               value: 'Tab two',
                             },
                           ],
-                          position: {
-                            start: {
-                              line: 9,
-                              column: 0,
-                            },
-                            end: {
-                              line: 10,
-                              column: 0,
-                            },
-                          },
                         },
                       ],
                     },
@@ -281,6 +202,6 @@ describe('tab directives', () => {
     const output = mystParse(content, {
       directives: [...tabDirectives],
     });
-    expect(output).toEqual(expected);
+    expect(deletePositions(output)).toEqual(expected);
   });
 });

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -15,6 +15,7 @@ import {
   mystPlugin,
   deflistPlugin,
   tasklistPlugin,
+  citationsPlugin,
 } from './plugins.js';
 import { applyDirectives } from './directives.js';
 import { applyRoles } from './roles.js';
@@ -32,6 +33,7 @@ export const defaultOptions: Omit<AllOptions, 'vfile'> = {
     frontmatter: true,
     math: true,
     footnotes: true,
+    citations: true,
     deflist: true,
     tasklist: true,
     tables: true,
@@ -63,6 +65,7 @@ export function createTokenizer(opts?: Options) {
   if (extensions.frontmatter) tokenizer.use(frontMatterPlugin, () => ({})).use(convertFrontMatter);
   if (extensions.blocks) tokenizer.use(mystBlockPlugin);
   if (extensions.footnotes) tokenizer.use(footnotePlugin).disable('footnote_inline'); // not yet implemented in myst-parser
+  if (extensions.citations) tokenizer.use(citationsPlugin);
   tokenizer.use(mystPlugin);
   if (extensions.math) tokenizer.use(mathPlugin, extensions.math);
   if (extensions.deflist) tokenizer.use(deflistPlugin);

--- a/packages/myst-parser/src/plugins.ts
+++ b/packages/myst-parser/src/plugins.ts
@@ -5,7 +5,7 @@ export { default as frontMatterPlugin } from 'markdown-it-front-matter';
 export { default as footnotePlugin } from 'markdown-it-footnote';
 export { default as tasklistPlugin } from 'markdown-it-task-lists';
 export { default as deflistPlugin } from 'markdown-it-deflist';
-export { mystPlugin } from 'markdown-it-myst';
+export { mystPlugin, citationsPlugin } from 'markdown-it-myst';
 export { mystBlockPlugin, colonFencePlugin } from 'markdown-it-myst-extras';
 export type { MathExtensionOptions } from './math.js';
 export { plugin as mathPlugin } from './math.js';

--- a/packages/myst-parser/src/tokensToMyst.ts
+++ b/packages/myst-parser/src/tokensToMyst.ts
@@ -335,6 +335,29 @@ const defaultMdast: Record<string, TokenHandlerSpec> = {
       return { identifier, label };
     },
   },
+  cite: {
+    type: 'cite',
+    noCloseToken: true,
+    isLeaf: true,
+    getAttrs(t) {
+      const { identifier, label } = normalizeLabel(t?.meta?.label) || {};
+      return {
+        identifier,
+        label,
+        kind: t.meta.kind,
+        partial: t.meta.partial, // author or year
+        // TODO: can use the parsed version in the future
+        prefix: t.meta.prefix?.[0].content,
+        suffix: t.meta.suffix?.[0].content,
+      };
+    },
+  },
+  cite_group: {
+    type: 'citeGroup',
+    getAttrs(t) {
+      return { kind: t.meta.kind };
+    },
+  },
   parsed_directive: {
     type: 'mystDirective',
     getAttrs(t) {

--- a/packages/myst-parser/src/types.ts
+++ b/packages/myst-parser/src/types.ts
@@ -22,6 +22,7 @@ export type AllOptions = {
     frontmatter?: boolean;
     math?: boolean | MathExtensionOptions;
     footnotes?: boolean;
+    citations?: boolean;
     deflist?: boolean;
     tasklist?: boolean;
     tables?: boolean;

--- a/packages/myst-parser/tests/commonmark.spec.ts
+++ b/packages/myst-parser/tests/commonmark.spec.ts
@@ -62,6 +62,7 @@ describe('Common Mark Spec with markdown it', () => {
       markdownit: { html: true },
       extensions: {
         frontmatter: false, // Frontmatter screws with some tests!
+        citations: false,
       },
     }).render(markdown);
     expect(output).toEqual(fixed);
@@ -80,6 +81,7 @@ describe('Common Mark Spec with unified', () => {
       },
       extensions: {
         frontmatter: false, // Frontmatter screws with some tests!
+        citations: false,
       },
     });
     const output = mystToHtml(tree, {

--- a/packages/myst-parser/tests/directives/ext.directive.spec.ts
+++ b/packages/myst-parser/tests/directives/ext.directive.spec.ts
@@ -20,7 +20,7 @@ describe('custom directive extensions', () => {
       children: [
         {
           type: 'mystDirective',
-          position: positionFn(0, 3),
+          position: positionFn(1, 3),
           name: 'test',
           value: '_a_',
           children: [
@@ -49,7 +49,7 @@ describe('custom directive extensions', () => {
       children: [
         {
           type: 'mystDirective',
-          position: positionFn(0, 3),
+          position: positionFn(1, 3),
           name: 'test',
           value: '_a_',
           children: [
@@ -58,13 +58,15 @@ describe('custom directive extensions', () => {
               children: [
                 {
                   type: 'paragraph',
-                  position: positionFn(1, 2),
+                  position: positionFn(2, 2),
                   children: [
                     {
                       type: 'emphasis',
+                      position: positionFn(2, 2),
                       children: [
                         {
                           type: 'text',
+                          position: positionFn(2, 2),
                           value: 'a',
                         },
                       ],
@@ -97,7 +99,7 @@ describe('custom directive extensions', () => {
       children: [
         {
           type: 'mystDirective',
-          position: positionFn(0, 3),
+          position: positionFn(1, 3),
           name: 'test',
           args: 'hello',
           value: '_a_',
@@ -130,7 +132,7 @@ describe('custom directive extensions', () => {
       children: [
         {
           type: 'mystDirective',
-          position: positionFn(0, 3),
+          position: positionFn(1, 3),
           name: 'test',
           args: '_a_',
           value: 'hello',
@@ -140,9 +142,11 @@ describe('custom directive extensions', () => {
               children: [
                 {
                   type: 'emphasis',
+                  position: positionFn(1, 1),
                   children: [
                     {
                       type: 'text',
+                      position: positionFn(1, 1),
                       value: 'a',
                     },
                   ],
@@ -172,7 +176,7 @@ describe('custom directive extensions', () => {
       children: [
         {
           type: 'mystDirective',
-          position: positionFn(0, 3),
+          position: positionFn(1, 3),
           name: 'test',
           options: {
             flag: true,
@@ -207,7 +211,7 @@ describe('custom directive extensions', () => {
       children: [
         {
           type: 'mystDirective',
-          position: positionFn(0, 3),
+          position: positionFn(1, 3),
           name: 'test',
           options: {
             flag: false,
@@ -245,7 +249,7 @@ describe('custom directive extensions', () => {
       children: [
         {
           type: 'mystDirective',
-          position: positionFn(0, 4),
+          position: positionFn(1, 4),
           name: 'test',
           options: {
             something: '_a_',
@@ -257,10 +261,12 @@ describe('custom directive extensions', () => {
               children: [
                 {
                   type: 'emphasis',
+                  position: positionFn(2, 2),
                   children: [
                     {
                       type: 'text',
                       value: 'a',
+                      position: positionFn(2, 2),
                     },
                   ],
                 },
@@ -291,7 +297,7 @@ describe('custom directive extensions', () => {
       children: [
         {
           type: 'mystDirective',
-          position: positionFn(0, 4),
+          position: positionFn(1, 4),
           name: 'test',
           options: {
             a: 'x',
@@ -328,7 +334,7 @@ describe('custom directive extensions', () => {
       children: [
         {
           type: 'mystDirective',
-          position: positionFn(0, 4),
+          position: positionFn(1, 4),
           name: 'test',
           options: {
             a: 'x',
@@ -360,7 +366,7 @@ describe('custom directive extensions', () => {
       children: [
         {
           type: 'mystDirective',
-          position: positionFn(0, 3),
+          position: positionFn(1, 3),
           name: 'abc',
           value: '_a_',
           children: [
@@ -390,7 +396,7 @@ describe('custom directive extensions', () => {
       children: [
         {
           type: 'mystDirective',
-          position: positionFn(0, 3),
+          position: positionFn(1, 3),
           name: 'def',
           value: '_a_',
           children: [

--- a/packages/myst-parser/tests/myst.spec.ts
+++ b/packages/myst-parser/tests/myst.spec.ts
@@ -115,6 +115,7 @@ describe('Testing myst --> mdast conversions', () => {
               },
               extensions: {
                 frontmatter: false, // Frontmatter screws with some tests!
+                citations: false,
               },
             }),
           ),

--- a/packages/myst-parser/tests/position.ts
+++ b/packages/myst-parser/tests/position.ts
@@ -1,22 +1,27 @@
 export const position = {
   end: {
-    column: 0,
+    column: 1,
     line: 1,
   },
   start: {
-    column: 0,
-    line: 0,
+    column: 1,
+    line: 1,
   },
 };
 
-export const positionFn = (start: number, end: number) => {
+export const positionFn = (
+  start: number,
+  end: number,
+  colStart: number = 1,
+  colEnd: number = 1,
+) => {
   return {
     end: {
-      column: 0,
+      column: colEnd,
       line: end,
     },
     start: {
-      column: 0,
+      column: colStart,
       line: start,
     },
   };

--- a/packages/myst-parser/tests/roles/ext.role.spec.ts
+++ b/packages/myst-parser/tests/roles/ext.role.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import type { GenericNode, RoleData, RoleSpec } from 'myst-common';
 import { mystParse } from '../../src';
-import { position } from '../position';
+import { position, positionFn } from '../position';
 
 describe('custom role extensions', () => {
   test('test role with string body', () => {
@@ -24,7 +24,7 @@ describe('custom role extensions', () => {
           children: [
             {
               type: 'mystRole',
-              position,
+              position: positionFn(1, 1, 1, 12),
               name: 'test',
               value: '_a_',
               children: [
@@ -60,7 +60,7 @@ describe('custom role extensions', () => {
           children: [
             {
               type: 'mystRole',
-              position,
+              position: positionFn(1, 1, 1, 12),
               name: 'test',
               value: '_a_',
               children: [
@@ -73,8 +73,10 @@ describe('custom role extensions', () => {
                         {
                           type: 'text',
                           value: 'a',
+                          position,
                         },
                       ],
+                      position,
                     },
                   ],
                 },
@@ -106,7 +108,7 @@ describe('custom role extensions', () => {
           children: [
             {
               type: 'mystRole',
-              position,
+              position: positionFn(1, 1, 1, 11),
               name: 'abc',
               value: '_a_',
               children: [
@@ -142,7 +144,7 @@ describe('custom role extensions', () => {
           children: [
             {
               type: 'mystRole',
-              position,
+              position: positionFn(1, 1, 1, 11),
               name: 'def',
               value: '_a_',
               children: [

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -99,9 +99,10 @@ export type Cite = {
   kind: CiteKind;
   label: string;
   children: StaticPhrasingContent[];
-  error?: boolean;
+  error?: boolean | 'not found' | 'rendering error';
   prefix?: string;
   suffix?: string;
+  partial?: 'author' | 'year';
 };
 
 export type CiteGroup = {


### PR DESCRIPTION
Adds pandoc-style `@citations`:

- `[@author2016, pg. 23; @author2023]`
- `See @author2023`
- `In authors et al. [-@author2023]`

As part of this I have improved the column and line tracking in `myst-parser`.

![image](https://github.com/executablebooks/mystmd/assets/913249/b4ba63c3-48b2-46ff-a151-5f3a9dd39f2d)

The citations and roles are now correctly linked with column information:
![image](https://github.com/executablebooks/mystmd/assets/913249/724a2a4c-60b3-429c-bf49-c7712fb55577)
This makes finding a particular citation much easier from the command line.