### PR TITLE
🐑 Keep track of session clones for error reporting

### DIFF
--- a/.changeset/famous-maps-float.md
+++ b/.changeset/famous-maps-float.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Keep track of session clones for error reporting

--- a/packages/myst-cli/src/session/session.spec.ts
+++ b/packages/myst-cli/src/session/session.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { addWarningForFile } from 'myst-cli';
+import { Session } from '../session';
+import { RuleId } from 'myst-common';
+
+describe('session warnings', () => {
+  it('getAllWarnings returns for single session', async () => {
+    const session = new Session();
+    addWarningForFile(session, 'my-file', 'my message', 'error', { ruleId: RuleId.bibFileExists });
+    expect(session.getAllWarnings(RuleId.bibFileExists)).toEqual([
+      {
+        file: 'my-file',
+        message: 'my message',
+        kind: 'error',
+        ruleId: RuleId.bibFileExists,
+      },
+    ]);
+  });
+  it('getAllWarnings empty for different rule', async () => {
+    const session = new Session();
+    addWarningForFile(session, 'my-file', 'my message', 'error', {
+      ruleId: RuleId.blockMetadataLoads,
+    });
+    expect(session.getAllWarnings(RuleId.bibFileExists)).toEqual([]);
+  });
+  it('getAllWarnings returns clone warnings', async () => {
+    const session = new Session();
+    const clone = session.clone();
+    addWarningForFile(session, 'my-file-0', 'my message', 'error', {
+      ruleId: RuleId.bibFileExists,
+    });
+    addWarningForFile(clone, 'my-file-1', 'my message', 'error', { ruleId: RuleId.bibFileExists });
+    expect(session.getAllWarnings(RuleId.bibFileExists)).toEqual([
+      {
+        file: 'my-file-0',
+        message: 'my message',
+        kind: 'error',
+        ruleId: RuleId.bibFileExists,
+      },
+      {
+        file: 'my-file-1',
+        message: 'my message',
+        kind: 'error',
+        ruleId: RuleId.bibFileExists,
+      },
+    ]);
+    expect(clone.getAllWarnings(RuleId.bibFileExists)).toEqual([
+      {
+        file: 'my-file-1',
+        message: 'my message',
+        kind: 'error',
+        ruleId: RuleId.bibFileExists,
+      },
+    ]);
+  });
+  it('getAllWarnings deduplicates clone warnings', async () => {
+    const session = new Session();
+    const clone = session.clone();
+    addWarningForFile(session, 'my-file', 'my message', 'error', { ruleId: RuleId.bibFileExists });
+    addWarningForFile(clone, 'my-file', 'my message', 'error', { ruleId: RuleId.bibFileExists });
+    expect(session.getAllWarnings(RuleId.bibFileExists)).toEqual([
+      {
+        file: 'my-file',
+        message: 'my message',
+        kind: 'error',
+        ruleId: RuleId.bibFileExists,
+      },
+    ]);
+    expect(clone.getAllWarnings(RuleId.bibFileExists)).toEqual([
+      {
+        file: 'my-file',
+        message: 'my message',
+        kind: 'error',
+        ruleId: RuleId.bibFileExists,
+      },
+    ]);
+  });
+});

--- a/packages/myst-cli/src/session/types.ts
+++ b/packages/myst-cli/src/session/types.ts
@@ -1,13 +1,13 @@
 import type { CitationRenderer } from 'citation-js-utils';
 import type { Inventory } from 'intersphinx';
 import type { Logger } from 'myst-cli-utils';
+import type { MystPlugin, RuleId } from 'myst-common';
 import type { ReferenceState } from 'myst-transforms';
 import type { MinifiedContentCache } from 'nbtx';
 import type { Store } from 'redux';
 
-import type { RootState } from '../store/index.js';
+import type { BuildWarning, RootState } from '../store/index.js';
 import type { PreRendererData, RendererData, SingleCitationRenderer } from '../transforms/types.js';
-import type { MystPlugin } from 'myst-common';
 
 export type ISession = {
   API_URL: string;
@@ -23,6 +23,7 @@ export type ISession = {
   showUpgradeNotice(): void;
   plugins: MystPlugin | undefined;
   loadPlugins(): Promise<MystPlugin>;
+  getAllWarnings(ruleId: RuleId): (BuildWarning & { file: string })[];
 };
 
 export type ISessionWithCache = ISession & {


### PR DESCRIPTION
Cloning a session didn't actually do anything besides create a new session... now, the original session keeps track of its clones. This means we can do things like report all errors/warnings from simultaneous builds using these clones.