### PR TITLE
🔗 Improve parsing of difficult DOIs

### DIFF
--- a/.changeset/short-bugs-tease.md
+++ b/.changeset/short-bugs-tease.md
@@ -1,0 +1,6 @@
+---
+'myst-transforms': patch
+'myst-cli': patch
+---
+
+Improve parsing of difficult DOIs.

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -22,6 +22,22 @@ which will insert the citation text in the correct format (e.g. adding an italic
 
 Providing your DOIs as full links has the advantage that on other rendering platforms (e.g. GitHub), your citation will still be shown as a link. If you have many citations, however, this will slow down the build process as the citation information is fetched dynamically.
 
+:::{note} Dealing with complex DOIs
+:class: dropdown
+If your DOI does not follow modern standards (e.g. strange characters or contains multiple `/`s), you must include the `https://doi.org` in the URL and may have to URL encode the DOI string to be recognized as a URL in markdown.
+
+For the DOI, `10.1175/1520-0493(1972)100<0081:OTAOSH>2.3.CO;2` there are `<`, `;` and `()` characters that do not work well with markdown URL parsing. There are two options:
+
+1. use the service https://shortdoi.org, which will give you a unique, persistent smaller DOI that will parse correctly, in this case `https://doi.org/cr3qwn` (which becomes https://doi.org/cr3qwn); or
+2. URL encode this to: \
+   `https://doi.org/10.1175%2F1520-0493%281972%29100%3C0081%3AOTAOSH%3E2.3.CO%3B2`, which also becomes https://doi.org/10.1175%2F1520-0493%281972%29100%3C0081%3AOTAOSH%3E2.3.CO%3B2[^brackets].
+
+[^brackets]: In this case we can also optionally encode the brackets as `%28` and `%29`. There aren't too many of these in the wild, so hopefully it isn't too bad!!
+
+For DOIs with multiple slashes in the identifier you also have to use the full https://doi.org URL, for example, `https://doi.org/10.3847/1538-4365/ac5f56` becomes <https://doi.org/10.3847/1538-4365/ac5f56>.
+
+:::
+
 ## Including BibTeX
 
 A standard way of including references for $\LaTeX$ is using <wiki:BibTeX>, you can include a `*.bib` file or files in the same directory as your content directory for the project. These will provide the reference keys for that project.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3988,9 +3988,9 @@
       }
     },
     "node_modules/doi-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/doi-utils/-/doi-utils-2.0.1.tgz",
-      "integrity": "sha512-oLEzcyMUDZkk6JKBiiKAcOY52ACaV/+QIjI8MzeN5yOblGETjlNFVQ1Zg1LMFWeXbRJCuob+LPJMDv0TuL7QHw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/doi-utils/-/doi-utils-2.0.2.tgz",
+      "integrity": "sha512-CsQJRloXCL1+TXVs02ne285GXd+M8Evc5Ytcb10hT2uTcCrnVIt83sylA5joAoD0YoYRKhsXPwrYUTExE27Ucw=="
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -13495,7 +13495,7 @@
         "commander": "^10.0.1",
         "cors": "^2.8.5",
         "docx": "^7.5.0",
-        "doi-utils": "^2.0.0",
+        "doi-utils": "^2.0.2",
         "express": "^4.18.2",
         "fs-extra": "^11.1.1",
         "get-port": "^6.1.2",

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -53,7 +53,7 @@
     "commander": "^10.0.1",
     "cors": "^2.8.5",
     "docx": "^7.5.0",
-    "doi-utils": "^2.0.0",
+    "doi-utils": "^2.0.2",
     "express": "^4.18.2",
     "fs-extra": "^11.1.1",
     "get-port": "^6.1.2",

--- a/packages/myst-cli/src/transforms/dois.ts
+++ b/packages/myst-cli/src/transforms/dois.ts
@@ -13,7 +13,7 @@ import type { SingleCitationRenderer } from './types.js';
 import type { VFile } from 'vfile';
 
 async function getDoiOrgBibtex(log: Logger, doiString: string): Promise<string | null> {
-  if (!doi.validate(doi.normalize(doiString))) return null;
+  if (!doi.validate(doiString)) return null;
   const toc = tic();
   log.debug('Fetching DOI information from doi.org');
   const url = `https://doi.org/${doi.normalize(doiString)}`;
@@ -38,7 +38,7 @@ async function getCitation(
   doiString: string,
   node: GenericNode,
 ): Promise<SingleCitationRenderer | null> {
-  if (!doi.validate(doi.normalize(doiString))) return null;
+  if (!doi.validate(doiString)) return null;
   const bibtex = await getDoiOrgBibtex(log, doiString);
   if (!bibtex) {
     fileWarn(vfile, `Could not find DOI from link: ${doiString} as ${doi.normalize(doiString)}`, {
@@ -69,12 +69,12 @@ export async function transformLinkedDOIs(
   const citeDois: Cite[] = [];
   selectAll('link', mdast).forEach((node: GenericNode) => {
     const { url } = node as Link;
-    if (!doi.validate(doi.normalize(url))) return;
+    if (!doi.validate(url)) return;
     linkedDois.push(node as Link);
   });
   selectAll('cite', mdast).forEach((node: GenericNode) => {
     const { label } = node as Cite;
-    if (!doi.validate(doi.normalize(label))) return;
+    if (!doi.validate(label)) return;
     citeDois.push(node as Cite);
   });
   if (linkedDois.length === 0 && citeDois.length === 0) return renderer;
@@ -94,7 +94,7 @@ export async function transformLinkedDOIs(
       citeNode.type = 'cite';
       citeNode.kind = 'narrative';
       citeNode.label = cite.id;
-      if (doi.validate(doi.normalize(toText(citeNode.children)))) {
+      if (doi.validate(toText(citeNode.children))) {
         // If the link text is the DOI, update with a citation in a following pass
         citeNode.children = [];
       }

--- a/packages/myst-transforms/src/links/doi.ts
+++ b/packages/myst-transforms/src/links/doi.ts
@@ -15,14 +15,14 @@ export class DOITransformer implements LinkTransformer {
       // This may not be valid but flag it for the transform
       return true;
     }
-    if (uri && doi.validate(uri, { strict: true })) return true;
+    if (uri && doi.validate(uri)) return true;
     return false;
   }
 
   transform(link: Link, file: VFile): boolean {
     const urlSource = link.urlSource || link.url;
     const doiString = doi.normalize(urlSource);
-    if (!doiString || !doi.validate(doiString)) {
+    if (!doiString) {
       fileError(file, `DOI is not valid: ${urlSource}`, {
         node: link,
         source: TRANSFORM_SOURCE,


### PR DESCRIPTION
Improves the parsing of difficult DOIs that need to be URL encoded or similar and does not validate them after being normalized.

![image](https://github.com/executablebooks/mystmd/assets/913249/0b90fead-8a78-45b0-8d57-5a0760bd64dd)
