### PR TITLE
👩‍💻 Improve HTML processing

### DIFF
--- a/.changeset/rotten-timers-worry.md
+++ b/.changeset/rotten-timers-worry.md
@@ -1,0 +1,6 @@
+---
+'myst-transforms': patch
+'myst-cli': patch
+---
+
+Improve HTML transforms for grouping and processing

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -24,6 +24,7 @@ import {
   joinGatesPlugin,
   glossaryPlugin,
   abbreviationPlugin,
+  reconstructHtmlPlugin,
 } from 'myst-transforms';
 import { unified } from 'unified';
 import { VFile } from 'vfile';
@@ -164,9 +165,10 @@ export async function transformMdast(
   liftCodeMetadataToBlock(session, vfile, mdast);
 
   const pipe = unified()
+    .use(reconstructHtmlPlugin) // We need to group and link the HTML first
+    .use(htmlPlugin, { htmlHandlers }) // Some of the HTML plugins need to operate on the transformed html, e.g. figure caption transforms
     .use(basicTransformationsPlugin)
     .use(inlineExpressionsPlugin) // Happens before math and images!
-    .use(htmlPlugin, { htmlHandlers })
     .use(mathPlugin, { macros: frontmatter.math })
     .use(glossaryPlugin, { state }) // This should be before the enumerate plugins
     .use(abbreviationPlugin, { abbreviations: frontmatter.abbreviations })

--- a/packages/myst-transforms/src/html.spec.ts
+++ b/packages/myst-transforms/src/html.spec.ts
@@ -336,4 +336,87 @@ describe('Test reconstructHtmlTransform', () => {
       ],
     });
   });
+  test('no paragraph when in a paragraph', async () => {
+    const mdast = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'See ',
+            },
+            {
+              type: 'html',
+              value: '<sup>',
+            },
+            {
+              type: 'text',
+              value: '[1]',
+            },
+            {
+              type: 'html',
+              value: '</sup>',
+            },
+            {
+              type: 'text',
+              value: '.',
+            },
+          ],
+        },
+      ],
+    };
+    reconstructHtmlTransform(mdast);
+    expect(mdast).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'See ',
+            },
+            {
+              type: 'html',
+              value: '<sup>[1]</sup>',
+            },
+            {
+              type: 'text',
+              value: '.',
+            },
+          ],
+        },
+      ],
+    });
+    htmlTransform(mdast);
+    expect(mdast).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'See ',
+            },
+            {
+              type: 'superscript',
+              children: [
+                {
+                  type: 'text',
+                  value: '[1]',
+                },
+              ],
+            },
+            {
+              type: 'text',
+              value: '.',
+            },
+          ],
+        },
+      ],
+    });
+  });
 });

--- a/packages/myst-transforms/src/html.ts
+++ b/packages/myst-transforms/src/html.ts
@@ -1,6 +1,6 @@
 import { unified } from 'unified';
 import type { Plugin } from 'unified';
-import { liftChildren } from 'myst-common';
+import { liftChildren, normalizeLabel } from 'myst-common';
 import type { GenericNode, GenericParent } from 'myst-common';
 import type { Parent } from 'myst-spec';
 import { mystToHtml } from 'myst-to-html';
@@ -20,6 +20,17 @@ export type HtmlTransformOptions = {
   htmlHandlers?: { [x: string]: Handle };
 };
 
