### PR TITLE
🐛 Normalize DOI for open-funder-registry

### DIFF
--- a/.changeset/strange-hats-knock.md
+++ b/.changeset/strange-hats-knock.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Ensure that DOI is normalized for JATS4R

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -266,14 +266,15 @@ function instWrapElementsFromAffiliation(affiliation: Affiliation): Element[] {
   }
   if (affiliation.doi) {
     const doiAttrs: Record<string, string> = { 'institution-id-type': 'doi' };
-    if (doi.isOpenFunderRegistry(affiliation.doi)) {
+    const funder = doi.isOpenFunderRegistry(affiliation.doi);
+    if (funder) {
       doiAttrs.vocab = 'open-funder-registry';
     }
     instWrapElements.push({
       type: 'element',
       name: 'institution-id',
       attributes: doiAttrs,
-      elements: [{ type: 'text', text: affiliation.doi }],
+      elements: [{ type: 'text', text: doi.normalize(affiliation.doi) }],
     });
   }
   if (instWrapElements.length) {

--- a/packages/myst-to-jats/tests/funding.yml
+++ b/packages/myst-to-jats/tests/funding.yml
@@ -297,7 +297,7 @@ cases:
           affiliations:
             - id: univa
               name: University A
-              doi: 10.13039/000000
+              doi: https://doi.org/10.13039/000000
               isni: '0000000000000000'
               ringgold: 99999
               ror: '0000000000000000'


### PR DESCRIPTION
https://jats4r.org/funding/

> If JATS 1.2 or later if `@vocab=”open-funder-registry”` or `@vocab-identifier=”10.13039/open_funder_registry”` then value of the element must start with `“10.13039/”` else `ERROR`