### PR TITLE
🔧 Improve JATS names

### DIFF
--- a/.changeset/chilled-mirrors-watch.md
+++ b/.changeset/chilled-mirrors-watch.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Add default name-style="western" to jats names

--- a/.changeset/fresh-buckets-carry.md
+++ b/.changeset/fresh-buckets-carry.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Remove string-name element if name element is present

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -147,13 +147,14 @@ export function getArticleAuthors(frontmatter: ProjectFrontmatter): Element[] {
       elements.push({
         type: 'element',
         name: 'name',
+        attributes: { 'name-style': 'western' },
         elements: nameElements,
       });
-    }
-    if (author.name) {
+    } else if (author.name) {
       elements.push({
         type: 'element',
         name: 'string-name',
+        attributes: { 'name-style': 'western' },
         elements: [{ type: 'text', text: author.name }],
       });
     }
@@ -484,13 +485,14 @@ export function getFundingGroup(frontmatter: ProjectFrontmatter): Element[] {
                   recipientElements.push({
                     type: 'element',
                     name: 'name',
+                    attributes: { 'name-style': 'western' },
                     elements: nameElements,
                   });
-                }
-                if (author.name) {
+                } else if (author.name) {
                   recipientElements.push({
                     type: 'element',
                     name: 'string-name',
+                    attributes: { 'name-style': 'western' },
                     elements: [{ type: 'text', text: author.name }],
                   });
                 }
@@ -559,13 +561,14 @@ export function getFundingGroup(frontmatter: ProjectFrontmatter): Element[] {
                   investigatorElements.push({
                     type: 'element',
                     name: 'name',
+                    attributes: { 'name-style': 'western' },
                     elements: nameElements,
                   });
-                }
-                if (author.name) {
+                } else if (author.name) {
                   investigatorElements.push({
                     type: 'element',
                     name: 'string-name',
+                    attributes: { 'name-style': 'western' },
                     elements: [{ type: 'text', text: author.name }],
                   });
                 }

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -85,6 +85,58 @@ export function getArticleTitle(frontmatter: ProjectFrontmatter): Element[] {
   ];
 }
 
