### PR TITLE
🏷 Add `no-tex` tag

### DIFF
--- a/.changeset/breezy-buckets-boil.md
+++ b/.changeset/breezy-buckets-boil.md
@@ -1,0 +1,5 @@
+---
+'myst-to-tex': patch
+---
+
+Exclude blocks with the "no-tex" tag

--- a/docs/creating-pdf-documents.md
+++ b/docs/creating-pdf-documents.md
@@ -184,3 +184,7 @@ exports:
 ```
 
 Please consider [contributing your template](/jtex/contribute-a-template) to the growing list of templates so that other people can benefit and improve your work!
+
+## Excluding Source
+
+If you have a block or notebook cell that you do now want to render to your LaTeX output, add the `no-tex` tag to the cell.

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -146,6 +146,7 @@ const handlers: Record<string, Handler> = {
       return;
     }
     if (node.visibility === 'remove') return;
+    if (node.data?.tags?.includes('no-tex')) return;
     state.renderChildren(node, false);
   },
   blockquote(node, state) {


### PR DESCRIPTION
This prevents the cell/block from being rendered in latex