### PR TITLE
🏷 Improve JATS frontmatter export

### DIFF
--- a/.changeset/witty-vans-remain.md
+++ b/.changeset/witty-vans-remain.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Add license and id fields to the JATS frontmatter

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -519,12 +519,12 @@ export function getFundingGroup(frontmatter: ProjectFrontmatter): Element[] {
                   ...(frontmatter.authors ?? []),
                   ...(frontmatter.contributors ?? []),
                 ].find((auth) => auth.id === recipient) ?? { name: recipient };
-                if (author.orcid) {
+                if (orcid.validate(author.orcid)) {
                   recipientElements.push({
                     type: 'element',
                     name: 'contrib-id',
                     attributes: { 'contrib-id-type': 'orcid' },
-                    elements: [{ type: 'text', text: author.orcid }],
+                    elements: [{ type: 'text', text: orcid.buildUrl(author.orcid) }],
                   });
                 }
                 const name = nameElementFromContributor(author);
@@ -545,12 +545,12 @@ export function getFundingGroup(frontmatter: ProjectFrontmatter): Element[] {
                   ...(frontmatter.authors ?? []),
                   ...(frontmatter.contributors ?? []),
                 ].find((auth) => auth.id === investigator) ?? { name: investigator };
-                if (author.orcid) {
+                if (orcid.validate(author.orcid)) {
                   investigatorElements.push({
                     type: 'element',
                     name: 'contrib-id',
                     attributes: { 'contrib-id-type': 'orcid' },
-                    elements: [{ type: 'text', text: author.orcid }],
+                    elements: [{ type: 'text', text: orcid.buildUrl(author.orcid) }],
                   });
                 }
                 const name = nameElementFromContributor(author);

--- a/packages/myst-to-jats/tests/article.yml
+++ b/packages/myst-to-jats/tests/article.yml
@@ -117,8 +117,11 @@ cases:
         <front>
           <article-meta>
             <permissions>
-              <license>
+              <license xlink:href="https://creativecommons.org/licenses/by/4.0/">
                 <ali:license_ref>https://creativecommons.org/licenses/by/4.0/</ali:license_ref>
+                <license-p>This article is distributed under the terms of the 
+                  <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution License</ext-link>, which permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited.
+                </license-p>
               </license>
             </permissions>
           </article-meta>
@@ -147,8 +150,11 @@ cases:
           <article-meta>
             <permissions>
               <ali:free_to_read/>
-              <license>
+              <license xlink:href="https://creativecommons.org/licenses/by/4.0/">
                 <ali:license_ref>https://creativecommons.org/licenses/by/4.0/</ali:license_ref>
+                <license-p>This is an open access article distributed under the terms of the 
+                  <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution License</ext-link>, which permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited.
+                </license-p>
               </license>
             </permissions>
           </article-meta>

--- a/packages/myst-to-jats/tests/authors.yml
+++ b/packages/myst-to-jats/tests/authors.yml
@@ -45,7 +45,7 @@ cases:
           <article-meta>
             <contrib-group>
               <contrib contrib-type="author" corresp="yes" deceased="yes" equal-contrib="no">
-                <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
+                <contrib-id contrib-id-type="orcid">https://orcid.org/0000-0000-0000-0000</contrib-id>
                 <name name-style="western">
                   <surname>Doe</surname>
                   <given-names>Jane</given-names>

--- a/packages/myst-to-jats/tests/funding.yml
+++ b/packages/myst-to-jats/tests/funding.yml
@@ -169,7 +169,7 @@ cases:
           <article-meta>
             <contrib-group>
               <contrib contrib-type="author">
-                <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
+                <contrib-id contrib-id-type="orcid">https://orcid.org/0000-0000-0000-0000</contrib-id>
                 <name name-style="western">
                   <surname>Doe</surname>
                   <given-names>John</given-names>
@@ -207,14 +207,14 @@ cases:
                   </name>
                 </principal-award-recipient>
                 <principal-award-recipient>
-                  <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
+                  <contrib-id contrib-id-type="orcid">https://orcid.org/0000-0000-0000-0000</contrib-id>
                   <name name-style="western">
                     <surname>Doe</surname>
                     <given-names>John</given-names>
                   </name>
                 </principal-award-recipient>
                 <principal-investigator>
-                  <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
+                  <contrib-id contrib-id-type="orcid">https://orcid.org/0000-0000-0000-0000</contrib-id>
                   <name name-style="western">
                     <surname>Doe</surname>
                     <given-names>John</given-names>
@@ -237,7 +237,7 @@ cases:
                 <award-id>ghi-789</award-id>
                 <award-desc>open access support</award-desc>
                 <principal-investigator>
-                  <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
+                  <contrib-id contrib-id-type="orcid">https://orcid.org/0000-0000-0000-0000</contrib-id>
                   <name name-style="western">
                     <surname>Doe</surname>
                     <given-names>John</given-names>
@@ -297,7 +297,7 @@ cases:
           <article-meta>
             <contrib-group>
               <contrib contrib-type="author">
-                <contrib-id contrib-id-type="orcid">0000-0000-0000-0000</contrib-id>
+                <contrib-id contrib-id-type="orcid">https://orcid.org/0000-0000-0000-0000</contrib-id>
                 <name name-style="western">
                   <surname>Doe</surname>
                   <given-names>John</given-names>


### PR DESCRIPTION
This adds a `license-p` paragraph for `CC-BY-4.0` output. Can add more in the future!

This also normalizes orcid output to be the URL.