+function addClassAndIdentifier(node: GenericNode, attrs: Record<string, string> = {}) {
+  const props = node.properties ?? {};
+  if (props.id) {
+    const normalized = normalizeLabel(props.id);
+    if (normalized?.identifier) attrs.identifier = normalized.identifier;
+    if (normalized?.label) attrs.label = normalized.label;
+  }
+  if (props.className) attrs.class = props.className.join(' ');
+  return attrs;
+}
+
 const defaultHtmlToMdastOptions: Record<keyof HtmlTransformOptions, any> = {
   keepBreaks: true,
   htmlHandlers: {
@@ -33,6 +44,27 @@ const defaultHtmlToMdastOptions: Record<keyof HtmlTransformOptions, any> = {
     },
     _brKeep(h: H, node: any) {
       return h(node, '_break');
+    },
+    a(h: H, node: any) {
+      const attrs = addClassAndIdentifier(node);
+      attrs.url = String(node.properties.href || '');
+      if (node.properties.title) attrs.title = node.properties.title;
+      if (node.properties.className) attrs.class = node.properties.className.join(' ');
+      return h(node, 'link', attrs, all(h, node));
+    },
+    img(h: H, node: any) {
+      const attrs = addClassAndIdentifier(node);
+      attrs.url = String(node.properties.src || '');
+      if (node.properties.title) attrs.title = node.properties.title;
+      if (node.properties.alt) attrs.alt = node.properties.alt;
+      return h(node, 'image', attrs);
+    },
+    figure(h: H, node: any) {
+      const attrs = addClassAndIdentifier(node);
+      return h(node, 'container', attrs, all(h, node));
+    },
+    figcaption(h: H, node: any) {
+      return h(node, 'caption', all(h, node));
     },
     comment(h: any, node: any) {
       // Prevents HTML comments from showing up as text in web
@@ -65,6 +97,12 @@ export function htmlTransform(tree: GenericParent, opts?: HtmlTransformOptions) 
     node.type = 'htmlParsed';
     node.children = mdast.children as Parent[];
     visit(node, (n: any) => delete n.position);
+  });
+  selectAll('paragraph > htmlParsed', tree).forEach((parsed) => {
+    const node = parsed as GenericParent;
+    if (node?.children?.length === 1 && node.children[0].type === 'paragraph') {
+      node.children = node.children[0].children as GenericNode[];
+    }
   });
   liftChildren(tree, 'htmlParsed');
   selectAll('_break', tree).forEach((node: any) => {
@@ -103,17 +141,41 @@ function finalizeNode(htmlOpenNodeWithChildren: GenericParent, htmlCloseNode: Ge
   delete (htmlOpenNodeWithChildren as GenericNode).children;
 }
 
+// https://html.spec.whatwg.org/multipage/syntax.html#elements-2
+const HTML_EMPTY_ELEMENTS = [
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'keygen',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+];
+
 function reconstructHtml(tree: GenericParent) {
   const htmlOpenNodes: GenericParent[] = [];
   tree.children.forEach((child: GenericNode) => {
     if (child.type === 'html') {
       const value = child.value?.trim();
-      if (value?.startsWith('</')) {
+      const selfClosing =
+        (value?.startsWith('<') && value?.endsWith('/>')) ||
+        value?.match(new RegExp(`<(${HTML_EMPTY_ELEMENTS.join('|')})([^>]*)?/?>`));
+      if (selfClosing) {
+        if (htmlOpenNodes.length) {
+          htmlOpenNodes[htmlOpenNodes.length - 1].children.push(child);
+        }
+      } else if (value?.startsWith('</')) {
         // In this case, child is a standalone closing html node
         const htmlOpenNode = htmlOpenNodes.pop();
-        if (!htmlOpenNode) {
-          return;
-        }
+        if (!htmlOpenNode) return;
         finalizeNode(htmlOpenNode, child);
         if (htmlOpenNodes.length) {
           htmlOpenNodes[htmlOpenNodes.length - 1].children.push(htmlOpenNode);
@@ -151,6 +213,10 @@ export function reconstructHtmlTransform(tree: GenericParent) {
   remove(tree, '__delete__');
   return tree;
 }
+
+export const reconstructHtmlPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
+  reconstructHtmlTransform(tree);
+};
 
 export const htmlPlugin: Plugin<[HtmlTransformOptions?], GenericParent, GenericParent> =
   (opts) => (tree) => {

--- a/packages/myst-transforms/src/html.ts
+++ b/packages/myst-transforms/src/html.ts
@@ -66,11 +66,17 @@ const defaultHtmlToMdastOptions: Record<keyof HtmlTransformOptions, any> = {
     figcaption(h: H, node: any) {
       return h(node, 'caption', all(h, node));
     },
-    comment(h: any, node: any) {
+    comment(h: H, node: any) {
       // Prevents HTML comments from showing up as text in web
       const result = h(node, 'comment');
       (result as any).value = node.value;
       return result;
+    },
+    sup(h: H, node: any) {
+      return h(node, 'superscript', all(h, node));
+    },
+    sub(h: H, node: any) {
+      return h(node, 'subscript', all(h, node));
     },
   },
 };

--- a/packages/myst-transforms/src/index.ts
+++ b/packages/myst-transforms/src/index.ts
@@ -6,7 +6,12 @@ export {
 } from './admonitions.js';
 export { captionParagraphPlugin, captionParagraphTransform } from './caption.js';
 export { footnotesPlugin, footnotesTransform } from './footnotes.js';
-export { htmlPlugin, htmlTransform, reconstructHtmlTransform } from './html.js';
+export {
+  htmlPlugin,
+  htmlTransform,
+  reconstructHtmlTransform,
+  reconstructHtmlPlugin,
+} from './html.js';
 export { htmlIdsPlugin, htmlIdsTransform } from './htmlIds.js';
 export { keysPlugin, keysTransform } from './keys.js';
 export {

--- a/packages/myst-transforms/tests/html.yml
+++ b/packages/myst-transforms/tests/html.yml
@@ -41,7 +41,6 @@ cases:
             - type: image
               url: example.jpg
               title: example
-              alt: ''
   - title: table
     before:
       type: root


### PR DESCRIPTION
This improves a lot of the functionality around HTML processing to get it into the AST before any other transformations. We can now have things like `<figure><img src=""><figcaption>The caption</figcaption></figure>` which will be processed into the correct container. This can also work with HTML links directly to that caption, which will be processed as normal.

The IDs are required to be on the `figure`, not the `image`, but that seems reasonable.

cc @dellaert who is motivated by having HTML that works in google collab, but also works with MyST for LaTeX export.

@fwkoch there are probably a number of other changes incoming for the HTML processing along these lines, but I think we can get them in iteratively.

Fixes:
- https://github.com/executablebooks/mystmd/issues/418