### PR TITLE
🤐 Add tex-zip to manuscripts included with meca

### DIFF
--- a/.changeset/lemon-fireants-love.md
+++ b/.changeset/lemon-fireants-love.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Add tex-zip to manuscripts included with meca

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -279,15 +279,20 @@ export async function runMecaExport(
       });
     }
   });
-  // Copy any existing pdf/docx exports
-  const manuscriptExports = await collectExportOptions(
-    session,
-    article ? [article] : [],
-    [ExportFormats.docx, ExportFormats.pdf],
-    {
-      projectPath,
-    },
-  );
+  // Copy any existing pdf/docx/tex-zip exports
+  const manuscriptExports = (
+    await collectExportOptions(
+      session,
+      article ? [article] : [],
+      [ExportFormats.docx, ExportFormats.pdf, ExportFormats.tex],
+      {
+        projectPath,
+      },
+    )
+  ).filter((exp) => {
+    // Do not copy unzipped tex exports
+    return exp.format !== ExportFormats.tex || path.extname(exp.output) === '.zip';
+  });
   manuscriptExports.forEach(({ output: manuscriptOutput }) => {
     if (!fs.existsSync(manuscriptOutput)) {
       fileWarn(


### PR DESCRIPTION
This addresses #611 - if a tex export with a .zip output file is specified, it will be added to the meca bundle as a manuscript.