### PR TITLE
🏫 Simplify affiliation IDs for JATS

### DIFF
--- a/.changeset/smooth-chairs-clap.md
+++ b/.changeset/smooth-chairs-clap.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Simplify affiliation ids for jats

--- a/packages/myst-to-jats/src/transforms/frontmatter.ts
+++ b/packages/myst-to-jats/src/transforms/frontmatter.ts
@@ -1,0 +1,54 @@
+import type { PageFrontmatter } from 'myst-frontmatter';
+
+/**
+ * Replace ids of affiliations associated with authors
+ *
+ * This does not change the ids of affiliations that are
+ * not referenced anywhere or only referenced in funding,
+ * as those ids do not come through to JATS.
+ *
+ * Also, it treats each frontmatter separately, so if one
+ * affiliation appears in multiple articles/sub-articles,
+ * it will be given a different id for each and be part
+ * of the JATS frontmatter for each.
+ */
+export function affiliationIdTransform(
+  frontmatters: PageFrontmatter[],
+  idPrefix: string | ((count: number) => string),
+) {
+  let affCount = 0;
+  frontmatters.forEach((frontmatter) => {
+    const idLookup: Record<string, string> = {};
+    // Only modify ids of affiliations associated with authors
+    frontmatter.authors?.forEach((auth) => {
+      if (!auth.affiliations?.length) return;
+      auth.affiliations = auth.affiliations.map((aff) => {
+        if (idLookup[aff]) {
+          return idLookup[aff];
+        } else {
+          affCount += 1;
+          const id =
+            typeof idPrefix === 'function' ? idPrefix(affCount) : `${idPrefix}-${affCount}`;
+          idLookup[aff] = id;
+          return id;
+        }
+      });
+    });
+    // Replace affiliation values in funding sources
+    frontmatter.funding?.forEach((funding) => {
+      funding.awards?.forEach((award) => {
+        if (!award.sources) return;
+        award.sources = award.sources.map((source) => {
+          if (idLookup[source]) return idLookup[source];
+          return source;
+        });
+      });
+    });
+    // Replace affiliation ids in affiliation list
+    frontmatter.affiliations?.forEach((aff) => {
+      if (aff.id && idLookup[aff.id]) {
+        aff.id = idLookup[aff.id];
+      }
+    });
+  });
+}

--- a/packages/myst-to-jats/tests/affiliations.yml
+++ b/packages/myst-to-jats/tests/affiliations.yml
@@ -43,16 +43,16 @@ cases:
                   <surname>Doe</surname>
                   <given-names>John</given-names>
                 </name>
-                <xref ref-type="aff" rid="univa"/>
-                <xref ref-type="aff" rid="univb"/>
+                <xref ref-type="aff" rid="aff-1"/>
+                <xref ref-type="aff" rid="aff-2"/>
               </contrib>
             </contrib-group>
-            <aff id="univa">
+            <aff id="aff-1">
               <institution-wrap>
                 <institution>University A</institution>
               </institution-wrap>
             </aff>
-            <aff id="univb">
+            <aff id="aff-2">
               <institution-wrap>
                 <institution>University B</institution>
                 <institution-id institution-id-type="isni">0000000000000000</institution-id>

--- a/packages/myst-to-jats/tests/authors.yml
+++ b/packages/myst-to-jats/tests/authors.yml
@@ -21,7 +21,7 @@ cases:
             - Editing # Note the british spelling
             - credit role & 2 # Test that "&" is encoded correctly
           affiliations:
-            - univa
+            - aff-1
           email: example@example.com
           equal-contributor: false # using the alias!
           deceased: true
@@ -35,7 +35,7 @@ cases:
             literal: John Doe III
             suffix: III
       affiliations:
-        - id: univa
+        - id: aff-1
           name: University A
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
@@ -54,7 +54,7 @@ cases:
                 <role vocab="credit" vocab-identifier="https://credit.niso.org/" vocab-term="Conceptualization" vocab-term-identifier="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
                 <role vocab="credit" vocab-identifier="https://credit.niso.org/" vocab-term="Writing – review &amp; editing" vocab-term-identifier="https://credit.niso.org/contributor-roles/writing-review-editing/">Writing – review &amp; editing</role>
                 <role>credit role &amp; 2</role>
-                <xref ref-type="aff" rid="univa"/>
+                <xref ref-type="aff" rid="aff-1"/>
                 <email>example@example.com</email>
                 <ext-link ext-link-type="uri" xlink:href="https://example.com">https://example.com</ext-link>
               </contrib>
@@ -69,7 +69,7 @@ cases:
                 <string-name name-style="western">John Doe III</string-name>
               </contrib>
             </contrib-group>
-            <aff id="univa">
+            <aff id="aff-1">
               <institution-wrap>
                 <institution>University A</institution>
               </institution-wrap>

--- a/packages/myst-to-jats/tests/funding.yml
+++ b/packages/myst-to-jats/tests/funding.yml
@@ -131,7 +131,7 @@ cases:
           name: John Doe
           orcid: 0000-0000-0000-0000
           affiliations:
-            - id: univa
+            - id: aff-1
               name: University A
               department: Some Department
       affiliations:
@@ -144,7 +144,7 @@ cases:
               name: Award
               description: my test award
               sources:
-                - univa
+                - aff-1
                 - univb
               investigators:
                 - jd
