### PR TITLE
🧑‍💻 Create flat XML by default in JATS export

### DIFF
--- a/.changeset/thin-eggs-tie.md
+++ b/.changeset/thin-eggs-tie.md
@@ -1,0 +1,6 @@
+---
+'myst-to-jats': patch
+'myst-cli': patch
+---
+
+Create zero-indent XML by default (newlines, but no indentation)

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -53,7 +53,7 @@ export async function runJatsExport(
   const jats = writeJats(vfile, processedArticle as any, {
     subArticles: processedSubArticles as any,
     writeFullArticle: true,
-    spaces: 2,
+    spaces: 0,
     abstractParts: [
       { part: 'abstract' },
       {

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -848,9 +848,14 @@ export function writeJats(file: VFile, content: ArticleContent, opts?: DocumentO
     : doc.body();
   const jats = js2xml(element, {
     compact: false,
-    spaces: opts?.spaces,
+    spaces: opts?.spaces === 'flat' ? 0 : opts?.spaces || 1,
   });
-  file.result = jats;
+  if (!opts?.spaces) {
+    // either `0` or `''`
+    file.result = jats.replace(/\n(\s*)</g, '\n<');
+  } else {
+    file.result = jats;
+  }
   return file;
 }
 

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -848,6 +848,8 @@ export function writeJats(file: VFile, content: ArticleContent, opts?: DocumentO
     : doc.body();
   const jats = js2xml(element, {
     compact: false,
+    //  No way to write XML with new lines, but no indentation with js2xml.
+    // If you use 0 or '', you get a single line.
     spaces: opts?.spaces === 'flat' ? 0 : opts?.spaces || 1,
   });
   if (!opts?.spaces) {

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -33,7 +33,12 @@ export type Options = {
 
 export type DocumentOptions = Options & {
   subArticles?: ArticleContent[];
-  spaces?: number;
+  /**
+   * When 'flat', the xml will be on a single line (with exception of CDATA),
+   * When `0`, the XML will be on different lines with 0 spaces.
+   * When any other value (e.g. `2` or `\t`) the XML will be indented at the start of the line by that amount.
+   */
+  spaces?: number | 'flat' | '\t';
   writeFullArticle?: boolean;
 };
 

--- a/packages/myst-to-jats/tests/basic.spec.ts
+++ b/packages/myst-to-jats/tests/basic.spec.ts
@@ -75,7 +75,14 @@ beforeEach(() => {
 describe('Basic JATS body', () => {
   const cases = [...loadCases('basic.yml'), ...loadCases('siunit.yml')];
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))('%s', async (_, { tree, jats }) => {
-    const pipe = unified().use(mystToJats, SourceFileKind.Article);
+    const pipe = unified().use(
+      mystToJats,
+      SourceFileKind.Article,
+      undefined,
+      undefined,
+      undefined,
+      { spaces: 'flat' },
+    );
     pipe.runSync(tree as any);
     const vfile = pipe.stringify(tree as any);
     expect(vfile.result).toEqual(jats);

--- a/packages/mystmd/tests/outputs/basic-md-and-config.xml
+++ b/packages/mystmd/tests/outputs/basic-md-and-config.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
 <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en" id="index">
-  <front>
-    <article-meta>
-      <title-group>
-        <article-title>Index</article-title>
-      </title-group>
-    </article-meta>
-  </front>
-  <body>
-    <p>Hello world</p>
-  </body>
+<front>
+<article-meta>
+<title-group>
+<article-title>Index</article-title>
+</title-group>
+</article-meta>
+</front>
+<body>
+<p>Hello world</p>
+</body>
 </article>


### PR DESCRIPTION
This adds new lines in the XML exports, but has zero indentation (previously this was 2 spaces).