### PR TITLE
🐛 Fixes to file processing - better typing, undefined handling

### DIFF
--- a/.changeset/forty-parents-grin.md
+++ b/.changeset/forty-parents-grin.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fixes to file processing

--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -114,7 +114,7 @@ export async function runWordExport(
     sourceFile: file,
   });
   const renderer = exportOptions.renderer ?? defaultWordRenderer;
-  await finalizeMdast(session, data.mdast, data.frontmatter, file, {
+  await finalizeMdast(session, data.mdast, data.frontmatter, article, {
     imageWriteFolder,
     imageExtensions: DOCX_IMAGE_EXTENSIONS,
     simplifyFigures: true,

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -131,24 +131,18 @@ export async function localArticleToTexTemplated(
   force?: boolean,
   extraLinkTransformers?: LinkTransformer[],
 ): Promise<ExportResults> {
-  const filesPath = path.join(path.dirname(templateOptions.output), 'files');
-  const [{ frontmatter, mdast, references }] = await getFileContent(
-    session,
-    [templateOptions.article],
-    {
-      projectPath,
-      imageExtensions: TEX_IMAGE_EXTENSIONS,
-      extraLinkTransformers,
-    },
-  );
-  writeBibtexFromCitationRenderers(
-    session,
-    path.join(path.dirname(templateOptions.output), DEFAULT_BIB_FILENAME),
-  );
+  const { output, article, template } = templateOptions;
+  const filesPath = path.join(path.dirname(output), 'files');
+  const [{ frontmatter, mdast, references }] = await getFileContent(session, [article], {
+    projectPath,
+    imageExtensions: TEX_IMAGE_EXTENSIONS,
+    extraLinkTransformers,
+  });
+  writeBibtexFromCitationRenderers(session, path.join(path.dirname(output), DEFAULT_BIB_FILENAME));
 
   const mystTemplate = new MystTemplate(session, {
     kind: TemplateKind.tex,
-    template: templateOptions.template || undefined,
+    template: template || undefined,
     buildDir: session.buildPath(),
     errorLogFn: (message: string) => {
       addWarningForFile(session, file, message, 'error', {
@@ -165,7 +159,7 @@ export async function localArticleToTexTemplated(
   const toc = tic();
   const templateYml = mystTemplate.getValidatedTemplateYml();
 
-  await finalizeMdast(session, mdast, frontmatter, file, {
+  await finalizeMdast(session, mdast, frontmatter, article, {
     imageWriteFolder: filesPath,
     imageAltOutputFolder: 'files/',
     imageExtensions: TEX_IMAGE_EXTENSIONS,
@@ -189,10 +183,10 @@ export async function localArticleToTexTemplated(
   // This will need opts eventually --v
   const result = mdastToTex(session, mdast, references, frontmatter, templateYml, true);
   // Fill in template
-  session.log.info(toc(`📑 Exported TeX in %s, copying to ${templateOptions.output}`));
+  session.log.info(toc(`📑 Exported TeX in %s, copying to ${output}`));
   renderTex(mystTemplate, {
     contentOrPath: result.value,
-    outputPath: templateOptions.output,
+    outputPath: output,
     frontmatter,
     parts,
     options: templateOptions,

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -143,7 +143,7 @@ export function selectFile(session: ISession, file: string): RendererData | unde
     });
     return undefined;
   }
-  const mdastPost = cache.$getMdast(file).post;
+  const mdastPost = cache.$getMdast(file)?.post;
   if (!mdastPost) {
     addWarningForFile(session, file, `Expected mdast to be processed and transformed`, 'error', {
       ruleId: RuleId.selectedFileIsProcessed,

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -127,8 +127,8 @@ export async function transformMdast(
     kind,
     frontmatter: preFrontmatter,
     location,
-  } = cache.$getMdast(file).pre;
-  if (!mdastPre) throw new Error(`Expected mdast to be parsed for ${file}`);
+  } = cache.$getMdast(file)?.pre ?? {};
+  if (!mdastPre || !kind || !location) throw new Error(`Expected mdast to be parsed for ${file}`);
   log.debug(`Processing "${file}"`);
   const vfile = new VFile(); // Collect errors on this file
   vfile.path = file;
@@ -251,7 +251,8 @@ export async function transformMdast(
     mdast,
     references,
   };
-  cache.$getMdast(file).post = data;
+  const cachedMdast = cache.$getMdast(file);
+  if (cachedMdast) cachedMdast.post = data;
   if (extraTransforms) {
     await Promise.all(
       extraTransforms.map(async (transform) => {
@@ -381,7 +382,7 @@ export async function finalizeMdast(
     transformPlaceholderImages(mdast, { imageExtensions });
   }
   const cache = castSession(session);
-  const postData = cache.$getMdast(file).post;
+  const postData = cache.$getMdast(file)?.post;
   if (postData) {
     postData.frontmatter = frontmatter;
     postData.mdast = mdast;

--- a/packages/myst-cli/src/session/types.ts
+++ b/packages/myst-cli/src/session/types.ts
@@ -34,7 +34,9 @@ export type ISessionWithCache = ISession & {
   $mdast: Record<string, { sha256?: string; pre: PreRendererData; post?: RendererData }>; // keyed on path
   $outputs: MinifiedContentCache;
   /** Method to get $mdast value with normalized path */
-  $getMdast(file: string): { sha256?: string; pre: PreRendererData; post?: RendererData };
+  $getMdast(
+    file: string,
+  ): { sha256?: string; pre: PreRendererData; post?: RendererData } | undefined;
   /** Method to set $mdast value with normalized path */
   $setMdast(
     file: string,

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -595,7 +595,7 @@ export async function transformWebp(
 ) {
   const { file, imageWriteFolder } = opts;
   const cache = castSession(session);
-  const postData = cache.$getMdast(opts.file).post;
+  const postData = cache.$getMdast(opts.file)?.post;
   if (!postData) throw new Error(`Expected mdast to be processed and transformed for ${file}`);
   if (!fs.existsSync(imageWriteFolder)) return; // No images exist to copy - not necessarily an error
   const writeFolderContents = fs.readdirSync(imageWriteFolder);
@@ -645,7 +645,8 @@ export async function transformWebp(
       }
     }),
   );
-  cache.$getMdast(file).post = { ...postData, mdast, frontmatter };
+  const cachedMdast = cache.$getMdast(file);
+  if (cachedMdast) cachedMdast.post = { ...postData, mdast, frontmatter };
 }
 
 function isValidImageNode(node: GenericNode, validExts: ImageExtensions[]) {


### PR DESCRIPTION
🤦‍♂️ I had this commit locally when testing #721 but it didn't make it into the release. Oh man. Most critically, tex exports are broken without this commit since the `cache.$mdast` lookup is using the wrong file (i.e. `file` vs `article` here https://github.com/executablebooks/mystmd/pull/728/files#diff-809f642b8b08c50fa59434f4dd5e68c8063c8be90e8022b375c13b1edb262a6bL168-R162)