### PR TITLE
🎆 Write thumbnails/banner back to redux store

### DIFF
--- a/.changeset/tough-moles-wave.md
+++ b/.changeset/tough-moles-wave.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Write thumbnails/banner back to redux store

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -14,7 +14,7 @@ import { VFile } from 'vfile';
 import { castSession } from './session/index.js';
 import { loadFile } from './process/index.js';
 import type { ISession } from './session/types.js';
-import { selectors } from './store/index.js';
+import { selectors, watch } from './store/index.js';
 import { logMessagesFromVFile } from './index.js';
 
 /**
@@ -122,4 +122,29 @@ export function getExportListFromRawFrontmatter(
     (exp: Export | undefined): exp is Export => !!exp && formats.includes(exp.format),
   );
   return exportOptions;
+}
+
+export function updateFileInfoFromFrontmatter(
+  session: ISession,
+  file: string,
+  frontmatter: PageFrontmatter,
+  url?: string,
+  dataUrl?: string,
+) {
+  session.store.dispatch(
+    watch.actions.updateFileInfo({
+      path: file,
+      title: frontmatter.title,
+      short_title: frontmatter.short_title,
+      description: frontmatter.description,
+      date: frontmatter.date,
+      thumbnail: frontmatter.thumbnail,
+      thumbnailOptimized: frontmatter.thumbnailOptimized,
+      banner: frontmatter.banner,
+      bannerOptimized: frontmatter.bannerOptimized,
+      tags: frontmatter.tags,
+      url,
+      dataUrl,
+    }),
+  );
 }

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -29,9 +29,12 @@ import {
 } from 'myst-transforms';
 import { unified } from 'unified';
 import { VFile } from 'vfile';
-import { getPageFrontmatter, processPageFrontmatter } from '../frontmatter.js';
+import {
+  getPageFrontmatter,
+  processPageFrontmatter,
+  updateFileInfoFromFrontmatter,
+} from '../frontmatter.js';
 import { selectors } from '../store/index.js';
-import { watch } from '../store/reducers.js';
 import type { ISession } from '../session/types.js';
 import { castSession } from '../session/index.js';
 import type { RendererData } from '../transforms/types.js';
@@ -224,22 +227,7 @@ export async function transformMdast(
     ? `/${projectSlug}/${useSlug ? pageSlug : ''}`
     : `/${useSlug ? pageSlug : ''}`;
   const dataUrl = projectSlug ? `/${projectSlug}/${pageSlug}.json` : `/${pageSlug}.json`;
-  store.dispatch(
-    watch.actions.updateFileInfo({
-      path: file,
-      title: frontmatter.title,
-      short_title: frontmatter.short_title,
-      description: frontmatter.description,
-      date: frontmatter.date,
-      thumbnail: frontmatter.thumbnail,
-      thumbnailOptimized: frontmatter.thumbnailOptimized,
-      banner: frontmatter.banner,
-      bannerOptimized: frontmatter.bannerOptimized,
-      tags: frontmatter.tags,
-      url,
-      dataUrl,
-    }),
-  );
+  updateFileInfoFromFrontmatter(session, file, frontmatter, url, dataUrl);
   const data: RendererData = {
     kind: frontmatter.kernelspec || frontmatter.jupytext ? SourceFileKind.Notebook : kind,
     file,
@@ -386,6 +374,7 @@ export async function finalizeMdast(
   if (postData) {
     postData.frontmatter = frontmatter;
     postData.mdast = mdast;
+    updateFileInfoFromFrontmatter(session, file, frontmatter);
   }
   logMessagesFromVFile(session, vfile);
 }


### PR DESCRIPTION
Thumbnail and banner paths in the site config were broken by this PR: #721 - The image transformations were moved later; we kept track of these changes in the file frontmatter, but we did not call `updateFileInfo` again with correct thumbnail/banner values.

Just updating file info again after image writing corrects the site config.