### PR TITLE
🎆Write images when serializing, not during mdast processing

### DIFF
--- a/.changeset/quiet-jars-tan.md
+++ b/.changeset/quiet-jars-tan.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Write images when serializing, not during mdast processing

--- a/packages/myst-cli/src/build/utils/getFileContent.ts
+++ b/packages/myst-cli/src/build/utils/getFileContent.ts
@@ -17,21 +17,14 @@ import type { ImageExtensions } from '../../utils/index.js';
 export async function getFileContent(
   session: ISession,
   files: string[],
-  imageWriteFolder: string,
   {
     projectPath,
-    useExistingImages,
-    imageAltOutputFolder,
     imageExtensions,
     extraLinkTransformers,
-    simplifyFigures,
   }: {
     projectPath?: string;
-    useExistingImages?: boolean;
-    imageAltOutputFolder?: string;
     imageExtensions: ImageExtensions[];
     extraLinkTransformers?: LinkTransformer[];
-    simplifyFigures: boolean;
   },
 ) {
   const toc = tic();
@@ -58,15 +51,11 @@ export async function getFileContent(
       const pageSlug = pages.find((page) => page.file === file)?.slug;
       await transformMdast(session, {
         file,
-        useExistingImages,
-        imageWriteFolder,
-        imageAltOutputFolder,
         imageExtensions,
         projectPath,
         pageSlug,
         minifyMaxCharacters: 0,
         index: project.index,
-        simplifyFigures,
       });
     }),
   );
@@ -82,8 +71,6 @@ export async function getFileContent(
         file,
         extraLinkTransformers,
         pageReferenceStates,
-        simplifyFigures,
-        imageExtensions,
       });
       const selectedFile = selectFile(session, file);
       if (!selectedFile) throw new Error(`Could not load file information for ${file}`);


### PR DESCRIPTION
This addresses most of https://github.com/executablebooks/mystmd/issues/709

The image/output steps that write to disk are pulled out of the base `process/postProcessMdast` functions into a separate processing step called at final serialization for export / site build.