### PR TITLE
🎆 Add inline property to images in paragraphs

### DIFF
--- a/.changeset/fifty-dolphins-sneeze.md
+++ b/.changeset/fifty-dolphins-sneeze.md
@@ -1,0 +1,7 @@
+---
+'myst-transforms': patch
+'myst-spec-ext': patch
+'myst-cli': patch
+---
+
+Add inline property to images in paragraphs

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -24,6 +24,7 @@ import {
   joinGatesPlugin,
   glossaryPlugin,
   abbreviationPlugin,
+  imageInlineTransform,
 } from 'myst-transforms';
 import { unified } from 'unified';
 import { VFile } from 'vfile';
@@ -239,6 +240,7 @@ export async function transformMdast(
       });
     }
   }
+  imageInlineTransform(mdast);
   await transformDeleteBase64UrlSource(mdast);
   const sha256 = selectors.selectFileInfo(store.getState(), file).sha256 as string;
   const useSlug = pageSlug !== index;

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -67,6 +67,7 @@ export type Image = SpecImage & {
   urlSource?: string;
   height?: string;
   placeholder?: boolean;
+  inline?: boolean;
 };
 
 export type Iframe = {

--- a/packages/myst-transforms/src/images.spec.ts
+++ b/packages/myst-transforms/src/images.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest';
+import { imageInlineTransform } from './images';
+
+describe('Test imageInlineTransform', () => {
+  test('image outside paragraph returns self', async () => {
+    const mdast = { type: 'root', children: [{ type: 'image', url: 'my-image' }] };
+    imageInlineTransform(mdast);
+    expect(mdast).toEqual({ type: 'root', children: [{ type: 'image', url: 'my-image' }] });
+  });
+  test('image inside paragraph adds inline', async () => {
+    const mdast = {
+      type: 'root',
+      children: [{ type: 'paragraph', children: [{ type: 'image', url: 'my-image' }] }],
+    };
+    imageInlineTransform(mdast);
+    expect(mdast).toEqual({
+      type: 'root',
+      children: [
+        { type: 'paragraph', children: [{ type: 'image', url: 'my-image', inline: true }] },
+      ],
+    });
+  });
+});

--- a/packages/myst-transforms/src/images.ts
+++ b/packages/myst-transforms/src/images.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from 'unified';
-import type { Container, Paragraph, PhrasingContent, Image } from 'myst-spec';
+import type { Container, Paragraph, PhrasingContent } from 'myst-spec';
+import type { Image } from 'myst-spec-ext';
 import { select, selectAll } from 'unist-util-select';
 import type { GenericParent } from 'myst-common';
 import { toText } from 'myst-common';
@@ -21,3 +22,10 @@ export function imageAltTextTransform(tree: GenericParent) {
 export const imageAltTextPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
   imageAltTextTransform(tree);
 };
+
+export function imageInlineTransform(tree: GenericParent) {
+  const imagesInParagraphs = selectAll('paragraph > image', tree) as Image[];
+  imagesInParagraphs.forEach((image) => {
+    image.inline = true;
+  });
+}

--- a/packages/myst-transforms/src/index.ts
+++ b/packages/myst-transforms/src/index.ts
@@ -25,7 +25,7 @@ export {
 } from './blocks.js';
 export { codePlugin, codeTransform } from './code.js';
 export { blockquotePlugin, blockquoteTransform } from './blockquote.js';
-export { imageAltTextPlugin, imageAltTextTransform } from './images.js';
+export { imageAltTextPlugin, imageAltTextTransform, imageInlineTransform } from './images.js';
 export {
   liftMystDirectivesAndRolesPlugin,
   liftMystDirectivesAndRolesTransform,


### PR DESCRIPTION
For all images that are children of `paragraph` nodes, add `inline: true` property. This will happen when an image is declared inline, e.g.:

```md
Here is my image ![](image.png) - it's inline!
```

(note: this works well with the `myst-parser` transform that ensures standalone images are _not_ nested in paragraphs - https://github.com/executablebooks/mystmd/blob/main/packages/myst-parser/src/tokensToMyst.ts#L470)