### PR TITLE
🔧 Cache mdast at full file path

### DIFF
--- a/.changeset/moody-walls-check.md
+++ b/.changeset/moody-walls-check.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Cache mdast at full file path

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -109,10 +109,10 @@ async function copyDependentFiles(
   errorLogFn: (m: string) => void,
 ) {
   const cache = castSession(session);
-  if (!cache.$mdast[sourceFile]) {
+  if (!cache.$getMdast(sourceFile)) {
     await loadFile(session, sourceFile);
   }
-  const pre = cache.$mdast[sourceFile]?.pre;
+  const pre = cache.$getMdast(sourceFile)?.pre;
   if (!pre) return;
   const { mdast, frontmatter } = pre;
   const urlNodes = selectAll('image,link', mdast);

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -83,8 +83,8 @@ export function prepareToWrite(frontmatter: { license?: Licenses }) {
 
 export async function getRawFrontmatterFromFile(session: ISession, file: string) {
   const cache = castSession(session);
-  if (!cache.$mdast[file]) await loadFile(session, file);
-  const result = cache.$mdast[file];
+  if (!cache.$getMdast(file)) await loadFile(session, file);
+  const result = cache.$getMdast(file);
   if (!result || !result.pre) return undefined;
   const vfile = new VFile();
   vfile.path = file;

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -128,8 +128,13 @@ export async function transformMdast(
   const toc = tic();
   const { store, log } = session;
   const cache = castSession(session);
-  if (!cache.$mdast[file]) return;
-  const { mdast: mdastPre, kind, frontmatter: preFrontmatter, location } = cache.$mdast[file].pre;
+  if (!cache.$getMdast(file)) return;
+  const {
+    mdast: mdastPre,
+    kind,
+    frontmatter: preFrontmatter,
+    location,
+  } = cache.$getMdast(file).pre;
   if (!mdastPre) throw new Error(`Expected mdast to be parsed for ${file}`);
   log.debug(`Processing "${file}"`);
   const vfile = new VFile(); // Collect errors on this file
@@ -284,7 +289,7 @@ export async function transformMdast(
     mdast,
     references,
   };
-  cache.$mdast[file].post = data;
+  cache.$getMdast(file).post = data;
   if (extraTransforms) {
     await Promise.all(
       extraTransforms.map(async (transform) => {

--- a/packages/myst-cli/src/session/cache.ts
+++ b/packages/myst-cli/src/session/cache.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type { ISession, ISessionWithCache } from './types.js';
 
 export function castSession(session: ISession): ISessionWithCache {
@@ -8,5 +9,11 @@ export function castSession(session: ISession): ISessionWithCache {
   if (!cache.$externalReferences) cache.$externalReferences = {};
   if (!cache.$mdast) cache.$mdast = {};
   if (!cache.$outputs) cache.$outputs = {};
+  cache.$setMdast = (file, data) => {
+    cache.$mdast[path.resolve(file)] = data;
+  };
+  cache.$getMdast = (file) => {
+    return cache.$mdast[path.resolve(file)];
+  };
   return cache;
 }

--- a/packages/myst-cli/src/session/types.ts
+++ b/packages/myst-cli/src/session/types.ts
@@ -33,4 +33,11 @@ export type ISessionWithCache = ISession & {
   $externalReferences: Record<string, Inventory>; // keyed on id
   $mdast: Record<string, { sha256?: string; pre: PreRendererData; post?: RendererData }>; // keyed on path
   $outputs: MinifiedContentCache;
+  /** Method to get $mdast value with normalized path */
+  $getMdast(file: string): { sha256?: string; pre: PreRendererData; post?: RendererData };
+  /** Method to set $mdast value with normalized path */
+  $setMdast(
+    file: string,
+    data: { sha256?: string; pre: PreRendererData; post?: RendererData },
+  ): void;
 };

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -578,7 +578,7 @@ export async function transformWebp(
 ) {
   const { file, imageWriteFolder } = opts;
   const cache = castSession(session);
-  const postData = cache.$mdast[opts.file].post;
+  const postData = cache.$getMdast(opts.file).post;
   if (!postData) throw new Error(`Expected mdast to be processed and transformed for ${file}`);
   if (!fs.existsSync(imageWriteFolder)) return; // No images exist to copy - not necessarily an error
   const writeFolderContents = fs.readdirSync(imageWriteFolder);
@@ -628,7 +628,7 @@ export async function transformWebp(
       }
     }),
   );
-  cache.$mdast[file].post = { ...postData, mdast, frontmatter };
+  cache.$getMdast(file).post = { ...postData, mdast, frontmatter };
 }
 
 function isValidImageNode(node: GenericNode, validExts: ImageExtensions[]) {


### PR DESCRIPTION
There was some mismatch in `cache.$mdast` with saving relative paths, then accessing by resolved paths (e.g. https://github.com/executablebooks/mystmd/compare/feat/mdast-cache?expand=1#diff-e11e13e3b479fbfb25096e4e27367dfcc16a339b97d3cab1a4f94b1a769f599cL139)

This PR swaps to uniformly getting/setting these values with resolved paths.