### PR TITLE
🐛 Space in paragraph (Tex Parsing)

### DIFF
--- a/.changeset/warm-socks-peel.md
+++ b/.changeset/warm-socks-peel.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Leading space in paragraph bug

--- a/packages/tex-to-myst/src/parser.ts
+++ b/packages/tex-to-myst/src/parser.ts
@@ -229,13 +229,13 @@ export class TexParser implements ITexParser {
   closeParagraph() {
     const top = this.top();
     if (top?.type !== 'paragraph') return;
-    const first = top.children?.slice(0, 1)?.[0];
+    const first = top.children?.[0];
     const last = top.children?.slice(-1)?.[0];
     if (first?.type === 'text') {
-      first.value = first.value?.replace(/^\s/, '') ?? '';
+      first.value = first.value?.replace(/^\s+/, '') ?? '';
     }
     if (last?.type === 'text') {
-      last.value = last.value?.replace(/\s$/, '') ?? '';
+      last.value = last.value?.replace(/\s+$/, '') ?? '';
     }
     if (
       top.children?.length === 0 ||

--- a/packages/tex-to-myst/tests/figures.yml
+++ b/packages/tex-to-myst/tests/figures.yml
@@ -32,6 +32,32 @@ cases:
                           value: link to notebook
                     - type: text
                       value: '.'
+  - title: Paragraph after figure should not have a leading space
+    tex: |-
+      \begin{figure}[t!]
+          \includegraphics[width=0.95\textwidth]{fig.jpg}
+          \vspace{0mm}
+      \end{figure}
+      \vspace{3mm}
+      As mentioned above...
+
+      Text
+    tree:
+      type: root
+      children:
+        - type: container
+          kind: figure
+          children:
+            - type: image
+              url: fig.jpg
+        - type: paragraph
+          children:
+            - type: text
+              value: As mentioned above... # There is a bug that can put a space here with the \vspace
+        - type: paragraph
+          children:
+            - type: text
+              value: Text
   - title: Figure environment (label in caption)
     tex: |-
       \begin{figure}[ht!]


### PR DESCRIPTION
We would only remove a single space previously, this now consumes all of the whitespace at the beginning and end of a paragraph.