### PR TITLE
Add `options` and `parts` to frontmatter

### DIFF
--- a/.changeset/fluffy-clocks-complain.md
+++ b/.changeset/fluffy-clocks-complain.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Do not duplicate site template options in redux store

--- a/.changeset/gentle-moons-film.md
+++ b/.changeset/gentle-moons-film.md
@@ -1,0 +1,6 @@
+---
+'myst-config': patch
+'myst-cli': patch
+---
+
+Write myst-cli version in site config

--- a/.changeset/late-doors-dress.md
+++ b/.changeset/late-doors-dress.md
@@ -1,0 +1,8 @@
+---
+'myst-frontmatter': patch
+'myst-to-jats': patch
+'myst-common': patch
+'myst-cli': patch
+---
+
+Consume frontmatter parts alongside tagged parts

--- a/.changeset/long-penguins-remember.md
+++ b/.changeset/long-penguins-remember.md
@@ -1,0 +1,8 @@
+---
+'myst-frontmatter': patch
+'myst-to-jats': patch
+'myst-common': patch
+'myst-cli': patch
+---
+
+Transform frontmatter parts into blocks in the mdast

--- a/.changeset/long-zoos-shout.md
+++ b/.changeset/long-zoos-shout.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Resolve site logo path with other template options of type file

--- a/.changeset/many-ravens-develop.md
+++ b/.changeset/many-ravens-develop.md
@@ -1,0 +1,7 @@
+---
+'myst-templates': patch
+'myst-cli': patch
+'jtex': patch
+---
+
+Template parts may now specify as_list

--- a/.changeset/pretty-zebras-warn.md
+++ b/.changeset/pretty-zebras-warn.md
@@ -1,0 +1,7 @@
+---
+'myst-frontmatter': patch
+'myst-config': patch
+'myst-cli': patch
+---
+
+Consume frontmatter options for template/site options

--- a/.changeset/sixty-sloths-impress.md
+++ b/.changeset/sixty-sloths-impress.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Add options to site/project/page frontmatter

--- a/.changeset/small-pens-arrive.md
+++ b/.changeset/small-pens-arrive.md
@@ -1,0 +1,5 @@
+---
+'myst-common': patch
+---
+
+Ensure the block is visible by default in extractParts

--- a/.changeset/stupid-knives-eat.md
+++ b/.changeset/stupid-knives-eat.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Add parts to page frontmatter