+function nameElementFromContributor(contrib: Contributor): Element | undefined {
+  if (contrib.nameParsed && (contrib.nameParsed?.given || contrib.nameParsed?.family)) {
+    const { given, family, dropping_particle, non_dropping_particle, suffix } = contrib.nameParsed;
+    const nameElements: Element[] = [];
+    if (family) {
+      nameElements.push({
+        type: 'element',
+        name: 'surname',
+        elements: [
+          {
+            type: 'text',
+            text: non_dropping_particle ? `${non_dropping_particle} ${family}` : family,
+          },
+        ],
+      });
+    }
+    if (given) {
+      nameElements.push({
+        type: 'element',
+        name: 'given-names',
+        elements: [
+          {
+            type: 'text',
+            text: dropping_particle ? `${given} ${dropping_particle}` : given,
+          },
+        ],
+      });
+    }
+    // Prefix not yet supported by name parsing
+    if (suffix) {
+      nameElements.push({
+        type: 'element',
+        name: 'suffix',
+        elements: [{ type: 'text', text: suffix }],
+      });
+    }
+    return {
+      type: 'element',
+      name: 'name',
+      attributes: { 'name-style': 'western' },
+      elements: nameElements,
+    };
+  } else if (contrib.name) {
+    return {
+      type: 'element',
+      name: 'string-name',
+      attributes: { 'name-style': 'western' },
+      elements: [{ type: 'text', text: contrib.name }],
+    };
+  }
+}
+
 /**
  * Add authors and contributors to contrib-group
  *
@@ -109,55 +161,8 @@ export function getArticleAuthors(frontmatter: ProjectFrontmatter): Element[] {
         elements: [{ type: 'text', text: author.orcid }],
       });
     }
-    if (author.nameParsed && (author.nameParsed?.given || author.nameParsed?.family)) {
-      const { given, family, dropping_particle, non_dropping_particle, suffix } = author.nameParsed;
-      const nameElements: Element[] = [];
-      if (family) {
-        nameElements.push({
-          type: 'element',
-          name: 'surname',
-          elements: [
-            {
-              type: 'text',
-              text: non_dropping_particle ? `${non_dropping_particle} ${family}` : family,
-            },
-          ],
-        });
-      }
-      if (given) {
-        nameElements.push({
-          type: 'element',
-          name: 'given-names',
-          elements: [
-            {
-              type: 'text',
-              text: dropping_particle ? `${given} ${dropping_particle}` : given,
-            },
-          ],
-        });
-      }
-      // Prefix not yet supported by name parsing
-      if (suffix) {
-        nameElements.push({
-          type: 'element',
-          name: 'suffix',
-          elements: [{ type: 'text', text: suffix }],
-        });
-      }
-      elements.push({
-        type: 'element',
-        name: 'name',
-        attributes: { 'name-style': 'western' },
-        elements: nameElements,
-      });
-    } else if (author.name) {
-      elements.push({
-        type: 'element',
-        name: 'string-name',
-        attributes: { 'name-style': 'western' },
-        elements: [{ type: 'text', text: author.name }],
-      });
-    }
+    const name = nameElementFromContributor(author);
+    if (name) elements.push(name);
     if (author.roles) {
       elements.push(
         ...author.roles.map((role): Element => {
@@ -444,58 +449,8 @@ export function getFundingGroup(frontmatter: ProjectFrontmatter): Element[] {
                     elements: [{ type: 'text', text: author.orcid }],
                   });
                 }
-                if (author.nameParsed && (author.nameParsed?.given || author.nameParsed?.family)) {
-                  const { given, family, dropping_particle, non_dropping_particle, suffix } =
-                    author.nameParsed;
-                  const nameElements: Element[] = [];
-                  if (family) {
-                    nameElements.push({
-                      type: 'element',
-                      name: 'surname',
-                      elements: [
-                        {
-                          type: 'text',
-                          text: non_dropping_particle
-                            ? `${non_dropping_particle} ${family}`
-                            : family,
-                        },
-                      ],
-                    });
-                  }
-                  if (given) {
-                    nameElements.push({
-                      type: 'element',
-                      name: 'given-names',
-                      elements: [
-                        {
-                          type: 'text',
-                          text: dropping_particle ? `${given} ${dropping_particle}` : given,
-                        },
-                      ],
-                    });
-                  }
-                  // Prefix not yet supported by name parsing
-                  if (suffix) {
-                    nameElements.push({
-                      type: 'element',
-                      name: 'suffix',
-                      elements: [{ type: 'text', text: suffix }],
-                    });
-                  }
-                  recipientElements.push({
-                    type: 'element',
-                    name: 'name',
-                    attributes: { 'name-style': 'western' },
-                    elements: nameElements,
-                  });
-                } else if (author.name) {
-                  recipientElements.push({
-                    type: 'element',
-                    name: 'string-name',
-                    attributes: { 'name-style': 'western' },
-                    elements: [{ type: 'text', text: author.name }],
-                  });
-                }
+                const name = nameElementFromContributor(author);
+                if (name) recipientElements.push(name);
                 return {
                   type: 'element',
                   name: 'principal-award-recipient',
@@ -520,58 +475,8 @@ export function getFundingGroup(frontmatter: ProjectFrontmatter): Element[] {
                     elements: [{ type: 'text', text: author.orcid }],
                   });
                 }
-                if (author.nameParsed && (author.nameParsed?.given || author.nameParsed?.family)) {
-                  const { given, family, dropping_particle, non_dropping_particle, suffix } =
-                    author.nameParsed;
-                  const nameElements: Element[] = [];
-                  if (family) {
-                    nameElements.push({
-                      type: 'element',
-                      name: 'surname',
-                      elements: [
-                        {
-                          type: 'text',
-                          text: non_dropping_particle
-                            ? `${non_dropping_particle} ${family}`
-                            : family,
-                        },
-                      ],
-                    });
-                  }
-                  if (given) {
-                    nameElements.push({
-                      type: 'element',
-                      name: 'given-names',
-                      elements: [
-                        {
-                          type: 'text',
-                          text: dropping_particle ? `${given} ${dropping_particle}` : given,
-                        },
-                      ],
-                    });
-                  }
-                  // Prefix not yet supported by name parsing
-                  if (suffix) {
-                    nameElements.push({
-                      type: 'element',
-                      name: 'suffix',
-                      elements: [{ type: 'text', text: suffix }],
-                    });
-                  }
-                  investigatorElements.push({
-                    type: 'element',
-                    name: 'name',
-                    attributes: { 'name-style': 'western' },
-                    elements: nameElements,
-                  });
-                } else if (author.name) {
-                  investigatorElements.push({
-                    type: 'element',
-                    name: 'string-name',
-                    attributes: { 'name-style': 'western' },
-                    elements: [{ type: 'text', text: author.name }],
-                  });
-                }
+                const name = nameElementFromContributor(author);
+                if (name) investigatorElements.push(name);
                 return {
                   type: 'element',
                   name: 'principal-investigator',

--- a/packages/myst-to-jats/tests/authors.yml
+++ b/packages/myst-to-jats/tests/authors.yml
@@ -29,6 +29,9 @@ cases:
             given: John
             family: Doe
             suffix: Jr.
+        - name:
+            literal: John Doe III
+            suffix: III
       affiliations:
         - id: univa
           name: University A
@@ -41,11 +44,10 @@ cases:
             <contrib-group>
               <contrib contrib-type="author" id="contributors-generated-uid-0" corresp="yes" deceased="yes" equal-contrib="no">
                 <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
-                <name>
+                <name name-style="western">
                   <surname>Doe</surname>
                   <given-names>Jane</given-names>
                 </name>
-                <string-name>Jane Doe</string-name>
                 <role vocab="CRediT" vocab-identifier="http://credit.niso.org/" vocab-term="credit role 1">credit role 1</role>
                 <role vocab="CRediT" vocab-identifier="http://credit.niso.org/" vocab-term="credit role &amp; 2">credit role &amp; 2</role>
                 <xref ref-type="aff" rid="univa"/>
@@ -53,12 +55,14 @@ cases:
                 <ext-link ext-link-type="uri" xlink:href="https://example.com">https://example.com</ext-link>
               </contrib>
               <contrib contrib-type="author" id="contributors-generated-uid-1">
-                <name>
+                <name name-style="western">
                   <surname>Doe</surname>
                   <given-names>John</given-names>
                   <suffix>Jr.</suffix>
                 </name>
-                <string-name>John Doe Jr.</string-name>
+              </contrib>
+              <contrib contrib-type="author" id="contributors-generated-uid-2">
+                <string-name name-style="western">John Doe III</string-name>
               </contrib>
             </contrib-group>
             <aff id="univa">

--- a/packages/myst-to-jats/tests/funding.yml
+++ b/packages/myst-to-jats/tests/funding.yml
@@ -80,18 +80,16 @@ cases:
           <article-meta>
             <contrib-group>
               <contrib contrib-type="author" id="John Doe">
-                <name>
+                <name name-style="western">
                   <surname>Doe</surname>
                   <given-names>John</given-names>
                 </name>
-                <string-name>John Doe</string-name>
               </contrib>
               <contrib id="Jane Doe">
-                <name>
+                <name name-style="western">
                   <surname>Doe</surname>
                   <given-names>Jane</given-names>
                 </name>
-                <string-name>Jane Doe</string-name>
               </contrib>
             </contrib-group>
             <aff id="University A">
@@ -108,18 +106,16 @@ cases:
                 <award-name>Award</award-name>
                 <award-desc>my test award</award-desc>
                 <principal-award-recipient>
-                  <name>
+                  <name name-style="western">
                     <surname>Doe</surname>
                     <given-names>Jane</given-names>
                   </name>
-                  <string-name>Jane Doe</string-name>
                 </principal-award-recipient>
                 <principal-investigator>
-                  <name>
+                  <name name-style="western">
                     <surname>Doe</surname>
                     <given-names>John</given-names>
                   </name>
-                  <string-name>John Doe</string-name>
                 </principal-investigator>
               </award-group>
               <funding-statement>my funding statement</funding-statement>
@@ -182,19 +178,17 @@ cases:
             <contrib-group>
               <contrib contrib-type="author" id="jd">
                 <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
-                <name>
+                <name name-style="western">
                   <surname>Doe</surname>
                   <given-names>John</given-names>
                 </name>
-                <string-name>John Doe</string-name>
                 <xref ref-type="aff" rid="univa"/>
               </contrib>
               <contrib id="contributors-generated-uid-1">
-                <name>
+                <name name-style="western">
                   <surname>Doe</surname>
                   <given-names>Jane</given-names>
                 </name>
-                <string-name>Jane Doe</string-name>
               </contrib>
             </contrib-group>
             <aff id="univb">
@@ -224,27 +218,24 @@ cases:
                 <award-name>Award</award-name>
                 <award-desc>my test award</award-desc>
                 <principal-award-recipient>
-                  <name>
+                  <name name-style="western">
                     <surname>Doe</surname>
                     <given-names>Jane</given-names>
                   </name>
-                  <string-name>Jane Doe</string-name>
                 </principal-award-recipient>
                 <principal-award-recipient>
                   <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
-                  <name>
+                  <name name-style="western">
                     <surname>Doe</surname>
                     <given-names>John</given-names>
                   </name>
-                  <string-name>John Doe</string-name>
                 </principal-award-recipient>
                 <principal-investigator>
                   <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
-                  <name>
+                  <name name-style="western">
                     <surname>Doe</surname>
                     <given-names>John</given-names>
                   </name>
-                  <string-name>John Doe</string-name>
                 </principal-investigator>
               </award-group>
               <award-group>
@@ -262,11 +253,10 @@ cases:
                 <award-desc>open access support</award-desc>
                 <principal-investigator>
                   <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
-                  <name>
+                  <name name-style="western">
                     <surname>Doe</surname>
                     <given-names>John</given-names>
                   </name>
-                  <string-name>John Doe</string-name>
                 </principal-investigator>
               </award-group>
               <open-access>

--- a/packages/myst-to-jats/tests/multi.yml
+++ b/packages/myst-to-jats/tests/multi.yml
@@ -168,28 +168,25 @@ cases:
             </title-group>
             <contrib-group>
               <contrib contrib-type="author" id="Author One">
-                <name>
+                <name name-style="western">
                   <surname>One</surname>
                   <given-names>Author</given-names>
                 </name>
-                <string-name>Author One</string-name>
               </contrib>
               <contrib id="Author Two">
-                <name>
+                <name name-style="western">
                   <surname>Two</surname>
                   <given-names>Author</given-names>
                 </name>
-                <string-name>Author Two</string-name>
               </contrib>
             </contrib-group>
             <funding-group>
               <award-group>
                 <principal-investigator>
-                  <name>
+                  <name name-style="western">
                     <surname>Two</surname>
                     <given-names>Author</given-names>
                   </name>
-                  <string-name>Author Two</string-name>
                 </principal-investigator>
               </award-group>
             </funding-group>
@@ -202,11 +199,10 @@ cases:
           <front-stub>
             <contrib-group>
               <contrib contrib-type="author" id="Author Three">
-                <name>
+                <name name-style="western">
                   <surname>Three</surname>
                   <given-names>Author</given-names>
                 </name>
-                <string-name>Author Three</string-name>
               </contrib>
             </contrib-group>
           </front-stub>


### PR DESCRIPTION
- add `name-style="western"` to jats names
- use either `name` or `string-name` element in jats, not both

See:
https://jats4r.org/authors-and-affiliations/

>  It is at the publisher’s discretion whether to use <name> or <string-name> to capture an author’s name

Note the `or`!
