### PR TITLE
🐛 Do not reload configs or files unnecessarily

### DIFF
--- a/.changeset/early-frogs-brush.md
+++ b/.changeset/early-frogs-brush.md
@@ -1,0 +1,6 @@
+---
+'myst-templates': patch
+'myst-cli': patch
+---
+
+Improve logging of MyST Template errors

--- a/.changeset/red-fans-attack.md
+++ b/.changeset/red-fans-attack.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Load raw/site/proj configs in single function with better caching

--- a/.changeset/swift-news-change.md
+++ b/.changeset/swift-news-change.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Stop reloading files when getting raw frontmatter

--- a/.changeset/wet-ants-crash.md
+++ b/.changeset/wet-ants-crash.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Export meca build functions

--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -101,7 +101,7 @@ export async function runWordExport(
     errorLogFn: (message: string) => {
       fileError(vfile, message, { ruleId: RuleId.docxRenders });
     },
-    warningLogFn: (message: string)=> {
+    warningLogFn: (message: string) => {
       fileWarn(vfile, message, { ruleId: RuleId.docxRenders });
     },
   });

--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -23,7 +23,7 @@ import {
 } from '../utils/index.js';
 import { createFooter } from './footers.js';
 import { createArticleTitle, createReferenceTitle } from './titles.js';
-import { TemplateKind } from 'myst-common';
+import { fileError, fileWarn, RuleId, TemplateKind } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 
 const DOCX_IMAGE_EXTENSIONS = [ImageExtensions.png, ImageExtensions.jpg, ImageExtensions.jpeg];
@@ -98,6 +98,12 @@ export async function runWordExport(
     kind: TemplateKind.docx,
     template: exportOptions.template || undefined,
     buildDir: session.buildPath(),
+    errorLogFn: (message: string) => {
+      fileError(vfile, message, { ruleId: RuleId.docxRenders });
+    },
+    warningLogFn: (message: string)=> {
+      fileWarn(vfile, message, { ruleId: RuleId.docxRenders });
+    },
   });
   await mystTemplate.ensureTemplateExistsOnPath();
   const toc = tic();

--- a/packages/myst-cli/src/build/index.ts
+++ b/packages/myst-cli/src/build/index.ts
@@ -8,3 +8,4 @@ export * from './tex/index.js';
 export * from './types.js';
 export * from './utils/index.js';
 export * from './html/index.js';
+export * from './meca/index.js';

--- a/packages/myst-cli/src/build/init.ts
+++ b/packages/myst-cli/src/build/init.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
-import { defaultConfigFile, loadConfigAndValidateOrThrow, writeConfigs } from '../config.js';
+import { defaultConfigFile, loadConfig, writeConfigs } from '../config.js';
 import { loadProjectFromDisk } from '../project/index.js';
 import { selectors } from '../store/index.js';
 import type { ISession } from '../session/index.js';
@@ -64,7 +64,7 @@ export async function init(session: ISession, opts: InitOptions) {
   if (!project && !site && !writeToc) {
     session.log.info(WELCOME());
   }
-  loadConfigAndValidateOrThrow(session, '.');
+  loadConfig(session, '.');
   const state = session.store.getState();
   const existingRawConfig = selectors.selectLocalRawConfig(state, '.');
   const existingProjectConfig = selectors.selectLocalProjectConfig(state, '.');
@@ -114,7 +114,7 @@ export async function init(session: ISession, opts: InitOptions) {
     fs.writeFileSync(configFile, configData);
   }
   if (writeToc) {
-    loadConfigAndValidateOrThrow(session, '.');
+    loadConfig(session, '.');
     await loadProjectFromDisk(session, '.', { writeToc });
   }
   // If we have any options, this command is complete!

--- a/packages/myst-cli/src/build/pdf/create.ts
+++ b/packages/myst-cli/src/build/pdf/create.ts
@@ -4,7 +4,7 @@ import util from 'util';
 import chalk from 'chalk';
 import { pdfExportCommand, texMakeGlossariesCommand } from 'jtex';
 import { exec, tic } from 'myst-cli-utils';
-import { RuleId, TemplateKind, fileError } from 'myst-common';
+import { RuleId, TemplateKind, fileError, fileWarn } from 'myst-common';
 import MystTemplate from 'myst-templates';
 import { VFile } from 'vfile';
 import type { ISession } from '../../session/types.js';
@@ -275,6 +275,12 @@ async function runPdfBuildCommand(
       kind: TemplateKind.tex,
       template: template || undefined,
       buildDir: session.buildPath(),
+      errorLogFn: (message: string) => {
+        fileError(vfile, message, { ruleId: RuleId.pdfBuilds });
+      },
+      warningLogFn: (message: string) => {
+        fileWarn(vfile, message, { ruleId: RuleId.pdfBuilds });
+      },
     });
     buildCommand = pdfExportCommand(texFile, texLogFile, mystTemplate);
   }

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -5,7 +5,7 @@ import type { TemplateImports } from 'jtex';
 import { renderTex, mergeTemplateImports } from 'jtex';
 import { tic, writeFileToFolder } from 'myst-cli-utils';
 import type { References, GenericParent } from 'myst-common';
