### PR TITLE
🏷 Add short_title to JATS output

### DIFF
--- a/.changeset/clever-days-do.md
+++ b/.changeset/clever-days-do.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Add alt-title to JATS (as running-head)

--- a/.changeset/plenty-planets-think.md
+++ b/.changeset/plenty-planets-think.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Remove restriction on short_title length from validation.

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -1049,10 +1049,7 @@ export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: Va
     output.description = validateString(value.description, incrementOptions('description', opts));
   }
   if (defined(value.short_title)) {
-    output.short_title = validateString(value.short_title, {
-      ...incrementOptions('short_title', opts),
-      maxLength: 40,
-    });
+    output.short_title = validateString(value.short_title, incrementOptions('short_title', opts));
   }
   if (defined(value.subtitle)) {
     output.subtitle = validateString(value.subtitle, incrementOptions('subtitle', opts));

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -61,7 +61,8 @@ export function getJournalMeta(): Element | null {
 export function getArticleTitle(frontmatter: ProjectFrontmatter): Element[] {
   const title = frontmatter?.title;
   const subtitle = frontmatter?.subtitle;
-  if (!title && !subtitle) return [];
+  const short_title = frontmatter?.short_title;
+  if (!title && !subtitle && !short_title) return [];
   const articleTitle: Element[] = [
     {
       type: 'element',
@@ -78,11 +79,21 @@ export function getArticleTitle(frontmatter: ProjectFrontmatter): Element[] {
         },
       ]
     : [];
+  const articleShortTitle: Element[] = short_title
+    ? [
+        {
+          type: 'element',
+          name: 'alt-title',
+          attributes: { 'alt-title-type': 'running-head' },
+          elements: [{ type: 'text', text: short_title }],
+        },
+      ]
+    : [];
   return [
     {
       type: 'element',
       name: 'title-group',
-      elements: [...articleTitle, ...articleSubtitle],
+      elements: [...articleTitle, ...articleSubtitle, ...articleShortTitle],
     },
   ];
 }


### PR DESCRIPTION
I have removed the `short_title` length restriction, which is different in various journals, etc. This should be better enforced with specific checks (e.g. in a template or journal).