### PR TITLE
🔬 Funding objects hold contributor/affiliation objects directly

### DIFF
--- a/.changeset/shiny-gorillas-drop.md
+++ b/.changeset/shiny-gorillas-drop.md
@@ -1,0 +1,6 @@
+---
+'myst-frontmatter': patch
+'myst-to-jats': patch
+---
+
+Funding objects hold contributor/affiliation objects directly

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -690,7 +690,7 @@ describe('fillPageFrontmatter', () => {
             {
               awards: [
                 {
-                  investigators: ['jn'],
+                  investigators: [{ id: 'jn' }],
                 },
               ],
             },
@@ -706,18 +706,17 @@ describe('fillPageFrontmatter', () => {
           nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
         },
       ],
-      contributors: [
-        {
-          id: 'jn',
-          name: 'Just A. Name',
-          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
-        },
-      ],
       funding: [
         {
           awards: [
             {
-              investigators: ['jn'],
+              investigators: [
+                {
+                  id: 'jn',
+                  name: 'Just A. Name',
+                  nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+                },
+              ],
             },
           ],
         },
@@ -748,7 +747,7 @@ describe('fillPageFrontmatter', () => {
             {
               awards: [
                 {
-                  investigators: ['jn', 'jd'],
+                  investigators: [{ id: 'jn' }, { id: 'jd' }],
                 },
               ],
             },
@@ -775,7 +774,18 @@ describe('fillPageFrontmatter', () => {
         {
           awards: [
             {
-              investigators: ['jn', 'jd'],
+              investigators: [
+                {
+                  id: 'jn',
+                  name: 'Just A. Name',
+                  nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+                },
+                {
+                  id: 'jd',
+                  name: 'John Doe',
+                  nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
+                },
+              ],
             },
           ],
         },
@@ -800,7 +810,7 @@ describe('fillPageFrontmatter', () => {
             {
               awards: [
                 {
-                  investigators: ['jn'],
+                  investigators: [{ id: 'jn' }],
                 },
               ],
             },
@@ -828,23 +838,19 @@ describe('fillPageFrontmatter', () => {
           affiliations: ['univa'],
         },
       ],
-      contributors: [
-        {
-          id: 'jn',
-          name: 'Just A. Name',
-          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
-          affiliations: ['univb'],
-        },
-      ],
-      affiliations: [
-        { id: 'univa', name: 'University A' },
-        { id: 'univb', name: 'University B' },
-      ],
+      affiliations: [{ id: 'univa', name: 'University A' }],
       funding: [
         {
           awards: [
             {
-              investigators: ['jn'],
+              investigators: [
+                {
+                  id: 'jn',
+                  name: 'Just A. Name',
+                  nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+                  affiliations: ['univb'],
+                },
+              ],
             },
           ],
         },
@@ -869,7 +875,7 @@ describe('fillPageFrontmatter', () => {
             {
               awards: [
                 {
-                  investigators: ['jn'],
+                  investigators: [{ id: 'jn' }],
                 },
               ],
             },
@@ -913,7 +919,14 @@ describe('fillPageFrontmatter', () => {
         {
           awards: [
             {
-              investigators: ['jn'],
+              investigators: [
+                {
+                  id: 'jn',
+                  name: 'Just A. Name',
+                  nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+                  affiliations: ['univb'],
+                },
+              ],
             },
           ],
         },

--- a/packages/myst-frontmatter/src/funding/types.ts
+++ b/packages/myst-frontmatter/src/funding/types.ts
@@ -1,11 +1,13 @@
+import type { Affiliation, Contributor } from '../index.js';
+
 export type Award = {
   id?: string;
   name?: string;
   description?: string;
-  sources?: string[]; // These are affiliation ids
+  sources?: Affiliation[]; // These are affiliation ids
   /** Recipients and investigators are added to author list; these are references */
-  recipients?: string[];
-  investigators?: string[];
+  recipients?: (Contributor | Affiliation)[];
+  investigators?: Contributor[];
 };
 
 export type Funding = {

--- a/packages/myst-frontmatter/tests/funding.yml
+++ b/packages/myst-frontmatter/tests/funding.yml
@@ -23,22 +23,23 @@ cases:
               name: Award
               description: my award
               sources:
-                - University A
+                - id: University A
+                  name: University A
               investigators:
-                - John Doe
+                - id: John Doe
+                  name: John Doe
+                  nameParsed:
+                    literal: John Doe
+                    family: Doe
+                    given: John
               recipients:
-                - John Doe
+                - id: John Doe
+                  name: John Doe
+                  nameParsed:
+                    literal: John Doe
+                    family: Doe
+                    given: John
         - open_access: my statement 2
-      contributors:
-        - id: John Doe
-          name: John Doe
-          nameParsed:
-            literal: John Doe
-            family: Doe
-            given: John
-      affiliations:
-        - id: University A
-          name: University A
   - title: String coerces to statement
     raw:
       funding: my statement
@@ -63,7 +64,7 @@ cases:
         - statement: my statement
           awards:
             - id: abc-123
-  - title: Source object coerces to list
+  - title: Source string coerces to list
     raw:
       funding:
         - statement: my statement
@@ -79,7 +80,8 @@ cases:
           awards:
             - id: abc-123
               sources:
-                - univa
+                - id: univa
+                  name: University A
       affiliations:
         - id: univa
           name: University A
@@ -96,14 +98,12 @@ cases:
           awards:
             - id: abc-123
               investigators:
-                - John Doe
-      contributors:
-        - id: John Doe
-          name: John Doe
-          nameParsed:
-            literal: John Doe
-            given: John
-            family: Doe
+                - id: John Doe
+                  name: John Doe
+                  nameParsed:
+                    literal: John Doe
+                    given: John
+                    family: Doe
   - title: Recipient object coerces to list
     raw:
       funding:
@@ -117,14 +117,12 @@ cases:
           awards:
             - id: abc-123
               recipients:
-                - John Doe
-      contributors:
-        - id: John Doe
-          name: John Doe
-          nameParsed:
-            literal: John Doe
-            given: John
-            family: Doe
+                - id: John Doe
+                  name: John Doe
+                  nameParsed:
+                    literal: John Doe
+                    given: John
+                    family: Doe
   - title: Award fields on funding coerce to object
     raw:
       funding:
@@ -146,27 +144,20 @@ cases:
               name: Award
               description: my award
               sources:
-                - University A
+                - id: University A
+                  name: University A
               recipients:
-                - contributors-generated-uid-0
+                - name: Jane Doe
+                  nameParsed:
+                    literal: Jane Doe
+                    given: Jane
+                    family: Doe
               investigators:
-                - contributors-generated-uid-1
-      affiliations:
-        - id: University A
-          name: University A
-      contributors:
-        - id: contributors-generated-uid-0
-          name: Jane Doe
-          nameParsed:
-            literal: Jane Doe
-            given: Jane
-            family: Doe
-        - id: contributors-generated-uid-1
-          name: John Doe
-          nameParsed:
-            literal: John Doe
-            given: John
-            family: Doe
+                - name: John Doe
+                  nameParsed:
+                    literal: John Doe
+                    given: John
+                    family: Doe
   - title: Award fields on funding warn if 'awards' is also present
     raw:
       funding:
@@ -190,27 +181,20 @@ cases:
               name: Award
               description: my award
               sources:
-                - University A
+                - id: University A
+                  name: University A
               recipients:
-                - contributors-generated-uid-0
+                - name: Jane Doe
+                  nameParsed:
+                    literal: Jane Doe
+                    given: Jane
+                    family: Doe
               investigators:
-                - contributors-generated-uid-1
-      affiliations:
-        - id: University A
-          name: University A
-      contributors:
-        - id: contributors-generated-uid-0
-          name: Jane Doe
-          nameParsed:
-            literal: Jane Doe
-            given: Jane
-            family: Doe
-        - id: contributors-generated-uid-1
-          name: John Doe
-          nameParsed:
-            literal: John Doe
-            given: John
-            family: Doe
+                - name: John Doe
+                  nameParsed:
+                    literal: John Doe
+                    given: John
+                    family: Doe
     warnings: 1
   - title: Funding contributor and author is persisted in authors
     raw:
@@ -235,11 +219,22 @@ cases:
               name: Award
               description: my award
               sources:
-                - University A
+                - id: University A
+                  name: University A
               investigators:
-                - John Doe
+                - id: John Doe
+                  name: John Doe
+                  nameParsed:
+                    literal: John Doe
+                    family: Doe
+                    given: John
               recipients:
-                - John Doe
+                - id: John Doe
+                  name: John Doe
+                  nameParsed:
+                    literal: John Doe
+                    family: Doe
+                    given: John
       authors:
         - id: John Doe
           name: John Doe
@@ -247,9 +242,6 @@ cases:
             literal: John Doe
             family: Doe
             given: John
-      affiliations:
-        - id: University A
-          name: University A
   - title: Non-funding contributors remain
     raw:
       funding:
@@ -274,11 +266,22 @@ cases:
               name: Award
               description: my award
               sources:
-                - University A
+                - id: University A
+                  name: University A
               investigators:
-                - John Doe
+                - id: John Doe
+                  name: John Doe
+                  nameParsed:
+                    literal: John Doe
+                    family: Doe
+                    given: John
               recipients:
-                - Jane Doe
+                - id: Jane Doe
+                  name: Jane Doe
+                  nameParsed:
+                    literal: Jane Doe
+                    family: Doe
+                    given: Jane
       authors:
         - id: John Doe
           name: John Doe
@@ -294,12 +297,3 @@ cases:
             family: Doe
             given: John
             suffix: Jr.
-        - id: Jane Doe
-          name: Jane Doe
-          nameParsed:
-            literal: Jane Doe
-            family: Doe
-            given: Jane
-      affiliations:
-        - id: University A
-          name: University A

--- a/packages/myst-frontmatter/tests/funding.yml
+++ b/packages/myst-frontmatter/tests/funding.yml
@@ -297,3 +297,28 @@ cases:
             family: Doe
             given: John
             suffix: Jr.
+  - title: Affiliation in funding contributor is removed and warns
+    raw:
+      funding:
+        - statement: my statement 1
+          awards:
+            - id: abc-123
+              name: Award
+              description: my award
+              recipients:
+                - name: Jane Doe
+                  affiliation: University A
+    normalized:
+      funding:
+        - statement: my statement 1
+          awards:
+            - id: abc-123
+              name: Award
+              description: my award
+              recipients:
+                - name: Jane Doe
+                  nameParsed:
+                    literal: Jane Doe
+                    family: Doe
+                    given: Jane
+    warnings: 1

--- a/packages/myst-to-jats/tests/funding.yml
+++ b/packages/myst-to-jats/tests/funding.yml
@@ -86,19 +86,6 @@ cases:
                 </name>
               </contrib>
             </contrib-group>
-            <contrib-group>
-              <contrib id="Jane Doe">
-                <name name-style="western">
-                  <surname>Doe</surname>
-                  <given-names>Jane</given-names>
-                </name>
-              </contrib>
-            </contrib-group>
-            <aff id="University A">
-              <institution-wrap>
-                <institution>University A</institution>
-              </institution-wrap>
-            </aff>
             <funding-group>
               <award-group>
                 <funding-source>
@@ -190,14 +177,6 @@ cases:
                 <xref ref-type="aff" rid="univa"/>
               </contrib>
             </contrib-group>
-            <contrib-group>
-              <contrib id="contributors-generated-uid-1">
-                <name name-style="western">
-                  <surname>Doe</surname>
-                  <given-names>Jane</given-names>
-                </name>
-              </contrib>
-            </contrib-group>
             <aff id="univb">
               <institution-wrap>
                 <institution>University B</institution>
@@ -209,11 +188,6 @@ cases:
               </institution-wrap>
               <institution-wrap>
                 <institution content-type="dept">Some Department</institution>
-              </institution-wrap>
-            </aff>
-            <aff id="University C">
-              <institution-wrap>
-                <institution>University C</institution>
               </institution-wrap>
             </aff>
             <funding-group>

--- a/packages/myst-to-jats/tests/multi.yml
+++ b/packages/myst-to-jats/tests/multi.yml
@@ -174,14 +174,6 @@ cases:
                 </name>
               </contrib>
             </contrib-group>
-            <contrib-group>
-              <contrib id="Author Two">
-                <name name-style="western">
-                  <surname>Two</surname>
-                  <given-names>Author</given-names>
-                </name>
-              </contrib>
-            </contrib-group>
             <funding-group>
               <award-group>
                 <principal-investigator>


### PR DESCRIPTION
Previously `Contributors` and `Affiliations` could be defined and referenced from anywhere in the frontmatter, e.g. you could do this:
```yaml
author: jdoe
funding:
  investigator:
    id: jdoe
    name: John Doe
    orcid: 0000-0000-0000-0000
```
Or
```yaml
author:
  id: jdoe
  name: John Doe
  orcid: 0000-0000-0000-0000
funding:
  investigator: jdoe
```

Similarly, this could be done with affiliations defined at the top level or nested on contributors anywhere. While flexible, this resulted in some unexpected behaviour, like affiliations from a `funding` living alongside author affiliations at the front of the document...

This PR attempts to provide more sensible behaviour by constraining what is allowed in frontmatter a bit.

Now, funding investigators/recipients/sources may reference existing contributors/affiliations, defined under `authors`/`affiliations`, but then they are just filled in with a copy of the object. They may also define their own investigators/recipients/sources as objects, but these objects are not available elsewhere; they are only part of the funding object.

(So - in the previous yaml snippets, only the second will resolve as expected. In the first, the author `jdoe` will not resolve.)

As a small positive side effect, this addresses #597 - recipients may now be institutions.