-import { extractPart, TemplateKind } from 'myst-common';
+import { extractPart, RuleId, TemplateKind } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import { ExportFormats } from 'myst-frontmatter';
 import type { TemplatePartDefinition, TemplateYml } from 'myst-templates';
@@ -18,7 +18,12 @@ import { findCurrentProjectAndLoad } from '../../config.js';
 import { loadProjectFromDisk } from '../../project/index.js';
 import { castSession } from '../../session/index.js';
 import type { ISession } from '../../session/types.js';
-import { createTempFolder, ImageExtensions, logMessagesFromVFile } from '../../utils/index.js';
+import {
+  addWarningForFile,
+  createTempFolder,
+  ImageExtensions,
+  logMessagesFromVFile,
+} from '../../utils/index.js';
 import type { ExportWithOutput, ExportOptions, ExportResults } from '../types.js';
 import {
   cleanOutput,
@@ -147,6 +152,16 @@ export async function localArticleToTexTemplated(
     kind: TemplateKind.tex,
     template: templateOptions.template || undefined,
     buildDir: session.buildPath(),
+    errorLogFn: (message: string) => {
+      addWarningForFile(session, file, message, 'error', {
+        ruleId: RuleId.texRenders,
+      });
+    },
+    warningLogFn: (message: string) => {
+      addWarningForFile(session, file, message, 'warn', {
+        ruleId: RuleId.texRenders,
+      });
+    },
   });
   await mystTemplate.ensureTemplateExistsOnPath();
   const toc = tic();

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -39,9 +39,31 @@ export function configFromPath(session: ISession, path: string) {
   return configs[0];
 }
 
