### PR TITLE
🪆 Section nesting for JATS

### DIFF
--- a/.changeset/big-dodos-reflect.md
+++ b/.changeset/big-dodos-reflect.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Improve section nesting

--- a/.changeset/gorgeous-glasses-repair.md
+++ b/.changeset/gorgeous-glasses-repair.md
@@ -1,0 +1,5 @@
+---
+'myst-to-tex': patch
+---
+
+Add ≥ and ≤ symbols

--- a/packages/myst-to-jats/package.json
+++ b/packages/myst-to-jats/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "eslint \"src/**/*.ts\" -c .eslintrc.cjs --max-warnings 1",
+    "lint": "eslint \"src/**/!(*.spec).ts\" -c ./.eslintrc.cjs",
     "lint:format": "prettier --check src/*.ts src/**/*.ts",
     "test": "vitest run",
     "test:watch": "vitest watch",

--- a/packages/myst-to-jats/src/transforms/sections.spec.ts
+++ b/packages/myst-to-jats/src/transforms/sections.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest';
+import { u } from 'unist-builder';
+import { sectionTransform } from './sections';
+
+describe('Section nesting', () => {
+  test('basic sections', () => {
+    const tree = u('root', [u('text', 'child'), u('heading', { depth: 1 }), u('text', 'hello!')]);
+    sectionTransform(tree, {});
+    const sections = u('root', [
+      u('text', 'child'),
+      u('section', { depth: 1 }, [u('heading'), u('text', 'hello!')]),
+    ]);
+    expect(tree).toEqual(sections);
+  });
+  test('two sections', () => {
+    const tree = u('root', [
+      u('heading', { depth: 1 }, [u('text', 'h1')]),
+      u('text', 'hello!'),
+      u('heading', { depth: 1 }, [u('text', 'h2')]),
+      u('text', 'second'),
+    ]);
+    sectionTransform(tree, {});
+    const sections = u('root', [
+      u('section', { depth: 1 }, [u('heading', [u('text', 'h1')]), u('text', 'hello!')]),
+      u('section', { depth: 1 }, [u('heading', [u('text', 'h2')]), u('text', 'second')]),
+    ]);
+    expect(tree).toEqual(sections);
+  });
+  test('nested sections', () => {
+    const tree = u('root', [
+      u('heading', { depth: 1 }, [u('text', 'h1')]),
+      u('text', 'hello!'),
+      u('heading', { depth: 2 }, [u('text', 'h2')]),
+      u('text', 'second'),
+    ]);
+    sectionTransform(tree, {});
+    const sections = u('root', [
+      u('section', { depth: 1 }, [
+        u('heading', [u('text', 'h1')]),
+        u('text', 'hello!'),
+        u('section', { depth: 2 }, [u('heading', [u('text', 'h2')]), u('text', 'second')]),
+      ]),
+    ]);
+    expect(tree).toEqual(sections);
+  });
+
+  test('nested sections - reversed', () => {
+    const tree = u('root', [
+      u('heading', { depth: 2 }, [u('text', 'h2')]),
+      u('text', 'hello!'),
+      u('heading', { depth: 1 }, [u('text', 'h1')]),
+      u('text', 'second'),
+    ]);
+    sectionTransform(tree, {});
+    const sections = u('root', [
+      u('section', { depth: 2 }, [u('heading', [u('text', 'h2')]), u('text', 'hello!')]),
+      u('section', { depth: 1 }, [u('heading', [u('text', 'h1')]), u('text', 'second')]),
+    ]);
+    expect(tree).toEqual(sections);
+  });
+  test('three sections', () => {
+    const tree = u('root', [
+      u('heading', { depth: 1 }, [u('text', 'h1')]),
+      u('text', 'hello!'),
+      u('heading', { depth: 2 }, [u('text', 'h2-1')]),
+      u('text', 'second'),
+      u('heading', { depth: 2 }, [u('text', 'h2-2')]),
+      u('text', 'third'),
+    ]);
+    sectionTransform(tree, {});
+    const sections = u('root', [
+      u('section', { depth: 1 }, [
+        u('heading', [u('text', 'h1')]),
+        u('text', 'hello!'),
+        u('section', { depth: 2 }, [u('heading', [u('text', 'h2-1')]), u('text', 'second')]),
+        u('section', { depth: 2 }, [u('heading', [u('text', 'h2-2')]), u('text', 'third')]),
+      ]),
+    ]);
+    expect(tree).toEqual(sections);
+  });
+});

--- a/packages/myst-to-tex/src/utils.ts
+++ b/packages/myst-to-tex/src/utils.ts
@@ -154,6 +154,8 @@ const mathReplacements: Record<string, string> = {
   '♾': '\\acidfree',
   '≈': '\\approx',
   '≠': '\\neq',
+  '≥': '\\geq',
+  '≤': '\\leq',
   '•': '\\cdot',
   // '‰': '\\permille',
 };


### PR DESCRIPTION
Adds tests to the section nesting. There was previously a bug that turned

`[1,2,2]` into `[1: [2], 2]` instead of `[1: [2, 2]]`