### PR TITLE
↔️ Full-width images in LaTeX

### DIFF
--- a/.changeset/twenty-coats-beg.md
+++ b/.changeset/twenty-coats-beg.md
@@ -1,0 +1,6 @@
+---
+'myst-directives': patch
+'myst-to-tex': patch
+---
+
+Add `full-width` to figure and table directives

--- a/packages/myst-directives/src/figure.ts
+++ b/packages/myst-directives/src/figure.ts
@@ -17,6 +17,9 @@ export const figureDirective: DirectiveSpec = {
     class: {
       type: String,
       alias: ['figclass'],
+      doc: `CSS classes to add to your figure. Special classes include:
+
+- \`full-width\`: changes the figure environment to cover two columns in LaTeX`,
     },
     height: {
       type: String,

--- a/packages/myst-directives/src/table.ts
+++ b/packages/myst-directives/src/table.ts
@@ -31,6 +31,9 @@ export const listTableDirective: DirectiveSpec = {
     class: {
       type: String,
       // class_option: list of strings?
+      doc: `CSS classes to add to your table. Special classes include:
+
+- \`full-width\`: changes the table environment to cover two columns in LaTeX`,
     },
     align: {
       type: String,

--- a/packages/myst-to-tex/src/container.ts
+++ b/packages/myst-to-tex/src/container.ts
@@ -11,6 +11,15 @@ export enum CaptionKind {
   table = 'table',
 }
 
+function getClasses(className?: string) {
+  const classes =
+    className
+      ?.split(' ')
+      .map((s) => s.trim().toLowerCase())
+      .filter((s) => !!s) ?? [];
+  return [...new Set(classes)];
+}
+
 function switchKind(node: Image | Table | Code | Math) {
   switch (node.type as string) {
     case 'iframe':
@@ -37,11 +46,13 @@ export function determineCaptionKind(node: GenericNode): CaptionKind | null {
 
 function nodeToCommand(node: Image | Table | Code | Math) {
   const kind = determineCaptionKind(node);
+  const classes = getClasses((node as any).class);
+  const fullWidth = classes.includes('full-width') || classes.includes('w-full');
   switch (kind) {
     case CaptionKind.fig:
-      return (node as any).fullpage ? 'figure*' : 'figure';
+      return fullWidth ? 'figure*' : 'figure';
     case CaptionKind.table:
-      return (node as any).fullpage ? 'table*' : 'table';
+      return fullWidth ? 'table*' : 'table';
     case CaptionKind.code:
       // TODO full width code
       return 'code';


### PR DESCRIPTION
Adding `class: full-width` will change a figure to the `figure*` environment that spans columns.

![image](https://github.com/executablebooks/mystmd/assets/913249/cc3cb6d9-154f-48b4-9d99-f98c513f7326)

See #716