### PR TITLE
🧮 Add support for sub-equations

### DIFF
--- a/.changeset/small-falcons-speak.md
+++ b/.changeset/small-falcons-speak.md
@@ -1,0 +1,9 @@
+---
+'myst-transforms': patch
+'myst-spec-ext': patch
+'myst-to-jats': patch
+'myst-common': patch
+'tex-to-myst': patch
+---
+
+Support for sub-equations, including adding the MathGroup node.

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -119,6 +119,7 @@ export type MystPlugin = {
 export enum TargetKind {
   heading = 'heading',
   equation = 'equation',
+  subequation = 'subequation',
   figure = 'figure',
   table = 'table',
   code = 'code',

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -15,6 +15,7 @@ import type {
   ListItem as SpecListItem,
   Container as SpecContainer,
   InlineMath as SpecInlineMath,
+  Math as SpecMath,
 } from 'myst-spec';
 
 type Visibility = 'show' | 'hide' | 'remove';
@@ -51,6 +52,19 @@ export type AlgorithmLine = Parent & {
 export type InlineMath = SpecInlineMath & {
   label?: string;
   identifier?: string;
+};
+
+export type Math = SpecMath & {
+  kind?: 'subequation';
+};
+
+export type MathGroup = {
+  type: 'mathGroup';
+  label?: string;
+  identifier?: string;
+  enumerated?: boolean;
+  enumerator?: string;
+  children: Math[];
 };
 
 export type FootnoteDefinition = FND & {

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -38,6 +38,7 @@ import type {
   ListItem,
   InlineMath,
   Image,
+  MathGroup,
   Delete,
   Smallcaps,
   Admonition,
@@ -95,6 +96,7 @@ function referenceKindToRefType(kind?: string): RefType {
       return RefType.sec;
     case 'figure':
       return RefType.fig;
+    case 'subequation':
     case 'equation':
       return RefType.dispFormula;
     case 'table':
@@ -238,6 +240,7 @@ type Handlers = {
   thematicBreak: Handler<ThematicBreak>;
   inlineMath: Handler<InlineMath>;
   math: Handler<Math>;
+  mathGroup: Handler<MathGroup>;
   mystRole: Handler<Role>;
   mystDirective: Handler<Directive>;
   comment: Handler<Comment>;
@@ -372,6 +375,16 @@ const handlers: Handlers = {
     state.addLeaf('cdata', { cdata: cleanLatex(node.value) });
     state.closeNode();
     state.closeNode();
+    state.closeNode();
+  },
+  mathGroup(node, state) {
+    const attrs: Attributes = {};
+    if (node.identifier) {
+      attrs.id = node.identifier;
+    }
+    state.openNode('disp-formula-group', attrs);
+    renderLabel(node, state, (enumerator) => `(${enumerator})`);
+    state.renderChildren(node);
     state.closeNode();
   },
   mystRole(node, state) {

--- a/packages/myst-transforms/src/basic.ts
+++ b/packages/myst-transforms/src/basic.ts
@@ -7,7 +7,7 @@ import { admonitionBlockquoteTransform, admonitionHeadersTransform } from './adm
 import { blockMetadataTransform, blockNestingTransform } from './blocks.js';
 import { htmlIdsTransform } from './htmlIds.js';
 import { imageAltTextTransform } from './images.js';
-import { mathLabelTransform, mathNestingTransform } from './math.js';
+import { mathLabelTransform, mathNestingTransform, subequationTransform } from './math.js';
 import { blockquoteTransform } from './blockquote.js';
 import { codeBlockToDirectiveTransform } from './code.js';
 import type { GenericParent } from 'myst-common';
@@ -21,6 +21,7 @@ export function basicTransformations(tree: GenericParent, file: VFile) {
   mathNestingTransform(tree, file);
   // Math labelling should happen before the target-transformation
   mathLabelTransform(tree, file);
+  subequationTransform(tree, file);
   // Target transformation must happen after lifting the directives, and before the heading labels
   mystTargetsTransform(tree);
   // Label headings after the targets-transform

--- a/packages/myst-transforms/src/enumerate.spec.ts
+++ b/packages/myst-transforms/src/enumerate.spec.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from 'vitest';
-import { formatHeadingEnumerator, incrementHeadingCounts } from './enumerate';
+import {
+  ReferenceState,
+  enumerateTargetsTransform,
+  formatHeadingEnumerator,
+  incrementHeadingCounts,
+} from './enumerate';
+import { u } from 'unist-builder';
 
-describe('Testing heading count', () => {
+describe('Heading counts and formatting', () => {
   test.each([
     [2, [0, 0, 0, null, 0, 0], [0, 1, 0, null, 0, 0]],
     [1, [0, 1, 0, null, 0, 0], [1, 0, 0, null, 0, 0]],
@@ -13,9 +19,6 @@ describe('Testing heading count', () => {
   ])('incrementHeadingCounts(%s, %s)}', (depth, counts, out) => {
     expect(incrementHeadingCounts(depth, counts)).toEqual(out);
   });
-});
-
-describe('Testing heading numbering format', () => {
   test.each([
     [[0, 0, 0, null, 0, 0], ''],
     [[0, 1, 0, null, 0, 0], '0.1'],
@@ -26,5 +29,48 @@ describe('Testing heading numbering format', () => {
     [[1, 2, 0, null, 0, 0], '1.2'],
   ])('formatHeadingEnumerator(%s)}', (counts, out) => {
     expect(formatHeadingEnumerator(counts)).toEqual(out);
+  });
+});
+
+describe('enumeration', () => {
+  test('sub-equations', () => {
+    const tree = u('root', [
+      u('mathGroup', { identifier: 'eq:1' }, [
+        u('math', { identifier: 'eq:1a', kind: 'subequation' }),
+        u('math', { identifier: 'eq:1b', kind: 'subequation' }),
+      ]),
+      u('math', { identifier: 'eq:x', enumerated: false }),
+      u('math', { identifier: 'eq:2' }),
+      u('mathGroup', { identifier: 'eq:3' }, [
+        u('math', { identifier: 'eq:3-1', kind: 'subequation', enumerated: false }),
+        u('math', { identifier: 'eq:3-2', kind: 'subequation' }),
+        u('math', { identifier: 'eq:3-3', kind: 'subequation', enumerated: false }),
+        u('math', { identifier: 'eq:3-4', kind: 'subequation' }),
+      ]),
+    ]);
+    const state = new ReferenceState({ numbering: { enumerator: 'A.%s' } });
+    enumerateTargetsTransform(tree, { state });
+    expect(state.getTarget('eq:1')?.node.enumerator).toBe('A.1');
+    expect(state.getTarget('eq:1a')?.node.enumerator).toBe('A.1a');
+    expect(state.getTarget('eq:1b')?.node.enumerator).toBe('A.1b');
+    expect(state.getTarget('eq:x')?.node.enumerator).toBeUndefined();
+    expect(state.getTarget('eq:2')?.node.enumerator).toBe('A.2');
+    expect(state.getTarget('eq:3')?.node.enumerator).toBe('A.3');
+    expect(state.getTarget('eq:3-1')?.node.enumerator).toBeUndefined();
+    expect(state.getTarget('eq:3-2')?.node.enumerator).toBe('A.3a');
+    expect(state.getTarget('eq:3-3')?.node.enumerator).toBeUndefined();
+    expect(state.getTarget('eq:3-4')?.node.enumerator).toBe('A.3b');
+  });
+  test('headers', () => {
+    const tree = u('root', [
+      u('heading', { identifier: 'h1', depth: 1 }),
+      u('heading', { identifier: 'h2', depth: 2 }),
+      u('heading', { identifier: 'h3', depth: 1 }),
+    ]);
+    const state = new ReferenceState({ numbering: { heading_1: true, heading_2: true } });
+    enumerateTargetsTransform(tree, { state });
+    expect(state.getTarget('h1')?.node.enumerator).toBe('1');
+    expect(state.getTarget('h2')?.node.enumerator).toBe('1.1');
+    expect(state.getTarget('h3')?.node.enumerator).toBe('2');
   });
 });

--- a/packages/myst-transforms/src/math.ts
+++ b/packages/myst-transforms/src/math.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from 'unified';
 import type { VFile } from 'vfile';
 import katex from 'katex';
-import type { Math, InlineMath, Node } from 'myst-spec';
+import type { InlineMath, Node } from 'myst-spec';
+import type { Math } from 'myst-spec-ext';
 import { selectAll } from 'unist-util-select';
 import type { GenericParent } from 'myst-common';
 import { RuleId, copyNode, fileError, fileWarn, normalizeLabel } from 'myst-common';
@@ -249,6 +250,13 @@ export function mathLabelTransform(tree: GenericParent, file: VFile) {
     transformMathValue(file, node);
     removeSimpleEquationEnv(file, node);
     labelMathNodes(file, node);
+  });
+}
+
+export function subequationTransform(tree: GenericParent, file: VFile) {
+  const nodes = selectAll('mathGroup > math', tree) as Math[];
+  nodes.forEach((node) => {
+    node.kind = 'subequation';
   });
 }
 

--- a/packages/tex-to-myst/tests/math.yml
+++ b/packages/tex-to-myst/tests/math.yml
@@ -116,3 +116,40 @@ cases:
               \nabla \times \vec{e}+\frac{\partial \vec{b}}{\partial t}&=0 \\
               \nabla \times \vec{h}-\vec{j}&=\vec{s}\_{e}
             \end{align*}
+  - title: subequations
+    tex: |-
+      \begin{subequations} \label{eq:system}
+        \begin{align}
+          x + y & \geq 0  \label{eq:sum} \\
+          x - y & \leq 4 \label{eq:diff}\\
+          x \times y & \geq 1 \label{eq:prod} \\
+          x^y + y^x &\geq 1 \label{eq:exp_sum}
+        \end{align}
+      \end{subequations}
+    tree:
+      type: root
+      children:
+        - type: mathGroup
+          label: eq:system
+          identifier: eq:system
+          equations:
+            - |-
+              \begin{align}
+                  x + y & \geq 0  \label{eq:sum} \\
+                  x - y & \leq 4 \label{eq:diff}\\
+                  x \times y & \geq 1 \label{eq:prod} \\
+                  x^y + y^x &\geq 1 \label{eq:exp_sum}
+                \end{align}
+          children:
+            - type: math
+              value: \begin{align*}x + y & \geq 0  \label{eq:sum}\end{align*}
+              kind: subequation
+            - type: math
+              value: \begin{align*}x - y & \leq 4 \label{eq:diff}\end{align*}
+              kind: subequation
+            - type: math
+              value: \begin{align*}x \times y & \geq 1 \label{eq:prod}\end{align*}
+              kind: subequation
+            - type: math
+              value: \begin{align*}x^y + y^x &\geq 1 \label{eq:exp_sum}\end{align*}
+              kind: subequation


### PR DESCRIPTION
This adds support for latex-parsing of sub-equations and subsequent export to JATS. The approach is to add a `mathGroup` node, and break up the align sub-equations (which are labeled `1a`, `1b`, etc.).

This breaks the alignment in the display equations, which is needed for JATS export as you cannot have one or more nested labels inside of a mathml block in JATS, and they should be a `disp-formula-group`.

In the future we can add better support for both modes with a custom renderer of `mathGroup` that prefers the aligned version, and stores it (currently) in an `equations` attribute. That theme work is not done yet.