@@ -174,10 +174,10 @@ cases:
                   <surname>Doe</surname>
                   <given-names>John</given-names>
                 </name>
-                <xref ref-type="aff" rid="univa"/>
+                <xref ref-type="aff" rid="aff-1"/>
               </contrib>
             </contrib-group>
-            <aff id="univa">
+            <aff id="aff-1">
               <institution-wrap>
                 <institution>University A</institution>
               </institution-wrap>
@@ -268,7 +268,7 @@ cases:
           name: John Doe
           orcid: 0000-0000-0000-0000
           affiliations:
-            - id: univa
+            - id: aff-1
               name: University A
               doi: https://doi.org/10.13039/000000
               isni: '0000000000000000'
@@ -287,7 +287,7 @@ cases:
               name: Award
               description: my test award
               sources:
-                - univa
+                - aff-1
                 - univb
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
@@ -302,10 +302,10 @@ cases:
                   <surname>Doe</surname>
                   <given-names>John</given-names>
                 </name>
-                <xref ref-type="aff" rid="univa"/>
+                <xref ref-type="aff" rid="aff-1"/>
               </contrib>
             </contrib-group>
-            <aff id="univa">
+            <aff id="aff-1">
               <institution-wrap>
                 <institution>University A</institution>
                 <institution-id institution-id-type="isni">0000000000000000</institution-id>

--- a/packages/myst-to-jats/tests/multi.yml
+++ b/packages/myst-to-jats/tests/multi.yml
@@ -129,7 +129,7 @@ cases:
           </body>
         </sub-article>
       </article>
-  - title: Authors deduplicate
+  - title: Authors do not deduplicate
     frontmatter:
       title: Top title
       authors:
@@ -157,6 +157,17 @@ cases:
               children:
                 - type: text
                   value: article 1
+      - frontmatter:
+          title: Top title
+          authors:
+            - Author Three
+        mdast:
+          type: root
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: article 2
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
@@ -194,11 +205,112 @@ cases:
             <contrib-group>
               <contrib contrib-type="author">
                 <name name-style="western">
+                  <surname>One</surname>
+                  <given-names>Author</given-names>
+                </name>
+              </contrib>
+              <contrib contrib-type="author">
+                <name name-style="western">
                   <surname>Three</surname>
                   <given-names>Author</given-names>
                 </name>
               </contrib>
             </contrib-group>
+          </front-stub>
+          <body>
+            <p>article 1</p>
+          </body>
+        </sub-article>
+        <sub-article>
+          <front-stub>
+            <contrib-group>
+              <contrib contrib-type="author">
+                <name name-style="western">
+                  <surname>Three</surname>
+                  <given-names>Author</given-names>
+                </name>
+              </contrib>
+            </contrib-group>
+          </front-stub>
+          <body>
+            <p>article 2</p>
+          </body>
+        </sub-article>
+      </article>
+  - title: Affiliations count across subarticles
+    frontmatter:
+      title: Top title
+      authors:
+        - name: Author One
+          affiliations:
+            - id: univa
+              name: University A
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    subArticles:
+      - frontmatter:
+          title: Top title
+          authors:
+            - name: Author Two
+              affiliations:
+                - id: univa
+                  name: University A
+        mdast:
+          type: root
+          children:
+            - type: paragraph
+              children:
+                - type: text
+                  value: article 1
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <title-group>
+              <article-title>Top title</article-title>
+            </title-group>
+            <contrib-group>
+              <contrib contrib-type="author">
+                <name name-style="western">
+                  <surname>One</surname>
+                  <given-names>Author</given-names>
+                </name>
+                <xref ref-type="aff" rid="aff-1"/>
+              </contrib>
+            </contrib-group>
+            <aff id="aff-1">
+              <institution-wrap>
+                <institution>University A</institution>
+              </institution-wrap>
+            </aff>
+          </article-meta>
+        </front>
+        <body>
+          <p>text</p>
+        </body>
+        <sub-article>
+          <front-stub>
+            <contrib-group>
+              <contrib contrib-type="author">
+                <name name-style="western">
+                  <surname>Two</surname>
+                  <given-names>Author</given-names>
+                </name>
+                <xref ref-type="aff" rid="aff-2"/>
+              </contrib>
+            </contrib-group>
+            <aff id="aff-2">
+              <institution-wrap>
+                <institution>University A</institution>
+              </institution-wrap>
+            </aff>
           </front-stub>
           <body>
             <p>article 1</p>


### PR DESCRIPTION
This modifies affiliation ids that appear in JATS to be simpler and uniform, by default `aff-1`, `aff-2`, etc.

It also removes the attempted author/affiliation deduplication (which previously didn't work as intended anyway).
- For authors, they simply shouldn't be deduplicated - you want to know all the different authors on each subarticle. Since we removed author ids from JATS (#662) there is no longer any JATS validation worry.
- Regarding affiliations, we do not deduplicate these either: the implication of this is that identical affiliations in different articles/subarticles will appear separately in each. However, they will also be given a different id, so JATS will be happy. I _think_ it would be nicer if affiliations were compared across articles and deduplicated, but the current behaviour matches citations (identical citations appear in each article). Good enough for now.

Really, what we need to do is rely on the [JATS library](https://github.com/curvenote/jats) to build a JATS-like unist tree, then we can apply all these id changes as post-processing unist transforms, rather than finessing the inputs prior to JATS serialization...