-export function readConfig(session: ISession, vfile: VFile) {
-  const file = vfile.path;
+/**
+ * Load site/project config from local path to redux store
+ *
+ * Errors if config file does not exist or if config file exists but is invalid.
+ */
+export function loadConfig(session: ISession, path: string) {
+  const file = configFromPath(session, path);
+  if (!file) {
+    session.log.debug(`No config loaded from path: ${path}`);
+    return;
+  }
+  const vfile = new VFile();
+  vfile.path = file;
   if (!fs.existsSync(file)) throw Error(`Cannot find config file: ${file}`);
+  let rawConf: Record<string, any>;
+  try {
+    rawConf = yaml.load(fs.readFileSync(file, 'utf-8')) as Record<string, any>;
+  } catch (err) {
+    const suffix = (err as Error).message ? `\n\n${(err as Error).message}` : '';
+    throw Error(`Unable to read config file ${file} as YAML${suffix}`);
+  }
+  const existingConf = selectors.selectLocalRawConfig(session.store.getState(), path);
+  if (existingConf && JSON.stringify(rawConf) === JSON.stringify(existingConf.raw)) {
+    return existingConf.validated;
+  }
   const opts: ValidationOptions = {
     file,
     property: 'config',
@@ -96,6 +118,22 @@ export function readConfig(session: ISession, vfile: VFile) {
     });
     const { logoText, ...rest } = conf.site;
     conf.site = { logo_text: logoText, ...rest };
+  }
+  session.store.dispatch(
+    config.actions.receiveRawConfig({ path, file, raw: rawConf, validated: conf }),
+  );
+  const { site, project } = conf ?? {};
+  if (site) {
+    validateSiteConfigAndSave(session, path, vfile, site);
+    session.log.debug(`Loaded site config from ${file}`);
+  } else {
+    session.log.debug(`No site config in ${file}`);
+  }
+  if (project) {
+    validateProjectConfigAndSave(session, path, vfile, project);
+    session.log.debug(`Loaded project config from ${file}`);
+  } else {
+    session.log.debug(`No project config defined in ${file}`);
   }
   logMessagesFromVFile(session, vfile);
   return conf;
@@ -227,7 +265,7 @@ function validateProjectConfigAndSave(
 ) {
   let projectConfig = validateProjectConfig(rawProjectConfig, {
     file: vfile.path,
-    property: 'project',
+    property: 'config.project',
     messages: {},
     errorLogFn: (message: string) => {
       fileError(vfile, message, { ruleId: RuleId.validProjectConfig });
@@ -243,40 +281,6 @@ function validateProjectConfigAndSave(
   }
   projectConfig = resolveProjectConfigPaths(session, path, projectConfig, resolveToAbsolute);
   session.store.dispatch(config.actions.receiveProjectConfig({ path, ...projectConfig }));
-}
-
-/**
- * Load site/project config from local path to redux store
- *
- * Errors if config file does not exist or if config file exists but is invalid.
- */
-export function loadConfigAndValidateOrThrow(session: ISession, path: string) {
-  const file = configFromPath(session, path);
-  if (!file) {
-    session.log.debug(`No config loaded from path: ${path}`);
-    return;
-  }
-  const vfile = new VFile();
-  vfile.path = file;
-  const conf = readConfig(session, vfile);
-  const existingConf = selectors.selectLocalRawConfig(session.store.getState(), path);
-  if (existingConf && JSON.stringify(conf) === JSON.stringify(existingConf)) {
-    return;
-  }
-  session.store.dispatch(config.actions.receiveRawConfig({ path, file, ...conf }));
-  const { site, project } = conf;
-  if (site) {
-    validateSiteConfigAndSave(session, path, vfile, site);
-    session.log.debug(`Loaded site config from ${file}`);
-  } else {
-    session.log.debug(`No site config in ${file}`);
-  }
-  if (project) {
-    validateProjectConfigAndSave(session, path, vfile, project);
-    session.log.debug(`Loaded project config from ${file}`);
-  } else {
-    session.log.debug(`No project config defined in ${file}`);
-  }
 }
 
 /**
@@ -321,12 +325,8 @@ export function writeConfigs(
     return;
   }
   // Get raw config to override
-  let rawConfig = selectors.selectLocalRawConfig(session.store.getState(), path);
-  if (!rawConfig && configFromPath(session, path)) {
-    rawConfig = readConfig(session, vfile);
-  } else if (!rawConfig) {
-    rawConfig = emptyConfig();
-  }
+  const rawConfig = loadConfig(session, path);
+  const validatedRawConfig = rawConfig?.validated ?? emptyConfig();
   let logContent: string;
   if (siteConfig && projectConfig) {
     logContent = 'site and project configs';
@@ -337,16 +337,16 @@ export function writeConfigs(
   }
   session.log.debug(`Writing ${logContent} to ${file}`);
   // Combine site/project configs with
-  const newConfig = { ...rawConfig };
-  if (siteConfig) newConfig.site = { ...rawConfig.site, ...siteConfig };
-  if (projectConfig) newConfig.project = { ...rawConfig.project, ...projectConfig };
+  const newConfig = { ...validatedRawConfig };
+  if (siteConfig) newConfig.site = { ...validatedRawConfig.site, ...siteConfig };
+  if (projectConfig) newConfig.project = { ...validatedRawConfig.project, ...projectConfig };
   writeFileToFolder(file, yaml.dump(newConfig), 'utf-8');
 }
 
 export function findCurrentProjectAndLoad(session: ISession, path: string): string | undefined {
   path = resolve(path);
   if (configFromPath(session, path)) {
-    loadConfigAndValidateOrThrow(session, path);
+    loadConfig(session, path);
     const project = selectors.selectLocalProjectConfig(session.store.getState(), path);
     if (project) {
       session.store.dispatch(config.actions.receiveCurrentProjectPath({ path: path }));
@@ -362,7 +362,7 @@ export function findCurrentProjectAndLoad(session: ISession, path: string): stri
 export function findCurrentSiteAndLoad(session: ISession, path: string): string | undefined {
   path = resolve(path);
   if (configFromPath(session, path)) {
-    loadConfigAndValidateOrThrow(session, path);
+    loadConfig(session, path);
     const site = selectors.selectLocalSiteConfig(session.store.getState(), path);
     if (site) {
       session.store.dispatch(config.actions.receiveCurrentSitePath({ path: path }));
@@ -386,7 +386,7 @@ export function reloadAllConfigsForCurrentSite(session: ISession) {
     addWarningForFile(session, file, message, 'error', { ruleId: RuleId.siteConfigExists });
     throw Error(message);
   }
-  loadConfigAndValidateOrThrow(session, sitePath);
+  loadConfig(session, sitePath);
   const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());
   if (!siteConfig?.projects) return;
   siteConfig.projects
@@ -395,7 +395,7 @@ export function reloadAllConfigsForCurrentSite(session: ISession) {
     })
     .forEach((project) => {
       try {
-        loadConfigAndValidateOrThrow(session, project.path);
+        loadConfig(session, project.path);
       } catch (error) {
         // TODO: what error?
         session.log.debug(`Failed to find or load project config from "${project.path}"`);

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -265,7 +265,7 @@ function validateProjectConfigAndSave(
 ) {
   let projectConfig = validateProjectConfig(rawProjectConfig, {
     file: vfile.path,
-    property: 'config.project',
+    property: 'project',
     messages: {},
     errorLogFn: (message: string) => {
       fileError(vfile, message, { ruleId: RuleId.validProjectConfig });

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -83,7 +83,7 @@ export function prepareToWrite(frontmatter: { license?: Licenses }) {
 
 export async function getRawFrontmatterFromFile(session: ISession, file: string) {
   const cache = castSession(session);
-  await loadFile(session, file);
+  if (!cache.$mdast[file]) await loadFile(session, file);
   const result = cache.$mdast[file];
   if (!result || !result.pre) return undefined;
   const vfile = new VFile();

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -373,11 +373,10 @@ export async function processSite(session: ISession, opts?: ProcessOptions): Pro
     reloadAllConfigsForCurrentSite(session);
   } catch (error) {
     session.log.debug(`\n\n${(error as Error)?.stack}\n\n`);
-    session.log.error(
-      `Error finding or reading configuration files, do you need to run ${chalk.bold(
-        'myst init',
-      )}?`,
-    );
+    const prefix = (error as Error)?.message
+      ? (error as Error).message
+      : 'Error finding or reading configuration files.';
+    session.log.error(`${prefix}\nDo you need to run ${chalk.bold('myst init')}?`);
     process.exit(1);
   }
   const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());

--- a/packages/myst-cli/src/project/load.ts
+++ b/packages/myst-cli/src/project/load.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { join, resolve } from 'node:path';
 import { isDirectory, isUrl } from 'myst-cli-utils';
 import { RuleId } from 'myst-common';
-import { loadConfigAndValidateOrThrow } from '../config.js';
+import { loadConfig } from '../config.js';
 import { loadFile, combineProjectCitationRenderers } from '../process/index.js';
 import type { ISession } from '../session/types.js';
 import { selectors } from '../store/index.js';
@@ -115,7 +115,7 @@ export function findProjectsOnPath(session: ISession, path: string) {
   let projectPaths: string[] = [];
   const content = fs.readdirSync(path);
   if (session.configFiles.filter((file) => content.includes(file)).length) {
-    loadConfigAndValidateOrThrow(session, path);
+    loadConfig(session, path);
     if (selectors.selectLocalProjectConfig(session.store.getState(), path)) {
       projectPaths.push(path);
     }

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -93,7 +93,6 @@ export class Session implements ISession {
   }
 
   reload() {
-    this.store.dispatch(config.actions.reload());
     findCurrentProjectAndLoad(this, '.');
     findCurrentSiteAndLoad(this, '.');
     if (selectors.selectCurrentSitePath(this.store.getState())) {

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -3,7 +3,7 @@ import type { Store } from 'redux';
 import { createStore } from 'redux';
 import { chalkLogger, LogLevel } from 'myst-cli-utils';
 import type { Logger } from 'myst-cli-utils';
-import { config, rootReducer, selectors } from '../store/index.js';
+import { rootReducer, selectors } from '../store/index.js';
 import type { BuildWarning, RootState } from '../store/index.js';
 import type { ISession } from './types.js';
 import {

--- a/packages/myst-cli/src/store/reducers.ts
+++ b/packages/myst-cli/src/store/reducers.ts
@@ -39,18 +39,13 @@ export const config = createSlice({
   } as {
     currentProjectPath: string | undefined;
     currentSitePath: string | undefined;
-    rawConfigs: Record<string, Record<string, any>>;
+    rawConfigs: Record<string, { raw: Record<string, any>; validated: Record<string, any> }>;
     projects: Record<string, ProjectConfig>;
     sites: Record<string, SiteConfig>;
     siteTemplateOptions: Record<string, SiteTemplateOptions>;
     filenames: Record<string, string>;
   },
   reducers: {
-    reload(state) {
-      state.rawConfigs = {};
-      state.projects = {};
-      state.sites = {};
-    },
     receiveCurrentProjectPath(state, action: PayloadAction<{ path: string }>) {
       state.currentProjectPath = resolve(action.payload.path);
     },
@@ -59,7 +54,12 @@ export const config = createSlice({
     },
     receiveRawConfig(
       state,
-      action: PayloadAction<Record<string, any> & { path: string; file: string }>,
+      action: PayloadAction<{
+        raw: Record<string, any>;
+        validated: Record<string, any>;
+        path: string;
+        file: string;
+      }>,
     ) {
       const { path, file, ...payload } = action.payload;
       state.rawConfigs[resolve(path)] = payload;

--- a/packages/myst-cli/src/store/selectors.ts
+++ b/packages/myst-cli/src/store/selectors.ts
@@ -65,7 +65,7 @@ export function selectLocalConfigFile(state: RootState, path: string): string | 
 export function selectLocalRawConfig(
   state: RootState,
   path: string,
-): Record<string, any> | undefined {
+): { raw: Record<string, any>; validated: Record<string, any> } | undefined {
   return state.local.config.rawConfigs[resolve(path)];
 }
 

--- a/packages/myst-templates/src/template.ts
+++ b/packages/myst-templates/src/template.ts
@@ -20,6 +20,8 @@ class MystTemplate {
   templatePath: string;
   templateUrl: string | undefined;
   validatedTemplateYml: TemplateYml | undefined;
+  errorLogFn: (message: string) => void;
+  warningLogFn: (message: string) => void;
 
   /**
    * MystTemplate class for template download / validation / render preparation
@@ -31,12 +33,20 @@ class MystTemplate {
    */
   constructor(
     session: ISession,
-    opts?: { kind?: TemplateKind; template?: string; buildDir?: string },
+    opts?: {
+      kind?: TemplateKind;
+      template?: string;
+      buildDir?: string;
+      errorLogFn?: (message: string) => void;
+      warningLogFn?: (message: string) => void;
+    },
   ) {
     this.session = session;
     const { templatePath, templateUrl } = resolveInputs(this.session, opts || {});
     this.templatePath = templatePath;
     this.templateUrl = templateUrl;
+    this.errorLogFn = opts?.errorLogFn ?? errorLogger(this.session);
+    this.warningLogFn = opts?.warningLogFn ?? warningLogger(this.session);
   }
 
   getTemplateYmlPath() {
@@ -58,8 +68,8 @@ class MystTemplate {
         file: this.getTemplateYmlPath(),
         property: 'template',
         messages: {},
-        errorLogFn: errorLogger(this.session),
-        warningLogFn: warningLogger(this.session),
+        errorLogFn: this.errorLogFn,
+        warningLogFn: this.warningLogFn,
       };
       const templateYml = validateTemplateYml(this.session, this.getTemplateYml(), {
         ...opts,
@@ -80,8 +90,8 @@ class MystTemplate {
       file,
       property: 'options',
       messages: {},
-      errorLogFn: errorLogger(this.session),
-      warningLogFn: warningLogger(this.session),
+      errorLogFn: this.errorLogFn,
+      warningLogFn: this.warningLogFn,
       ...fileOpts,
     };
     const validatedOptions = validateTemplateOptions(
@@ -107,8 +117,8 @@ class MystTemplate {
       file,
       property: 'parts',
       messages: {},
-      errorLogFn: errorLogger(this.session),
-      warningLogFn: warningLogger(this.session),
+      errorLogFn: this.errorLogFn,
+      warningLogFn: this.warningLogFn,
     };
     const validatedParts = validateTemplateParts(parts, templateYml?.parts || [], options, opts);
     if (validatedParts === undefined) {
@@ -133,8 +143,8 @@ class MystTemplate {
       file,
       property: 'frontmatter',
       messages: {},
-      errorLogFn: errorLogger(this.session),
-      warningLogFn: warningLogger(this.session),
+      errorLogFn: this.errorLogFn,
+      warningLogFn: this.warningLogFn,
     };
     const bibFrontmatter = {
       ...frontmatter,


### PR DESCRIPTION
When consuming file warnings there was a bug that sometimes made them disappear. You see the log message that the warning occurred, but the store no longer has any record of the warning when processing is complete.

This was caused by `getRawFrontmatterFromFile` always re-loading files, even if they were already loaded, which in the process clears all previous warnings. Simply not re-loading the file if it is already loaded prevents this bug.