--- a/.changeset/swift-eagles-call.md
+++ b/.changeset/swift-eagles-call.md
@@ -1,0 +1,6 @@
+---
+'myst-frontmatter': patch
+'myst-cli': patch
+---
+
+Frontmatter parts each coerce to list

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -133,6 +133,9 @@ The following table lists the available frontmatter fields, a brief description 
 * - `abbreviations`
   - a dictionary of abbreviations in the project (see [](#abbreviations))
   - page can override project
+* - `parts`
+  - a dictionary of arbitrary content parts, not part of the main article, for example `abstract`, `data_availability`
+  - page only
 ```
 
 +++

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -136,6 +136,9 @@ The following table lists the available frontmatter fields, a brief description 
 * - `parts`
   - a dictionary of arbitrary content parts, not part of the main article, for example `abstract`, `data_availability`
   - page only
+* - `options`
+  - a dictionary of arbitrary options validated and consumed by templates, for example, during site or PDF build
+  - page can override project
 ```
 
 +++

--- a/docs/quickstart-myst-websites.md
+++ b/docs/quickstart-myst-websites.md
@@ -183,7 +183,8 @@ project:
 site:
   template: book-theme
   # title:
-  # logo:
+  # options:
+  #   logo: my_logo.png
   nav: []
   actions:
     - title: Learn More

--- a/package-lock.json
+++ b/package-lock.json
@@ -13691,6 +13691,7 @@
       "license": "MIT",
       "dependencies": {
         "mdast": "^3.0.0",
+        "myst-frontmatter": "^1.1.11",
         "myst-spec": "^0.0.4",
         "nanoid": "^4.0.0",
         "unified": "^10.1.2",

--- a/packages/jtex/src/types.ts
+++ b/packages/jtex/src/types.ts
@@ -9,6 +9,6 @@ export type TexRenderer = {
   CONTENT: string;
   doc: RendererDoc;
   options: Record<string, any>;
-  parts: Record<string, string>;
+  parts: Record<string, string | string[]>;
   IMPORTS?: string;
 };

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -111,6 +111,7 @@
     "@types/mime-types": "^2.1.1",
     "@types/which": "^3.0.0",
     "@types/ws": "^8.5.5",
-    "concurrently": "^8.2.0"
+    "concurrently": "^8.2.0",
+    "unist-util-visit": "^5.0.0"
   }
 }

--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -110,7 +110,7 @@ export async function runWordExport(
   const { options, doc } = mystTemplate.prepare({
     frontmatter: data.frontmatter,
     parts: [],
-    options: exportOptions,
+    options: { ...data.frontmatter.options, ...exportOptions },
     sourceFile: file,
   });
   const renderer = exportOptions.renderer ?? defaultWordRenderer;

--- a/packages/myst-cli/src/build/init.ts
+++ b/packages/myst-cli/src/build/init.ts
@@ -25,7 +25,8 @@ function createProjectConfig({ github }: { github?: string } = {}) {
 const SITE_CONFIG = `site:
   template: book-theme
   # title:
-  # logo:
+  # options:
+  #   logo: site_logo.png
   nav: []
   actions:
     - title: Learn More

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -5,7 +5,7 @@ import { writeJats } from 'myst-to-jats';
 import type { LinkTransformer } from 'myst-transforms';
 import { VFile } from 'vfile';
 import { findCurrentProjectAndLoad } from '../../config.js';
-import { combineCitationRenderers, finalizeMdast } from '../../process/index.js';
+import { combineCitationRenderers, finalizeMdast, parseMyst } from '../../process/index.js';
 import { loadProjectFromDisk } from '../../project/index.js';
 import { castSession } from '../../session/index.js';
 import type { ISession } from '../../session/types.js';
@@ -73,6 +73,7 @@ export async function runJatsExport(
         title: 'Data Availability',
       },
     ],
+    mystParseFn: (content) => parseMyst(session, content, article),
   });
   logMessagesFromVFile(session, jats);
   session.log.info(toc(`📑 Exported JATS in %s, copying to ${output}`));

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -73,7 +73,6 @@ export async function runJatsExport(
         title: 'Data Availability',
       },
     ],
-    mystParseFn: (content) => parseMyst(session, content, article),
     // if we want to add templating here, we have access to { ...processedArticle.frontmatter.options, ...exportOptions }
   });
   logMessagesFromVFile(session, jats);

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -5,7 +5,7 @@ import { writeJats } from 'myst-to-jats';
 import type { LinkTransformer } from 'myst-transforms';
 import { VFile } from 'vfile';
 import { findCurrentProjectAndLoad } from '../../config.js';
-import { combineCitationRenderers, finalizeMdast, parseMyst } from '../../process/index.js';
+import { combineCitationRenderers, finalizeMdast } from '../../process/index.js';
 import { loadProjectFromDisk } from '../../project/index.js';
 import { castSession } from '../../session/index.js';
 import type { ISession } from '../../session/types.js';

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -74,6 +74,7 @@ export async function runJatsExport(
       },
     ],
     mystParseFn: (content) => parseMyst(session, content, article),
+    // if we want to add templating here, we have access to { ...processedArticle.frontmatter.options, ...exportOptions }
   });
   logMessagesFromVFile(session, jats);
   session.log.info(toc(`📑 Exported JATS in %s, copying to ${output}`));

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { hashAndCopyStaticFile } from 'myst-cli-utils';
 import { RuleId, TemplateOptionType } from 'myst-common';
-import type { SiteAction, SiteManifest, SiteTemplateOptions } from 'myst-config';
+import type { SiteAction, SiteManifest } from 'myst-config';
 import { PROJECT_FRONTMATTER_KEYS, SITE_FRONTMATTER_KEYS } from 'myst-frontmatter';
 import type MystTemplate from 'myst-templates';
 import { filterKeys } from 'simple-validators';
@@ -113,7 +113,7 @@ export async function localToManifestProject(
 async function resolveTemplateFileOptions(
   session: ISession,
   mystTemplate: MystTemplate,
-  options: SiteTemplateOptions,
+  options: Record<string, any>,
 ) {
   const resolvedOptions = { ...options };
   mystTemplate.getValidatedTemplateYml().options?.forEach((option) => {

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -6,7 +6,7 @@ import type { SiteAction, SiteManifest, SiteTemplateOptions } from 'myst-config'
 import { PROJECT_FRONTMATTER_KEYS, SITE_FRONTMATTER_KEYS } from 'myst-frontmatter';
 import type MystTemplate from 'myst-templates';
 import { filterKeys } from 'simple-validators';
-import { addWarningForFile, version } from '../../index.js';
+import { addWarningForFile, resolveToAbsolute, version } from '../../index.js';
 import { resolvePageExports } from '../../process/site.js';
 import type { ISession } from '../../session/types.js';
 import type { RootState } from '../../store/index.js';
@@ -118,9 +118,13 @@ async function resolveTemplateFileOptions(
   const resolvedOptions = { ...options };
   mystTemplate.getValidatedTemplateYml().options?.forEach((option) => {
     if (option.type === TemplateOptionType.file && options[option.id]) {
+      const configPath = selectors.selectCurrentSitePath(session.store.getState());
+      const absPath = configPath
+        ? resolveToAbsolute(session, configPath, options[option.id])
+        : options[option.id];
       const fileHash = hashAndCopyStaticFile(
         session,
-        options[option.id],
+        absPath,
         session.publicPath(),
         (m: string) => {
           addWarningForFile(session, options[option.id], m, 'error', {
@@ -172,10 +176,12 @@ export async function getSiteManifest(
   const { nav } = siteConfig;
   const actions = siteConfig.actions?.map((action) => resolveSiteManifestAction(session, action));
   const siteFrontmatter = filterKeys(siteConfig as Record<string, any>, SITE_FRONTMATTER_KEYS);
-  const siteTemplateOptions = selectors.selectCurrentSiteTemplateOptions(state) || {};
   const mystTemplate = await getMystTemplate(session, opts);
   const siteConfigFile = selectors.selectCurrentSiteFile(state);
-  const validatedOptions = mystTemplate.validateOptions(siteTemplateOptions, siteConfigFile);
+  const validatedOptions = mystTemplate.validateOptions(
+    siteFrontmatter.options ?? {},
+    siteConfigFile,
+  );
   const validatedFrontmatter = mystTemplate.validateDoc(
     siteFrontmatter,
     validatedOptions,
@@ -183,9 +189,9 @@ export async function getSiteManifest(
     siteConfigFile,
   );
   const resolvedOptions = await resolveTemplateFileOptions(session, mystTemplate, validatedOptions);
+  validatedFrontmatter.options = resolvedOptions;
   const manifest: SiteManifest = {
     ...validatedFrontmatter,
-    ...resolvedOptions,
     myst: version,
     nav: nav || [],
     actions: actions || [],

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -6,7 +6,7 @@ import type { SiteAction, SiteManifest, SiteTemplateOptions } from 'myst-config'
 import { PROJECT_FRONTMATTER_KEYS, SITE_FRONTMATTER_KEYS } from 'myst-frontmatter';
 import type MystTemplate from 'myst-templates';
 import { filterKeys } from 'simple-validators';
-import { addWarningForFile } from '../../index.js';
+import { addWarningForFile, version } from '../../index.js';
 import { resolvePageExports } from '../../process/site.js';
 import type { ISession } from '../../session/types.js';
 import type { RootState } from '../../store/index.js';
@@ -186,7 +186,7 @@ export async function getSiteManifest(
   const manifest: SiteManifest = {
     ...validatedFrontmatter,
     ...resolvedOptions,
-    myst: 'v1',
+    myst: version,
     nav: nav || [],
     actions: actions || [],
     projects: siteProjects,

--- a/packages/myst-cli/src/build/tex/single.spec.ts
+++ b/packages/myst-cli/src/build/tex/single.spec.ts
@@ -13,7 +13,6 @@ describe('extractTexPart', () => {
         { id: 'test_tag', required: true },
         {},
         { myst: 'v1' },
-        'file.md',
       ),
     ).toEqual(undefined);
   });
@@ -38,14 +37,14 @@ describe('extractTexPart', () => {
         },
       ],
     };
-    expect(
-      extractTexPart(new Session(), tree, {}, { id: 'test_tag' }, {}, { myst: 'v1' }, 'file.md'),
-    ).toEqual({
-      value: 'tagged content\n\nalso tagged content',
-      imports: [],
-      commands: {},
-      preamble: '',
-    });
+    expect(extractTexPart(new Session(), tree, {}, { id: 'test_tag' }, {}, { myst: 'v1' })).toEqual(
+      {
+        value: 'tagged content\n\nalso tagged content',
+        imports: [],
+        commands: {},
+        preamble: '',
+      },
+    );
     expect(tree).toEqual({
       type: 'root',
       children: [
@@ -76,7 +75,6 @@ describe('extractTexPart', () => {
         { id: 'test_tag', max_chars: 1000, max_words: 100 },
         {},
         { myst: 'v1' },
-        'file.md',
       ),
     ).toEqual({
       value: 'tagged content',
@@ -97,15 +95,7 @@ describe('extractTexPart', () => {
       ],
     };
     expect(
-      extractTexPart(
-        new Session(),
-        tree,
-        {},
-        { id: 'test_tag', max_chars: 5 },
-        {},
-        { myst: 'v1' },
-        'file.md',
-      ),
+      extractTexPart(new Session(), tree, {}, { id: 'test_tag', max_chars: 5 }, {}, { myst: 'v1' }),
     ).toEqual({
       value: 'tagged content',
       imports: [],
@@ -125,15 +115,7 @@ describe('extractTexPart', () => {
       ],
     };
     expect(
-      extractTexPart(
-        new Session(),
-        tree,
-        {},
-        { id: 'test_tag', max_words: 1 },
-        {},
-        { myst: 'v1' },
-        'file.md',
-      ),
+      extractTexPart(new Session(), tree, {}, { id: 'test_tag', max_words: 1 }, {}, { myst: 'v1' }),
     ).toEqual({
       value: 'tagged content',
       imports: [],

--- a/packages/myst-cli/src/build/tex/single.spec.ts
+++ b/packages/myst-cli/src/build/tex/single.spec.ts
@@ -123,4 +123,208 @@ describe('extractTexPart', () => {
       preamble: '',
     });
   });
+  it('part as_list returns list', async () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          data: { part: 'test_tag' },
+          children: [{ type: 'text', value: 'tagged content' }],
+        },
+        {
+          type: 'block' as any,
+          data: { part: 'test_tag' },
+          children: [{ type: 'text', value: 'also tagged content' }],
+        },
+      ],
+    };
+    expect(
+      extractTexPart(
+        new Session(),
+        tree,
+        {},
+        { id: 'test_tag', as_list: true },
+        {},
+        { myst: 'v1' },
+      ),
+    ).toEqual([
+      {
+        value: 'tagged content',
+        imports: [],
+        commands: {},
+        preamble: '',
+      },
+      {
+        value: 'also tagged content',
+        imports: [],
+        commands: {},
+        preamble: '',
+      },
+    ]);
+  });
+  it('part as_list returns list for markdown list', async () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          data: { part: 'test_tag' },
+          children: [
+            {
+              type: 'list',
+              ordered: false,
+              spread: false,
+              children: [
+                {
+                  type: 'listItem',
+                  spread: true,
+                  children: [{ type: 'text', value: 'tagged content' }],
+                },
+                {
+                  type: 'listItem',
+                  spread: true,
+                  children: [{ type: 'text', value: 'also tagged content' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(
+      extractTexPart(
+        new Session(),
+        tree,
+        {},
+        { id: 'test_tag', as_list: true },
+        {},
+        { myst: 'v1' },
+      ),
+    ).toEqual([
+      {
+        value: 'tagged content',
+        imports: [],
+        commands: {},
+        preamble: '',
+      },
+      {
+        value: 'also tagged content',
+        imports: [],
+        commands: {},
+        preamble: '',
+      },
+    ]);
+  });
+  it('part as_list returns single item for block with markdown list and other stuff', async () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          data: { part: 'test_tag' },
+          children: [
+            {
+              type: 'paragraph',
+              children: [{ type: 'text', value: 'some other stuff' }],
+            },
+            {
+              type: 'list',
+              ordered: false,
+              spread: false,
+              children: [
+                {
+                  type: 'listItem',
+                  spread: true,
+                  children: [{ type: 'text', value: 'tagged content' }],
+                },
+                {
+                  type: 'listItem',
+                  spread: true,
+                  children: [{ type: 'text', value: 'also tagged content' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(
+      extractTexPart(
+        new Session(),
+        tree,
+        {},
+        { id: 'test_tag', as_list: true },
+        {},
+        { myst: 'v1' },
+      ),
+    ).toEqual([
+      {
+        value:
+          'some other stuff\n\n\\begin{itemize}\n\\item tagged content\n\\item also tagged content\n\\end{itemize}',
+        imports: [],
+        commands: {},
+        preamble: '',
+      },
+    ]);
+  });
+  it('part as_list ignores markdown list if there are multiple blocks', async () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          data: { part: 'test_tag' },
+          children: [
+            {
+              type: 'list',
+              ordered: false,
+              spread: false,
+              children: [
+                {
+                  type: 'listItem',
+                  spread: true,
+                  children: [{ type: 'text', value: 'tagged content' }],
+                },
+                {
+                  type: 'listItem',
+                  spread: true,
+                  children: [{ type: 'text', value: 'also tagged content' }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'block' as any,
+          data: { part: 'test_tag' },
+          children: [{ type: 'text', value: 'more tagged content...' }],
+        },
+      ],
+    };
+    expect(
+      extractTexPart(
+        new Session(),
+        tree,
+        {},
+        { id: 'test_tag', as_list: true },
+        {},
+        { myst: 'v1' },
+      ),
+    ).toEqual([
+      {
+        value:
+          '\\begin{itemize}\n\\item tagged content\n\\item also tagged content\n\\end{itemize}',
+        imports: [],
+        commands: {},
+        preamble: '',
+      },
+      {
+        value: 'more tagged content...',
+        imports: [],
+        commands: {},
+        preamble: '',
+      },
+    ]);
+  });
 });

--- a/packages/myst-cli/src/build/tex/single.spec.ts
+++ b/packages/myst-cli/src/build/tex/single.spec.ts
@@ -3,7 +3,7 @@ import type { GenericParent } from 'myst-common';
 import { Session } from '../../session';
 import { extractTexPart } from './single';
 
-describe('extractPart', () => {
+describe('extractTexPart', () => {
   it('no tagged part returns undefined', async () => {
     expect(
       extractTexPart(
@@ -13,6 +13,7 @@ describe('extractPart', () => {
         { id: 'test_tag', required: true },
         {},
         { myst: 'v1' },
+        'file.md',
       ),
     ).toEqual(undefined);
   });
@@ -37,14 +38,14 @@ describe('extractPart', () => {
         },
       ],
     };
-    expect(extractTexPart(new Session(), tree, {}, { id: 'test_tag' }, {}, { myst: 'v1' })).toEqual(
-      {
-        value: 'tagged content\n\nalso tagged content',
-        imports: [],
-        commands: {},
-        preamble: '',
-      },
-    );
+    expect(
+      extractTexPart(new Session(), tree, {}, { id: 'test_tag' }, {}, { myst: 'v1' }, 'file.md'),
+    ).toEqual({
+      value: 'tagged content\n\nalso tagged content',
+      imports: [],
+      commands: {},
+      preamble: '',
+    });
     expect(tree).toEqual({
       type: 'root',
       children: [
@@ -75,6 +76,7 @@ describe('extractPart', () => {
         { id: 'test_tag', max_chars: 1000, max_words: 100 },
         {},
         { myst: 'v1' },
+        'file.md',
       ),
     ).toEqual({
       value: 'tagged content',
@@ -95,7 +97,15 @@ describe('extractPart', () => {
       ],
     };
     expect(
-      extractTexPart(new Session(), tree, {}, { id: 'test_tag', max_chars: 5 }, {}, { myst: 'v1' }),
+      extractTexPart(
+        new Session(),
+        tree,
+        {},
+        { id: 'test_tag', max_chars: 5 },
+        {},
+        { myst: 'v1' },
+        'file.md',
+      ),
     ).toEqual({
       value: 'tagged content',
       imports: [],
@@ -115,7 +125,15 @@ describe('extractPart', () => {
       ],
     };
     expect(
-      extractTexPart(new Session(), tree, {}, { id: 'test_tag', max_words: 1 }, {}, { myst: 'v1' }),
+      extractTexPart(
+        new Session(),
+        tree,
+        {},
+        { id: 'test_tag', max_words: 1 },
+        {},
+        { myst: 'v1' },
+        'file.md',
+      ),
     ).toEqual({
       value: 'tagged content',
       imports: [],

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -192,7 +192,7 @@ export async function localArticleToTexTemplated(
     outputPath: output,
     frontmatter,
     parts,
-    options: templateOptions,
+    options: { ...frontmatter.options, ...templateOptions },
     bibliography: [DEFAULT_BIB_FILENAME],
     sourceFile: file,
     imports: mergeTemplateImports(collectedImports, result),

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -70,11 +70,8 @@ export function extractTexPart(
   partDefinition: TemplatePartDefinition,
   frontmatter: PageFrontmatter,
   templateYml: TemplateYml,
-  file: string,
 ): LatexResult | undefined {
-  const part = extractPart(mdast, frontmatter, partDefinition.id, {
-    mystParseFn: (content) => parseMyst(session, content, file),
-  });
+  const part = extractPart(mdast, partDefinition.id);
   if (!part) return undefined;
   // Do not build glossaries when extracting parts: references cannot be mapped to definitions
   const partContent = mdastToTex(session, part, references, frontmatter, templateYml, false);
@@ -173,7 +170,7 @@ export async function localArticleToTexTemplated(
   const parts: Record<string, string> = {};
   let collectedImports: TemplateImports = { imports: [], commands: {} };
   partDefinitions.forEach((def) => {
-    const result = extractTexPart(session, mdast, references, def, frontmatter, templateYml, file);
+    const result = extractTexPart(session, mdast, references, def, frontmatter, templateYml);
     if (result != null) {
       collectedImports = mergeTemplateImports(collectedImports, result);
       parts[def.id] = result?.value ?? '';

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -15,7 +15,7 @@ import type { LatexResult } from 'myst-to-tex';
 import type { LinkTransformer } from 'myst-transforms';
 import { unified } from 'unified';
 import { findCurrentProjectAndLoad } from '../../config.js';
-import { finalizeMdast, parseMyst } from '../../process/index.js';
+import { finalizeMdast } from '../../process/index.js';
 import { loadProjectFromDisk } from '../../project/index.js';
 import { castSession } from '../../session/index.js';
 import type { ISession } from '../../session/types.js';

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -15,7 +15,7 @@ import type { LatexResult } from 'myst-to-tex';
 import type { LinkTransformer } from 'myst-transforms';
 import { unified } from 'unified';
 import { findCurrentProjectAndLoad } from '../../config.js';
-import { finalizeMdast } from '../../process/index.js';
+import { finalizeMdast, parseMyst } from '../../process/index.js';
 import { loadProjectFromDisk } from '../../project/index.js';
 import { castSession } from '../../session/index.js';
 import type { ISession } from '../../session/types.js';
@@ -70,8 +70,11 @@ export function extractTexPart(
   partDefinition: TemplatePartDefinition,
   frontmatter: PageFrontmatter,
   templateYml: TemplateYml,
+  file: string,
 ): LatexResult | undefined {
-  const part = extractPart(mdast, partDefinition.id);
+  const part = extractPart(mdast, frontmatter, partDefinition.id, {
+    mystParseFn: (content) => parseMyst(session, content, file),
+  });
   if (!part) return undefined;
   // Do not build glossaries when extracting parts: references cannot be mapped to definitions
   const partContent = mdastToTex(session, part, references, frontmatter, templateYml, false);
@@ -170,7 +173,7 @@ export async function localArticleToTexTemplated(
   const parts: Record<string, string> = {};
   let collectedImports: TemplateImports = { imports: [], commands: {} };
   partDefinitions.forEach((def) => {
-    const result = extractTexPart(session, mdast, references, def, frontmatter, templateYml);
+    const result = extractTexPart(session, mdast, references, def, frontmatter, templateYml, file);
     if (result != null) {
       collectedImports = mergeTemplateImports(collectedImports, result);
       parts[def.id] = result?.value ?? '';

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -139,7 +139,7 @@ export function loadConfig(session: ISession, path: string) {
   return conf;
 }
 
-function resolveToAbsolute(session: ISession, basePath: string, relativePath: string) {
+export function resolveToAbsolute(session: ISession, basePath: string, relativePath: string) {
   let message: string;
   try {
     const absPath = resolve(join(basePath, relativePath));
@@ -244,17 +244,6 @@ function validateSiteConfigAndSave(
   }
   siteConfig = resolveSiteConfigPaths(session, path, siteConfig, resolveToAbsolute);
   session.store.dispatch(config.actions.receiveSiteConfig({ path, ...siteConfig }));
-
-  let siteTemplateOptions = siteConfig.options ?? {};
-  if (siteTemplateOptions.logo) {
-    siteTemplateOptions = {
-      ...siteTemplateOptions,
-      logo: resolveToAbsolute(session, path, siteTemplateOptions.logo),
-    };
-  }
-  session.store.dispatch(
-    config.actions.receiveSiteTemplateOptions({ path, ...siteTemplateOptions }),
-  );
 }
 
 function validateProjectConfigAndSave(

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 import { writeFileToFolder } from 'myst-cli-utils';
 import { fileError, fileWarn, RuleId } from 'myst-common';
 import type { Config, ProjectConfig, SiteConfig, SiteProject } from 'myst-config';
-import { getSiteTemplateOptions, validateProjectConfig, validateSiteConfig } from 'myst-config';
+import { validateProjectConfig, validateSiteConfig } from 'myst-config';
 import type { ValidationOptions } from 'simple-validators';
 import { incrementOptions, validateKeys, validateObject, validationError } from 'simple-validators';
 import { VFile } from 'vfile';
@@ -245,7 +245,7 @@ function validateSiteConfigAndSave(
   siteConfig = resolveSiteConfigPaths(session, path, siteConfig, resolveToAbsolute);
   session.store.dispatch(config.actions.receiveSiteConfig({ path, ...siteConfig }));
 
-  let siteTemplateOptions = getSiteTemplateOptions(rawSiteConfig);
+  let siteTemplateOptions = siteConfig.options ?? {};
   if (siteTemplateOptions.logo) {
     siteTemplateOptions = {
       ...siteTemplateOptions,

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -70,7 +70,7 @@ export function processPageFrontmatter(
 
   const frontmatter = fillPageFrontmatter(pageFrontmatter, projectFrontmatter, validationOpts);
 
-  if (siteFrontmatter?.design?.hide_authors) {
+  if (siteFrontmatter?.options?.hide_authors || siteFrontmatter?.options?.design?.hide_authors) {
     delete frontmatter.authors;
   }
   return frontmatter;

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -69,6 +69,7 @@ import { combineCitationRenderers } from './citations.js';
 import { bibFilesInDir, selectFile } from './file.js';
 import { loadIntersphinx } from './intersphinx.js';
 import { select, selectAll } from 'unist-util-select';
+import { frontmatterPartsTransform } from '../transforms/parts.js';
 
 const LINKS_SELECTOR = 'link,card,linkBlock';
 
@@ -161,6 +162,7 @@ export async function transformMdast(
   const state = new ReferenceState({ numbering: frontmatter.numbering, file: vfile });
   cache.$internalReferences[file] = state;
   // Import additional content from mdast or other files
+  frontmatterPartsTransform(session, file, mdast, frontmatter);
   importMdastFromJson(session, file, mdast);
   await includeFilesTransform(session, file, mdast, vfile);
   // This needs to come before basic transformations since it may add labels to blocks

--- a/packages/myst-cli/src/store/reducers.ts
+++ b/packages/myst-cli/src/store/reducers.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import type { ProjectConfig, SiteConfig, SiteTemplateOptions } from 'myst-config';
+import type { ProjectConfig, SiteConfig } from 'myst-config';
 import { combineReducers } from 'redux';
 import type { BuildWarning, ExternalLinkResult } from './types.js';
 import type { LocalProject } from '../project/types.js';
@@ -34,7 +34,6 @@ export const config = createSlice({
     rawConfigs: {},
     projects: {},
     sites: {},
-    siteTemplateOptions: {},
     filenames: {},
   } as {
     currentProjectPath: string | undefined;
@@ -42,7 +41,6 @@ export const config = createSlice({
     rawConfigs: Record<string, { raw: Record<string, any>; validated: Record<string, any> }>;
     projects: Record<string, ProjectConfig>;
     sites: Record<string, SiteConfig>;
-    siteTemplateOptions: Record<string, SiteTemplateOptions>;
     filenames: Record<string, string>;
   },
   reducers: {
@@ -68,13 +66,6 @@ export const config = createSlice({
     receiveSiteConfig(state, action: PayloadAction<SiteConfig & { path: string }>) {
       const { path, ...payload } = action.payload;
       state.sites[resolve(path)] = payload;
-    },
-    receiveSiteTemplateOptions(
-      state,
-      action: PayloadAction<SiteTemplateOptions & { path: string }>,
-    ) {
-      const { path, ...payload } = action.payload;
-      state.siteTemplateOptions[resolve(path)] = payload;
     },
     receiveProjectConfig(state, action: PayloadAction<ProjectConfig & { path: string }>) {
       const { path, ...payload } = action.payload;

--- a/packages/myst-cli/src/store/selectors.ts
+++ b/packages/myst-cli/src/store/selectors.ts
@@ -24,11 +24,6 @@ export function selectCurrentSiteConfig(state: RootState): SiteConfig | undefine
   return { ...config, projects: [{ path }] };
 }
 
-export function selectCurrentSiteTemplateOptions(state: RootState) {
-  if (!state.local.config.currentSitePath) return undefined;
-  return state.local.config.siteTemplateOptions[resolve(state.local.config.currentSitePath)];
-}
-
 export function selectCurrentSitePath(state: RootState) {
   return state.local.config.currentSitePath;
 }

--- a/packages/myst-cli/src/transforms/parts.spec.ts
+++ b/packages/myst-cli/src/transforms/parts.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { visit } from 'unist-util-visit';
+import { GenericParent } from 'myst-common';
+import { frontmatterPartsTransform } from './parts';
+import { Session } from '../session/session';
+
+function stripPositions(tree: GenericParent) {
+  visit(tree, (node) => {
+    delete node.position;
+  });
+  return tree;
+}
+
+function testMdast() {
+  return {
+    type: 'root',
+    children: [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            value: 'hi',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('frontmatterPartsTransform', () => {
+  it('frontmatter with no parts passes', async () => {
+    const mdast = testMdast();
+    const frontmatter = { title: 'No parts' };
+    frontmatterPartsTransform(new Session(), 'test.md', mdast, frontmatter);
+    expect(mdast).toEqual(testMdast());
+    expect(frontmatter).toEqual({ title: 'No parts' });
+  });
+  it('frontmatter part is moved to mdast', async () => {
+    const mdast = testMdast();
+    const frontmatter = {
+      title: 'Abstract and Statement part',
+      parts: { abstract: 'This is my abstract', statement: 'and this is my statement' },
+    };
+    frontmatterPartsTransform(new Session(), 'test.md', mdast, frontmatter);
+    expect(stripPositions(mdast)).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'block',
+          data: { part: 'abstract', hidden: true },
+          children: [
+            { type: 'paragraph', children: [{ type: 'text', value: 'This is my abstract' }] },
+          ],
+        },
+        {
+          type: 'block',
+          data: { part: 'statement', hidden: true },
+          children: [
+            { type: 'paragraph', children: [{ type: 'text', value: 'and this is my statement' }] },
+          ],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'hi',
+            },
+          ],
+        },
+      ],
+    });
+    expect(frontmatter).toEqual({
+      title: 'Abstract and Statement part',
+    });
+  });
+});

--- a/packages/myst-cli/src/transforms/parts.spec.ts
+++ b/packages/myst-cli/src/transforms/parts.spec.ts
@@ -48,14 +48,16 @@ describe('frontmatterPartsTransform', () => {
       children: [
         {
           type: 'block',
-          data: { part: 'abstract', hidden: true },
+          data: { part: 'abstract' },
+          visibility: 'remove',
           children: [
             { type: 'paragraph', children: [{ type: 'text', value: 'This is my abstract' }] },
           ],
         },
         {
           type: 'block',
-          data: { part: 'statement', hidden: true },
+          data: { part: 'statement' },
+          visibility: 'remove',
           children: [
             { type: 'paragraph', children: [{ type: 'text', value: 'and this is my statement' }] },
           ],

--- a/packages/myst-cli/src/transforms/parts.spec.ts
+++ b/packages/myst-cli/src/transforms/parts.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { visit } from 'unist-util-visit';
-import { GenericParent } from 'myst-common';
+import type { GenericParent } from 'myst-common';
 import { frontmatterPartsTransform } from './parts';
 import { Session } from '../session/session';
 
@@ -40,7 +40,10 @@ describe('frontmatterPartsTransform', () => {
     const mdast = testMdast();
     const frontmatter = {
       title: 'Abstract and Statement part',
-      parts: { abstract: 'This is my abstract', statement: 'and this is my statement' },
+      parts: {
+        abstract: ['This is my abstract'],
+        statement: ['and this is my statement', 'and a second statement'],
+      },
     };
     frontmatterPartsTransform(new Session(), 'test.md', mdast, frontmatter);
     expect(stripPositions(mdast)).toEqual({
@@ -60,6 +63,14 @@ describe('frontmatterPartsTransform', () => {
           visibility: 'remove',
           children: [
             { type: 'paragraph', children: [{ type: 'text', value: 'and this is my statement' }] },
+          ],
+        },
+        {
+          type: 'block',
+          data: { part: 'statement' },
+          visibility: 'remove',
+          children: [
+            { type: 'paragraph', children: [{ type: 'text', value: 'and a second statement' }] },
           ],
         },
         {

--- a/packages/myst-cli/src/transforms/parts.ts
+++ b/packages/myst-cli/src/transforms/parts.ts
@@ -12,11 +12,12 @@ export function frontmatterPartsTransform(
 ) {
   if (!frontmatter.parts) return;
   const partBlocks = Object.entries(frontmatter.parts).map(([part, content]) => {
-    const data = { part, hidden: true };
+    const data = { part };
     const root = parseMyst(session, content, file);
     return {
       type: 'block',
       data,
+      visibility: 'remove',
       children: root.children,
     } as Block;
   });

--- a/packages/myst-cli/src/transforms/parts.ts
+++ b/packages/myst-cli/src/transforms/parts.ts
@@ -11,16 +11,20 @@ export function frontmatterPartsTransform(
   frontmatter: PageFrontmatter,
 ) {
   if (!frontmatter.parts) return;
-  const partBlocks = Object.entries(frontmatter.parts).map(([part, content]) => {
-    const data = { part };
-    const root = parseMyst(session, content, file);
-    return {
-      type: 'block',
-      data,
-      visibility: 'remove',
-      children: root.children,
-    } as Block;
-  });
-  mdast.children = [...partBlocks, ...mdast.children];
+  const blocks = Object.entries(frontmatter.parts)
+    .map(([part, contents]) => {
+      const data = { part };
+      return contents.map((content) => {
+        const root = parseMyst(session, content, file);
+        return {
+          type: 'block',
+          data,
+          visibility: 'remove',
+          children: root.children,
+        } as Block;
+      });
+    })
+    .flat();
+  mdast.children = [...blocks, ...mdast.children];
   delete frontmatter.parts;
 }

--- a/packages/myst-cli/src/transforms/parts.ts
+++ b/packages/myst-cli/src/transforms/parts.ts
@@ -1,0 +1,25 @@
+import type { Block } from 'myst-spec-ext';
+import type { ISession } from '../index.js';
+import { parseMyst } from '../index.js';
+import type { GenericParent } from 'myst-common';
+import type { PageFrontmatter } from 'myst-frontmatter';
+
+export function frontmatterPartsTransform(
+  session: ISession,
+  file: string,
+  mdast: GenericParent,
+  frontmatter: PageFrontmatter,
+) {
+  if (!frontmatter.parts) return;
+  const partBlocks = Object.entries(frontmatter.parts).map(([part, content]) => {
+    const data = { part, hidden: true };
+    const root = parseMyst(session, content, file);
+    return {
+      type: 'block',
+      data,
+      children: root.children,
+    } as Block;
+  });
+  mdast.children = [...partBlocks, ...mdast.children];
+  delete frontmatter.parts;
+}

--- a/packages/myst-common/package.json
+++ b/packages/myst-common/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "mdast": "^3.0.0",
+    "myst-frontmatter": "^1.1.11",
     "myst-spec": "^0.0.4",
     "nanoid": "^4.0.0",
     "unified": "^10.1.2",

--- a/packages/myst-common/src/extractParts.spec.ts
+++ b/packages/myst-common/src/extractParts.spec.ts
@@ -7,6 +7,7 @@ describe('extractPart', () => {
     expect(
       extractPart(
         { type: 'root', children: [{ type: 'text', value: 'untagged content' }] },
+        { parts: { abstract: 'abstract part in frontmatter' } },
         'test_part',
       ),
     ).toEqual(undefined);
@@ -37,7 +38,7 @@ describe('extractPart', () => {
         },
       ],
     };
-    expect(extractPart(tree, 'test_part')).toEqual({
+    expect(extractPart(tree, {}, 'test_part')).toEqual({
       type: 'root',
       children: [
         {
@@ -86,6 +87,7 @@ describe('extractPart', () => {
             },
           ],
         },
+        {},
         'tagged_part',
       ),
     ).toEqual({
@@ -117,6 +119,7 @@ describe('extractPart', () => {
             },
           ],
         },
+        {},
         ['test_part', 'tagged_part'],
         { removePartData: false },
       ),
@@ -154,6 +157,7 @@ describe('extractPart', () => {
             },
           ],
         },
+        {},
         ['test_part', 'tagged_part'],
         { removePartData: true },
       ),
@@ -169,6 +173,79 @@ describe('extractPart', () => {
           type: 'block' as any,
           data: { tags: ['other_tag'] },
           children: [{ type: 'text', value: 'also tagged content' }],
+        },
+      ],
+    });
+  });
+  it('part returned from frontmatter', async () => {
+    const frontmatter = { parts: { test_part: 'frontmatter test part' } };
+    expect(extractPart({ type: 'root', children: [] }, frontmatter, 'test_part')).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          data: { part: 'test_part' },
+          children: [
+            { type: 'paragraph', children: [{ type: 'text', value: 'frontmatter test part' }] },
+          ],
+        },
+      ],
+    });
+    expect(frontmatter).toEqual({ parts: { test_part: 'frontmatter test part' } });
+  });
+  it('part combined from frontmatter and tree', async () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          data: { part: 'other_tag' },
+          children: [{ type: 'text', value: 'untagged content' }],
+        },
+        {
+          type: 'block' as any,
+          data: { part: 'test_part' },
+          children: [{ type: 'text', value: 'a first part' }],
+        },
+        {
+          type: 'block' as any,
+          data: { tags: ['other_tag', 'test_part'] },
+          children: [{ type: 'text', value: 'also tagged content' }],
+        },
+        {
+          type: 'block' as any,
+          data: { part: 'test_part' },
+          children: [{ type: 'text', value: 'a part' }],
+        },
+      ],
+    };
+    const frontmatter = {
+      parts: { test_part: 'frontmatter test part', other_tag: 'frontmatter other tag' },
+    };
+    expect(extractPart(tree, frontmatter, 'test_part')).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          data: { part: 'test_part' },
+          children: [
+            { type: 'paragraph', children: [{ type: 'text', value: 'frontmatter test part' }] },
+          ],
+        },
+        {
+          type: 'block' as any,
+          data: { part: 'test_part' },
+          children: [{ type: 'text', value: 'a first part' }],
+        },
+        {
+          type: 'block' as any,
+          data: { part: 'test_part', tags: ['other_tag'] },
+          children: [{ type: 'text', value: 'also tagged content' }],
+        },
+        {
+          type: 'block' as any,
+          data: { part: 'test_part' },
+          children: [{ type: 'text', value: 'a part' }],
         },
       ],
     });

--- a/packages/myst-common/src/extractParts.spec.ts
+++ b/packages/myst-common/src/extractParts.spec.ts
@@ -7,7 +7,6 @@ describe('extractPart', () => {
     expect(
       extractPart(
         { type: 'root', children: [{ type: 'text', value: 'untagged content' }] },
-        { parts: { abstract: 'abstract part in frontmatter' } },
         'test_part',
       ),
     ).toEqual(undefined);
@@ -38,7 +37,7 @@ describe('extractPart', () => {
         },
       ],
     };
-    expect(extractPart(tree, {}, 'test_part')).toEqual({
+    expect(extractPart(tree, 'test_part')).toEqual({
       type: 'root',
       children: [
         {
@@ -87,7 +86,6 @@ describe('extractPart', () => {
             },
           ],
         },
-        {},
         'tagged_part',
       ),
     ).toEqual({
@@ -119,7 +117,6 @@ describe('extractPart', () => {
             },
           ],
         },
-        {},
         ['test_part', 'tagged_part'],
         { removePartData: false },
       ),
@@ -157,7 +154,6 @@ describe('extractPart', () => {
             },
           ],
         },
-        {},
         ['test_part', 'tagged_part'],
         { removePartData: true },
       ),
@@ -173,79 +169,6 @@ describe('extractPart', () => {
           type: 'block' as any,
           data: { tags: ['other_tag'] },
           children: [{ type: 'text', value: 'also tagged content' }],
-        },
-      ],
-    });
-  });
-  it('part returned from frontmatter', async () => {
-    const frontmatter = { parts: { test_part: 'frontmatter test part' } };
-    expect(extractPart({ type: 'root', children: [] }, frontmatter, 'test_part')).toEqual({
-      type: 'root',
-      children: [
-        {
-          type: 'block' as any,
-          data: { part: 'test_part' },
-          children: [
-            { type: 'paragraph', children: [{ type: 'text', value: 'frontmatter test part' }] },
-          ],
-        },
-      ],
-    });
-    expect(frontmatter).toEqual({ parts: { test_part: 'frontmatter test part' } });
-  });
-  it('part combined from frontmatter and tree', async () => {
-    const tree: GenericParent = {
-      type: 'root',
-      children: [
-        {
-          type: 'block' as any,
-          data: { part: 'other_tag' },
-          children: [{ type: 'text', value: 'untagged content' }],
-        },
-        {
-          type: 'block' as any,
-          data: { part: 'test_part' },
-          children: [{ type: 'text', value: 'a first part' }],
-        },
-        {
-          type: 'block' as any,
-          data: { tags: ['other_tag', 'test_part'] },
-          children: [{ type: 'text', value: 'also tagged content' }],
-        },
-        {
-          type: 'block' as any,
-          data: { part: 'test_part' },
-          children: [{ type: 'text', value: 'a part' }],
-        },
-      ],
-    };
-    const frontmatter = {
-      parts: { test_part: 'frontmatter test part', other_tag: 'frontmatter other tag' },
-    };
-    expect(extractPart(tree, frontmatter, 'test_part')).toEqual({
-      type: 'root',
-      children: [
-        {
-          type: 'block' as any,
-          data: { part: 'test_part' },
-          children: [
-            { type: 'paragraph', children: [{ type: 'text', value: 'frontmatter test part' }] },
-          ],
-        },
-        {
-          type: 'block' as any,
-          data: { part: 'test_part' },
-          children: [{ type: 'text', value: 'a first part' }],
-        },
-        {
-          type: 'block' as any,
-          data: { part: 'test_part', tags: ['other_tag'] },
-          children: [{ type: 'text', value: 'also tagged content' }],
-        },
-        {
-          type: 'block' as any,
-          data: { part: 'test_part' },
-          children: [{ type: 'text', value: 'a part' }],
         },
       ],
     });

--- a/packages/myst-common/src/extractParts.ts
+++ b/packages/myst-common/src/extractParts.ts
@@ -1,4 +1,4 @@
-import type { Block } from 'myst-spec';
+import type { Block } from 'myst-spec-ext';
 import type { GenericParent } from './types.js';
 import { remove } from 'unist-util-remove';
 import { selectAll } from 'unist-util-select';
@@ -36,6 +36,8 @@ export function extractPart(
   opts?: {
     /** Helpful for when we are doing recursions, we don't want to extract the part again. */
     removePartData?: boolean;
+    /** Ensure that blocks are by default turned to visible */
+    keepVisibility?: boolean;
   },
 ): GenericParent | undefined {
   const partStrings = typeof part === 'string' ? [part] : part;
@@ -56,6 +58,8 @@ export function extractPart(
       }
     }
     if (opts?.removePartData) delete block.data.part;
+    // The default is to remove the visibility on the parts
+    if (!opts?.keepVisibility) delete block.visibility;
     return block;
   });
   const partsTree = { type: 'root', children } as GenericParent;

--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -61,7 +61,7 @@ type ManifestProject = {
 } & ProjectFrontmatter;
 
 export type SiteManifest = SiteFrontmatter & {
-  myst: 'v1';
+  myst: string;
   id?: string;
   projects?: ManifestProject[];
   nav?: SiteNavItem[];

--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -22,8 +22,6 @@ export interface SiteAction {
   static?: boolean;
 }
 
-export type SiteTemplateOptions = Record<string, any>;
-
 export type SiteConfig = SiteFrontmatter & {
   projects?: SiteProject[];
   nav?: SiteNavItem[];
@@ -31,7 +29,7 @@ export type SiteConfig = SiteFrontmatter & {
   domains?: string[];
   favicon?: string;
   template?: string;
-} & SiteTemplateOptions;
+};
 
 type ManifestProjectItem = {
   title: string;
@@ -69,4 +67,4 @@ export type SiteManifest = SiteFrontmatter & {
   domains?: string[];
   favicon?: string;
   template?: string;
-} & SiteTemplateOptions;
+};

--- a/packages/myst-frontmatter/src/page/page.yml
+++ b/packages/myst-frontmatter/src/page/page.yml
@@ -101,3 +101,67 @@ cases:
       date: https://example.com
     normalized: {}
     errors: 1
+  - title: parts validates arbitrary keys
+    raw:
+      parts:
+        example_part: |
+          Just an example part!
+    normalized:
+      parts:
+        example_part: |
+          Just an example part!
+  - title: parts validates known keys
+    raw:
+      parts:
+        abstract: |
+          Just an example part!
+    normalized:
+      parts:
+        abstract: |
+          Just an example part!
+  - title: known part moves to parts
+    raw:
+      abstract: |
+        Just an example part!
+    normalized:
+      parts:
+        abstract: |
+          Just an example part!
+  - title: known part combines with parts
+    raw:
+      abstract: |
+        Just an example part!
+      data_availability: Example
+      parts:
+        example_part: |
+          Another example part!
+    normalized:
+      parts:
+        abstract: |
+          Just an example part!
+        data_availability: Example
+        example_part: |
+          Another example part!
+  - title: duplicate part errors
+    raw:
+      abstract: |
+        Just an example part!
+      parts:
+        abstract: |
+          Another example part!
+    normalized:
+      parts:
+        abstract: |
+          Another example part!
+    errors: 1
+  - title: non-string abstract errors
+    raw:
+      abstract: true
+    normalized: {}
+    errors: 1
+  - title: non-string part errors
+    raw:
+      parts:
+        abstract: true
+    normalized: {}
+    errors: 1

--- a/packages/myst-frontmatter/src/page/page.yml
+++ b/packages/myst-frontmatter/src/page/page.yml
@@ -104,55 +104,67 @@ cases:
   - title: parts validates arbitrary keys
     raw:
       parts:
-        example_part: |
+        example_part: |-
           Just an example part!
     normalized:
       parts:
-        example_part: |
-          Just an example part!
+        example_part:
+          - Just an example part!
+  - title: parts validates list of strings
+    raw:
+      parts:
+        example_part:
+          - first example
+          - second example
+    normalized:
+      parts:
+        example_part:
+          - first example
+          - second example
   - title: parts validates known keys
     raw:
       parts:
-        abstract: |
+        abstract: |-
           Just an example part!
     normalized:
       parts:
-        abstract: |
-          Just an example part!
+        abstract:
+          - Just an example part!
   - title: known part moves to parts
     raw:
-      abstract: |
+      abstract: |-
         Just an example part!
     normalized:
       parts:
-        abstract: |
-          Just an example part!
+        abstract:
+          - Just an example part!
   - title: known part combines with parts
     raw:
-      abstract: |
+      abstract: |-
         Just an example part!
       data_availability: Example
       parts:
-        example_part: |
+        example_part: |-
           Another example part!
     normalized:
       parts:
-        abstract: |
-          Just an example part!
-        data_availability: Example
-        example_part: |
-          Another example part!
+        abstract:
+          - Just an example part!
+        data_availability:
+          - Example
+        example_part:
+          - Another example part!
   - title: duplicate part errors
     raw:
-      abstract: |
+      abstract: |-
         Just an example part!
       parts:
-        abstract: |
+        abstract: |-
           Another example part!
     normalized:
       parts:
-        abstract: |
-          Another example part!
+        abstract:
+          - Another example part!
     errors: 1
   - title: non-string abstract errors
     raw:

--- a/packages/myst-frontmatter/src/page/types.ts
+++ b/packages/myst-frontmatter/src/page/types.ts
@@ -6,4 +6,8 @@ export type PageFrontmatter = ProjectAndPageFrontmatter & {
   kernelspec?: KernelSpec;
   jupytext?: Jupytext;
   tags?: string[];
+  parts?: Record<string, string>;
+  // Known parts - these values are duplicated to 'parts' object on validation
+  abstract?: string;
+  data_availability?: string;
 };

--- a/packages/myst-frontmatter/src/page/types.ts
+++ b/packages/myst-frontmatter/src/page/types.ts
@@ -7,7 +7,4 @@ export type PageFrontmatter = ProjectAndPageFrontmatter & {
   jupytext?: Jupytext;
   tags?: string[];
   parts?: Record<string, string>;
-  // Known parts - these values are duplicated to 'parts' object on validation
-  abstract?: string;
-  data_availability?: string;
 };

--- a/packages/myst-frontmatter/src/page/types.ts
+++ b/packages/myst-frontmatter/src/page/types.ts
@@ -6,5 +6,5 @@ export type PageFrontmatter = ProjectAndPageFrontmatter & {
   kernelspec?: KernelSpec;
   jupytext?: Jupytext;
   tags?: string[];
-  parts?: Record<string, string>;
+  parts?: Record<string, string[]>;
 };

--- a/packages/myst-frontmatter/src/page/validators.ts
+++ b/packages/myst-frontmatter/src/page/validators.ts
@@ -91,9 +91,14 @@ export function validatePageFrontmatterKeys(value: Record<string, any>, opts: Va
   if (parts) {
     const partsEntries = Object.entries(parts)
       .map(([k, v]) => {
-        return [k, validateString(v, incrementOptions(k, partsOptions))];
+        return [
+          k,
+          validateList(v, { coerce: true, ...incrementOptions(k, partsOptions) }, (item, index) => {
+            return validateString(item, incrementOptions(`${k}.${index}`, partsOptions));
+          }),
+        ];
       })
-      .filter((entry): entry is [string, string] => entry[1] != null);
+      .filter((entry): entry is [string, string[]] => !!entry[1]?.length);
     if (partsEntries.length > 0) {
       output.parts = Object.fromEntries(partsEntries);
     }

--- a/packages/myst-frontmatter/src/page/validators.ts
+++ b/packages/myst-frontmatter/src/page/validators.ts
@@ -5,6 +5,8 @@ import {
   validateList,
   validateObjectKeys,
   validateString,
+  validateObject,
+  validationError,
 } from 'simple-validators';
 import {
   PROJECT_AND_PAGE_FRONTMATTER_KEYS,
@@ -15,12 +17,16 @@ import { FRONTMATTER_ALIASES } from '../index.js';
 import { validateKernelSpec } from '../kernelspec/validators.js';
 import { validateJupytext } from '../jupytext/validators.js';
 
+const KNOWN_PARTS = ['abstract', 'data_availability'];
+
 export const PAGE_FRONTMATTER_KEYS = [
   ...PROJECT_AND_PAGE_FRONTMATTER_KEYS,
   // These keys only exist on the page
   'kernelspec',
   'jupytext',
   'tags',
+  'parts',
+  ...KNOWN_PARTS,
 ];
 
 export const USE_PROJECT_FALLBACK = [
@@ -58,6 +64,31 @@ export function validatePageFrontmatterKeys(value: Record<string, any>, opts: Va
         return validateString(file, incrementOptions(`tags.${index}`, opts));
       },
     );
+  }
+  const partsOptions = incrementOptions('parts', opts);
+  let parts: Record<string, any> | undefined;
+  if (defined(value.parts)) {
+    parts = validateObject(value.parts, partsOptions);
+  }
+  KNOWN_PARTS.forEach((partKey) => {
+    if (defined(value[partKey])) {
+      parts ??= {};
+      if (parts[partKey]) {
+        validationError(`duplicate value for part ${partKey}`, partsOptions);
+      } else {
+        parts[partKey] = value[partKey];
+      }
+    }
+  });
+  if (parts) {
+    const partsEntries = Object.entries(parts)
+      .map(([k, v]) => {
+        return [k, validateString(v, incrementOptions(k, partsOptions))];
+      })
+      .filter((entry): entry is [string, string] => entry[1] != null);
+    if (partsEntries.length > 0) {
+      output.parts = Object.fromEntries(partsEntries);
+    }
   }
   return output;
 }

--- a/packages/myst-frontmatter/src/page/validators.ts
+++ b/packages/myst-frontmatter/src/page/validators.ts
@@ -17,7 +17,15 @@ import { FRONTMATTER_ALIASES } from '../index.js';
 import { validateKernelSpec } from '../kernelspec/validators.js';
 import { validateJupytext } from '../jupytext/validators.js';
 
-const KNOWN_PARTS = ['abstract', 'data_availability'];
+const KNOWN_PARTS = [
+  'abstract',
+  'summary',
+  'keypoints',
+  'dedication',
+  'epigraph',
+  'data_availability',
+  'acknowledgments',
+];
 
 export const PAGE_FRONTMATTER_KEYS = [
   ...PROJECT_AND_PAGE_FRONTMATTER_KEYS,

--- a/packages/myst-frontmatter/src/site/options.yml
+++ b/packages/myst-frontmatter/src/site/options.yml
@@ -1,0 +1,29 @@
+title: Options
+cases:
+  - title: arbitrary options validate
+    raw:
+      options:
+        a: b
+        c: d
+    normalized:
+      options:
+        a: b
+        c: d
+  - title: non-string options validate
+    raw:
+      options:
+        a: 1
+        b: true
+        c:
+          - x: y
+    normalized:
+      options:
+        a: 1
+        b: true
+        c:
+          - x: y
+  - title: non-object options errors
+    raw:
+      options: ''
+    normalized: {}
+    errors: 1

--- a/packages/myst-frontmatter/src/site/options.yml
+++ b/packages/myst-frontmatter/src/site/options.yml
@@ -27,3 +27,19 @@ cases:
       options: ''
     normalized: {}
     errors: 1
+  - title: reserved export keys error
+    raw:
+      options:
+        a: b
+        format: ''
+        template: ''
+        output: ''
+        id: ''
+        name: ''
+        renderer: ''
+        article: ''
+        sub_articles: ''
+    normalized:
+      options:
+        a: b
+    errors: 8

--- a/packages/myst-frontmatter/src/site/types.ts
+++ b/packages/myst-frontmatter/src/site/types.ts
@@ -19,4 +19,5 @@ export type SiteFrontmatter = {
   keywords?: string[];
   funding?: Funding[];
   contributors?: Contributor[];
+  options?: Record<string, any>;
 };

--- a/packages/myst-frontmatter/src/site/validators.ts
+++ b/packages/myst-frontmatter/src/site/validators.ts
@@ -43,6 +43,12 @@ export const FRONTMATTER_ALIASES = {
   export: 'exports',
   jupyter: 'thebe',
   part: 'parts',
+  ack: 'acknowledgments',
+  acknowledgements: 'acknowledgments',
+  availability: 'data_availability',
+  plain_language_summary: 'summary',
+  quote: 'epigraph',
+  lay_summary: 'summary',
 };
 
 export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: ValidationOptions) {

--- a/packages/myst-frontmatter/src/site/validators.ts
+++ b/packages/myst-frontmatter/src/site/validators.ts
@@ -49,6 +49,7 @@ export const FRONTMATTER_ALIASES = {
   plain_language_summary: 'summary',
   quote: 'epigraph',
   lay_summary: 'summary',
+  image: 'thumbnail',
 };
 
 export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: ValidationOptions) {

--- a/packages/myst-frontmatter/src/site/validators.ts
+++ b/packages/myst-frontmatter/src/site/validators.ts
@@ -42,6 +42,7 @@ export const FRONTMATTER_ALIASES = {
   affiliation: 'affiliations',
   export: 'exports',
   jupyter: 'thebe',
+  part: 'parts',
 };
 
 export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: ValidationOptions) {

--- a/packages/myst-frontmatter/src/site/validators.ts
+++ b/packages/myst-frontmatter/src/site/validators.ts
@@ -1,5 +1,11 @@
 import type { ValidationOptions } from 'simple-validators';
-import { defined, incrementOptions, validateList, validateString } from 'simple-validators';
+import {
+  defined,
+  incrementOptions,
+  validateList,
+  validateObject,
+  validateString,
+} from 'simple-validators';
 import { validateAffiliation } from '../affiliations/validators.js';
 import { validateContributor } from '../contributors/validators.js';
 import { validateFunding } from '../funding/validators.js';
@@ -25,6 +31,7 @@ export const SITE_FRONTMATTER_KEYS = [
   'keywords',
   'affiliations',
   'funding',
+  'options',
 ];
 
 export const FRONTMATTER_ALIASES = {
@@ -126,15 +133,19 @@ export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: Va
     });
   }
   if (defined(value.funding)) {
-    const funding = Array.isArray(value.funding) ? value.funding : [value.funding];
     output.funding = validateList(
-      funding,
+      value.funding,
       { coerce: true, ...incrementOptions('funding', opts) },
       (fund, index) => {
         return validateFunding(fund, stash, incrementOptions(`funding.${index}`, opts));
       },
     );
   }
+  if (defined(value.options)) {
+    output.options = validateObject(value.options, incrementOptions('options', opts));
+  }
+
+  // Contributor resolution should happen last
   const stashContribAuthors = stash.contributors?.filter(
     (contrib) => stash.authorIds?.includes(contrib.id),
   );

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.spec.ts
@@ -531,4 +531,20 @@ describe('fillPageFrontmatter', () => {
     });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
+  it('project options fill page', async () => {
+    expect(fillPageFrontmatter({}, { options: { a: 'b' } }, opts)).toEqual({ options: { a: 'b' } });
+  });
+  it('page options persist', async () => {
+    expect(fillPageFrontmatter({ options: { a: 'b' } }, {}, opts)).toEqual({ options: { a: 'b' } });
+  });
+  it('project and page options combine', async () => {
+    expect(fillPageFrontmatter({ options: { a: 'b' } }, { options: { c: 'd' } }, opts)).toEqual({
+      options: { a: 'b', c: 'd' },
+    });
+  });
+  it('page options override project options', async () => {
+    expect(fillPageFrontmatter({ options: { a: 'b' } }, { options: { a: 'z' } }, opts)).toEqual({
+      options: { a: 'b' },
+    });
+  });
 });

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
@@ -48,6 +48,14 @@ export function fillPageFrontmatter(
     };
   }
 
+  // Combine all options defined on page and project
+  if (projectFrontmatter.options || pageFrontmatter.options) {
+    frontmatter.options = {
+      ...(projectFrontmatter.options ?? {}),
+      ...(pageFrontmatter.options ?? {}),
+    };
+  }
+
   // Gather all contributors and affiliations from funding sources
   const contributorIds: Set<string> = new Set();
   const affiliationIds: Set<string> = new Set();

--- a/packages/myst-templates/src/template.ts
+++ b/packages/myst-templates/src/template.ts
@@ -6,7 +6,7 @@ import type { ValidationOptions } from 'simple-validators';
 import { downloadTemplate, resolveInputs, TEMPLATE_FILENAME, TEMPLATE_YML } from './download.js';
 import { extendFrontmatter } from './frontmatter.js';
 import type { TemplateYml, ISession } from './types.js';
-import { errorLogger, warningLogger } from './utils.js';
+import { debugLogger, errorLogger, warningLogger } from './utils.js';
 import type { FileOptions, FileValidationOptions } from './validators.js';
 import {
   validateTemplateDoc,
@@ -22,6 +22,7 @@ class MystTemplate {
   validatedTemplateYml: TemplateYml | undefined;
   errorLogFn: (message: string) => void;
   warningLogFn: (message: string) => void;
+  debugLogFn: (message: string) => void;
 
   /**
    * MystTemplate class for template download / validation / render preparation
@@ -39,6 +40,7 @@ class MystTemplate {
       buildDir?: string;
       errorLogFn?: (message: string) => void;
       warningLogFn?: (message: string) => void;
+      debugLogFn?: (message: string) => void;
     },
   ) {
     this.session = session;
@@ -47,6 +49,7 @@ class MystTemplate {
     this.templateUrl = templateUrl;
     this.errorLogFn = opts?.errorLogFn ?? errorLogger(this.session);
     this.warningLogFn = opts?.warningLogFn ?? warningLogger(this.session);
+    this.debugLogFn = opts?.debugLogFn ?? debugLogger(this.session);
   }
 
   getTemplateYmlPath() {
@@ -91,7 +94,8 @@ class MystTemplate {
       property: 'options',
       messages: {},
       errorLogFn: this.errorLogFn,
-      warningLogFn: this.warningLogFn,
+      // Warnings about extra options are just debug messages
+      warningLogFn: this.debugLogFn,
       ...fileOpts,
     };
     const validatedOptions = validateTemplateOptions(

--- a/packages/myst-templates/src/types.ts
+++ b/packages/myst-templates/src/types.ts
@@ -49,6 +49,9 @@ export type TemplatePartDefinition = {
   description?: string;
   required?: boolean;
   plain?: boolean;
+  /** Expect parts as a list of entries instead of a single concatenated entry */
+  as_list?: boolean;
+  /** If as_list is true, max_chars/max_words will apply to each entry of the list */
   max_chars?: number;
   max_words?: number;
   condition?: {

--- a/packages/myst-templates/src/utils.ts
+++ b/packages/myst-templates/src/utils.ts
@@ -7,3 +7,7 @@ export function errorLogger(session: ISession) {
 export function warningLogger(session: ISession) {
   return (message: string) => session.log.warn(message);
 }
+
+export function debugLogger(session: ISession) {
+  return (message: string) => session.log.debug(message);
+}

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -30,7 +30,6 @@ export type Options = {
   extractAbstract?: boolean;
   abstractParts?: JatsPart[];
   backSections?: JatsPart[];
-  mystParseFn?: (content: string) => GenericParent;
 };
 
 export type DocumentOptions = Options &

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -1,4 +1,4 @@
-import type { GenericNode, GenericParent, MessageInfo } from 'myst-common';
+import type { GenericNode, MessageInfo } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import type { Root } from 'myst-spec';
 import type { SourceFileKind } from 'myst-spec-ext';

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -1,4 +1,4 @@
-import type { GenericNode, MessageInfo } from 'myst-common';
+import type { GenericNode, GenericParent, MessageInfo } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import type { Root } from 'myst-spec';
 import type { SourceFileKind } from 'myst-spec-ext';
@@ -30,6 +30,7 @@ export type Options = {
   extractAbstract?: boolean;
   abstractParts?: JatsPart[];
   backSections?: JatsPart[];
+  mystParseFn?: (content: string) => GenericParent;
 };
 
 export type DocumentOptions = Options &

--- a/packages/mystmd/tests/basic-md-and-config/myst.yml
+++ b/packages/mystmd/tests/basic-md-and-config/myst.yml
@@ -1,16 +1,11 @@
 # See docs at: https://mystmd.org/guide/frontmatter
 version: 1
 project:
-  # title:
-  # description:
   keywords: []
   authors: []
   github: https://github.com/executablebooks/mystmd
-  # bibliography: []
 site:
   template: book-theme
-  # title:
-  # logo:
   nav: []
   actions:
     - title: Learn More


### PR DESCRIPTION
- __options__ are template options for site config or page/project frontmatter; this (1) allows options to be provided in a centralized place, rather than on each export, and (2) gives an explicit place for these arbitrary options to be found
  - [x] TODO: tidy up warning messages for unused options, now that options may apply to different exports, so they may be unused on one place but used in another.
- __parts__ are document parts, previously only defined with block metadata `part: 'abstract'`, now you can put the abstract directly in the frontmatter. It is then inserted into the document as a hidden block, and transformed with the rest of the content.
  - [x] TODO: audit exports to make sure ~`hidden: true`~ `visibility: 'remove'` is respected on blocks - This is the case for exports defined in mystmd.
  - [x] For site builds, I added this pr: https://github.com/executablebooks/myst-theme/pull/259