### PR TITLE
🐛 Add `plain-language-summary` & `summary` parts

### DIFF
--- a/.changeset/six-bikes-divide.md
+++ b/.changeset/six-bikes-divide.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Add 'summary' to the list of known parts for `plain-text-summary` parts

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -57,7 +57,7 @@ export async function runJatsExport(
     abstractParts: [
       { part: 'abstract' },
       {
-        part: 'plain-language-summary',
+        part: ['plain-language-summary', 'plain-language-abstract', 'summary'],
         type: 'plain-language-summary',
         title: 'Plain Language Summary',
       },


### PR DESCRIPTION
This adds aliases for the `plain-language-summary`, now used and parsed by default.

This is necessary for the agu2019 template.