### PR TITLE
🔢 Add number to template options

### DIFF
--- a/.changeset/dry-rules-itch.md
+++ b/.changeset/dry-rules-itch.md
@@ -1,0 +1,5 @@
+---
+'myst-templates': patch
+---
+
+Add validation options to template number option

--- a/.changeset/thin-elephants-flash.md
+++ b/.changeset/thin-elephants-flash.md
@@ -1,0 +1,6 @@
+---
+'myst-templates': patch
+'myst-common': patch
+---
+
+Add number to template options

--- a/packages/myst-common/src/templates.ts
+++ b/packages/myst-common/src/templates.ts
@@ -7,6 +7,7 @@ export enum TemplateKind {
 export enum TemplateOptionType {
   boolean = 'boolean',
   string = 'string',
+  number = 'number',
   choice = 'choice',
   file = 'file',
 }

--- a/packages/myst-templates/src/types.ts
+++ b/packages/myst-templates/src/types.ts
@@ -73,6 +73,9 @@ export type TemplateOptionDefinition = TemplateDocDefinition & {
   default?: any;
   choices?: string[];
   max_chars?: number;
+  min?: number;
+  max?: number;
+  integer?: boolean;
 };
 
 export type TemplateStyles = {

--- a/packages/myst-templates/src/validators.spec.ts
+++ b/packages/myst-templates/src/validators.spec.ts
@@ -69,6 +69,65 @@ describe('validateTemplateOption', () => {
     ).toEqual(undefined);
     expect(opts.messages.errors?.length).toEqual(1);
   });
+  it('number option validates number', async () => {
+    expect(validateTemplateOption(session, -0.5, { id: '', type: 'number' } as any, opts)).toEqual(
+      -0.5,
+    );
+  });
+  it('number option validates string number', async () => {
+    expect(
+      validateTemplateOption(session, '-0.5', { id: '', type: 'number' } as any, opts),
+    ).toEqual(-0.5);
+  });
+  it('number option with min/max/integer validates number', async () => {
+    expect(
+      validateTemplateOption(
+        session,
+        10,
+        { id: '', type: 'number', min: 9, max: 10, integer: true } as any,
+        opts,
+      ),
+    ).toEqual(10);
+  });
+  it('number option errors with < min', async () => {
+    expect(
+      validateTemplateOption(
+        session,
+        8,
+        { id: '', type: 'number', min: 9, max: 10, integer: true } as any,
+        opts,
+      ),
+    ).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('number option errors with > max', async () => {
+    expect(
+      validateTemplateOption(
+        session,
+        11,
+        { id: '', type: 'number', min: 9, max: 10, integer: true } as any,
+        opts,
+      ),
+    ).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('number option errors with non-integer', async () => {
+    expect(
+      validateTemplateOption(
+        session,
+        9.5,
+        { id: '', type: 'number', min: 9, max: 10, integer: true } as any,
+        opts,
+      ),
+    ).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('number option errors with non-number string', async () => {
+    expect(
+      validateTemplateOption(session, 'invalid', { id: '', type: 'number' } as any, opts),
+    ).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
 });
 
 describe('validateTemplateOptions', () => {

--- a/packages/myst-templates/src/validators.ts
+++ b/packages/myst-templates/src/validators.ts
@@ -80,14 +80,14 @@ export function validateTemplateOption(
   optionDefinition: TemplateOptionDefinition,
   opts: FileValidationOptions,
 ) {
-  const { type, max_chars, choices } = optionDefinition;
+  const { type, max_chars, min, max, integer, choices } = optionDefinition;
   switch (type) {
     case TemplateOptionType.boolean:
       return validateBoolean(input, opts);
     case TemplateOptionType.string:
       return validateString(input, { ...opts, maxLength: max_chars });
     case TemplateOptionType.number:
-      return validateNumber(input, { ...opts });
+      return validateNumber(input, { ...opts, min, max, integer });
     case TemplateOptionType.choice:
       return validateChoice(input, { ...opts, choices: choices || [] });
     case TemplateOptionType.file:

--- a/packages/myst-templates/src/validators.ts
+++ b/packages/myst-templates/src/validators.ts
@@ -86,6 +86,8 @@ export function validateTemplateOption(
       return validateBoolean(input, opts);
     case TemplateOptionType.string:
       return validateString(input, { ...opts, maxLength: max_chars });
+    case TemplateOptionType.number:
+      return validateNumber(input, { ...opts });
     case TemplateOptionType.choice:
       return validateChoice(input, { ...opts, choices: choices || [] });
     case TemplateOptionType.file:


### PR DESCRIPTION
Seems surprising that we didn't have this yet! I suppose this is mostly driven by the jtex side. where we don't have a template option that is a number. This is helpful if we are going to start to use this in other places though!