### PR TITLE
🐛 Fix bug with async project/site loading

### DIFF
--- a/.changeset/cold-weeks-hunt.md
+++ b/.changeset/cold-weeks-hunt.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fix bug with async project/site loading

--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -123,7 +123,7 @@ export async function localArticleToWord(
   extraLinkTransformers?: LinkTransformer[],
 ): Promise<ExportResults> {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
     await collectWordExportOptions(session, file, 'docx', [ExportFormats.docx], projectPath, opts)

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -68,7 +68,7 @@ export async function localArticleToJats(
   extraLinkTransformers?: LinkTransformer[],
 ) {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
     await collectBasicExportOptions(session, file, 'xml', [ExportFormats.xml], projectPath, opts)

--- a/packages/myst-cli/src/build/md/index.ts
+++ b/packages/myst-cli/src/build/md/index.ts
@@ -55,7 +55,7 @@ export async function localArticleToMd(
   extraLinkTransformers?: LinkTransformer[],
 ) {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
     await collectBasicExportOptions(session, file, 'md', [ExportFormats.md], projectPath, opts)

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -392,7 +392,7 @@ export async function localProjectToMeca(
   extraLinkTransformers?: LinkTransformer[],
 ) {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
     await collectBasicExportOptions(session, file, 'zip', [ExportFormats.meca], projectPath, opts)

--- a/packages/myst-cli/src/build/pdf/single.ts
+++ b/packages/myst-cli/src/build/pdf/single.ts
@@ -35,7 +35,7 @@ export async function localArticleToPdf(
   templateOptions?: Record<string, any>,
 ): Promise<ExportResults> {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const pdfExportOptionsList = (
     await collectTexExportOptions(

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -243,7 +243,7 @@ export async function localArticleToTex(
   extraLinkTransformers?: LinkTransformer[],
 ): Promise<ExportResults> {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
     await collectTexExportOptions(session, file, 'tex', [ExportFormats.tex], projectPath, opts)

--- a/packages/myst-cli/src/build/utils/collectExportOptions.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.ts
@@ -277,7 +277,7 @@ export async function collectExportOptions(
     sourceFiles.map(async (file) => {
       let fileProjectPath: string | undefined;
       if (!projectPath) {
-        fileProjectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
+        fileProjectPath = findCurrentProjectAndLoad(session, path.dirname(file));
         if (fileProjectPath) await loadProjectFromDisk(session, fileProjectPath);
       } else {
         fileProjectPath = projectPath;

--- a/packages/myst-cli/src/build/utils/localArticleExport.ts
+++ b/packages/myst-cli/src/build/utils/localArticleExport.ts
@@ -26,9 +26,7 @@ async function _localArticleExport(
       const { format, output } = exportOptions;
       const sessionClone = session.clone();
       const fileProjectPath =
-        projectPath ??
-        $project ??
-        (await findCurrentProjectAndLoad(sessionClone, path.dirname($file)));
+        projectPath ?? $project ?? findCurrentProjectAndLoad(sessionClone, path.dirname($file));
 
       let exportResults: ExportResults | undefined;
       if (fileProjectPath) {

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -343,10 +343,7 @@ export function writeConfigs(
   writeFileToFolder(file, yaml.dump(newConfig), 'utf-8');
 }
 
-export async function findCurrentProjectAndLoad(
-  session: ISession,
-  path: string,
-): Promise<string | undefined> {
+export function findCurrentProjectAndLoad(session: ISession, path: string): string | undefined {
   path = resolve(path);
   if (configFromPath(session, path)) {
     loadConfigAndValidateOrThrow(session, path);
@@ -362,10 +359,7 @@ export async function findCurrentProjectAndLoad(
   return findCurrentProjectAndLoad(session, dirname(path));
 }
 
-export async function findCurrentSiteAndLoad(
-  session: ISession,
-  path: string,
-): Promise<string | undefined> {
+export function findCurrentSiteAndLoad(session: ISession, path: string): string | undefined {
   path = resolve(path);
   if (configFromPath(session, path)) {
     loadConfigAndValidateOrThrow(session, path);


### PR DESCRIPTION
Addresses #625 - turns out the loading functions were erroneously marked as `async`. This pr just gets rid of that and gets rid of any `await`s elsewhere...