### PR TITLE
🔧 Fix up undefined types from selectors

### DIFF
--- a/.changeset/sixty-balloons-fix.md
+++ b/.changeset/sixty-balloons-fix.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fix up undefined types from selectors

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -73,10 +73,10 @@ async function copyFilesFromConfig(
 ) {
   const projConfig = selectors.selectLocalProjectConfig(session.store.getState(), projectPath);
   const entries: { itemType: string; entry: string }[] = [
-    ...(projConfig.requirements ?? []).map((entry: string) => {
+    ...(projConfig?.requirements ?? []).map((entry: string) => {
       return { itemType: 'article-source-environment', entry };
     }),
-    ...(projConfig.resources ?? []).map((entry: string) => {
+    ...(projConfig?.resources ?? []).map((entry: string) => {
       return { itemType: 'article-source', entry };
     }),
   ];
@@ -312,16 +312,25 @@ export async function runMecaExport(
   const bundle = bundleFolder(mecaFolder);
   if (projectPath && project) {
     // Copy myst.yml
-    const configDest = copyFileMaintainPath(
-      session,
-      selectors.selectLocalConfigFile(session.store.getState(), projectPath),
-      projectPath,
-      bundle,
-      fileCopyErrorLogFn,
-    );
-    addManifestItem(manifestItems, 'article-source', mecaFolder, configDest);
-    // Copy requirements and resources
-    await copyFilesFromConfig(session, projectPath, mecaFolder, manifestItems, fileCopyErrorLogFn);
+    const configFile = selectors.selectLocalConfigFile(session.store.getState(), projectPath);
+    if (configFile) {
+      const configDest = copyFileMaintainPath(
+        session,
+        configFile,
+        projectPath,
+        bundle,
+        fileCopyErrorLogFn,
+      );
+      addManifestItem(manifestItems, 'article-source', mecaFolder, configDest);
+      // Copy requirements and resources
+      await copyFilesFromConfig(
+        session,
+        projectPath,
+        mecaFolder,
+        manifestItems,
+        fileCopyErrorLogFn,
+      );
+    }
     // Copy table of contents or write one if it does not exist
     if (fs.existsSync(path.join(projectPath, '_toc.yml'))) {
       copyFileToFolder(session, path.join(projectPath, '_toc.yml'), bundle, fileCopyErrorLogFn);

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -74,11 +74,11 @@ export async function localToManifestProject(
 
   const projFrontmatter = projConfig ? filterKeys(projConfig, PROJECT_FRONTMATTER_KEYS) : {};
   const projConfigFile = selectors.selectLocalConfigFile(state, projectPath);
-  const exports = (await resolvePageExports(session, projConfigFile)).map(
-    ({ format, filename, url }) => {
-      return { format, filename, url };
-    },
-  );
+  const exports = projConfigFile
+    ? (await resolvePageExports(session, projConfigFile)).map(({ format, filename, url }) => {
+        return { format, filename, url };
+      })
+    : [];
   const banner = await transformBanner(
     session,
     path.join(projectPath, 'myst.yml'),

--- a/packages/myst-cli/src/build/utils/collectExportOptions.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.ts
@@ -270,7 +270,8 @@ export async function collectExportOptions(
   const sourceFiles = [...files];
   if (projectPath) {
     await loadProjectFromDisk(session, projectPath);
-    sourceFiles.push(selectors.selectLocalConfigFile(session.store.getState(), projectPath));
+    const configFile = selectors.selectLocalConfigFile(session.store.getState(), projectPath);
+    if (configFile) sourceFiles.push(configFile);
   }
   const exportOptionsList: ExportWithInputOutput[] = [];
   await Promise.all(

--- a/packages/myst-cli/src/process/intersphinx.ts
+++ b/packages/myst-cli/src/process/intersphinx.ts
@@ -13,11 +13,12 @@ export async function loadIntersphinx(
 ): Promise<Inventory[]> {
   const state = session.store.getState();
   const projectConfig = selectors.selectLocalProjectConfig(state, opts.projectPath);
-  const vfile = new VFile();
-  vfile.path = selectors.selectLocalConfigFile(state, opts.projectPath);
-  const cache = castSession(session);
+  const configFile = selectors.selectLocalConfigFile(state, opts.projectPath);
   // A bit confusing here, references is the frontmatter, but those are `externalReferences`
-  if (!projectConfig?.references) return [];
+  if (!projectConfig?.references || !configFile) return [];
+  const vfile = new VFile();
+  vfile.path = configFile;
+  const cache = castSession(session);
   const references = Object.entries(projectConfig.references)
     .filter(([key, object]) => {
       if (isUrl(object.url)) return true;

--- a/packages/myst-cli/src/store/selectors.ts
+++ b/packages/myst-cli/src/store/selectors.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import type { SiteConfig } from 'myst-config';
+import type { ProjectConfig, SiteConfig } from 'myst-config';
 import type { LocalProject, LocalProjectPage } from '../project/types.js';
 import type { RootState } from './reducers.js';
 import type { BuildWarning, ExternalLinkResult } from './types.js';
@@ -12,7 +12,7 @@ export function selectAffiliation(state: RootState, id: string): string | undefi
   return state.local.affiliations[id];
 }
 
-export function selectLocalSiteConfig(state: RootState, path: string) {
+export function selectLocalSiteConfig(state: RootState, path: string): ProjectConfig | undefined {
   return state.local.config.sites[resolve(path)];
 }
 
@@ -38,7 +38,10 @@ export function selectCurrentSiteFile(state: RootState) {
   return state.local.config.filenames[resolve(state.local.config.currentSitePath)];
 }
 
-export function selectLocalProjectConfig(state: RootState, path: string) {
+export function selectLocalProjectConfig(
+  state: RootState,
+  path: string,
+): ProjectConfig | undefined {
   return state.local.config.projects[resolve(path)];
 }
 
@@ -55,7 +58,7 @@ export function selectCurrentProjectFile(state: RootState) {
   if (!state.local.config.currentProjectPath) return undefined;
   return state.local.config.filenames[resolve(state.local.config.currentProjectPath)];
 }
-export function selectLocalConfigFile(state: RootState, path: string) {
+export function selectLocalConfigFile(state: RootState, path: string): string | undefined {
   return state.local.config.filenames[resolve(path)];
 }
 

--- a/packages/mystmd/tests/exports.yml
+++ b/packages/mystmd/tests/exports.yml
@@ -5,3 +5,9 @@ cases:
     outputs:
       - path: basic-md-and-config/_build/exports/index.xml
         content: outputs/basic-md-and-config.xml
+  - title: Export with no config works
+    cwd: no-config
+    command: myst build --jats index.md -o _build/index.xml
+    outputs:
+      - path: no-config/_build/index.xml
+        content: outputs/basic-md-and-config.xml

--- a/packages/mystmd/tests/no-config/index.md
+++ b/packages/mystmd/tests/no-config/index.md
@@ -1,0 +1,3 @@
+# Index
+
+Hello world


### PR DESCRIPTION
Hopefully this actually fixes #625 - a few `selectors` were not recognizing that they may have `undefined` results, meaning that case was not handled appropriately. After explicitly adding that return type, type errors were exposed and resolved.

I was able to recreate #625 by simply deleting my `myst.yml` file and trying to build an export; with this fix, that now works fine.