### PR TITLE
🏷 Ability to customize IDs in myst-to-jats

### DIFF
--- a/.changeset/dull-dolphins-learn.md
+++ b/.changeset/dull-dolphins-learn.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Add ability to customize ID funciton in myst-to-jats processing

--- a/packages/myst-to-jats/src/transforms/references.ts
+++ b/packages/myst-to-jats/src/transforms/references.ts
@@ -21,12 +21,13 @@ const CONTAINER_KINDS: (keyof IdInventory)[] = ['figure', 'table', 'code', 'quot
 function updateInventory(
   node: GenericNode,
   key: keyof IdInventory,
-  idPrefix: string,
+  idPrefix: string | ((count: number) => string),
   inventory: IdInventory,
 ) {
   const keyInv = inventory[key] ?? { count: 0, lookup: {} };
   keyInv.count += 1;
-  const newId = `${idPrefix}-${keyInv.count}`;
+  const newId =
+    typeof idPrefix === 'function' ? idPrefix(keyInv.count) : `${idPrefix}-${keyInv.count}`;
   if (node.identifier) {
     keyInv.lookup[node.identifier] = newId;
   }
@@ -72,9 +73,7 @@ export function referenceTargetTransform(
   if (!citations) return;
   const citationIds = Object.keys(citations);
   citationIds.forEach((citationId) => {
-    if (!inventory.cite?.count) {
-      inventory.cite = { count: 0, lookup: {} };
-    }
+    inventory.cite ??= { count: 0, lookup: {} };
     if (!inventory.cite.lookup[citationId]) {
       inventory.cite.count += 1;
       const newId = `ref-${inventory.cite.count}`;


### PR DESCRIPTION
Still to do is to customize both the types of elements that are numbered as well as pass in the counter functions as options. Ideally through a plugin structure.