### PR TITLE
🐛 Turn off glossaries for rawTex output

### DIFF
--- a/.changeset/silly-parents-listen.md
+++ b/.changeset/silly-parents-listen.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Turn off glossaries for raw tex output

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -98,7 +98,7 @@ export async function localArticleToTexRaw(
     simplifyFigures: true,
   });
   const toc = tic();
-  const result = mdastToTex(session, mdast, references, frontmatter, null, true);
+  const result = mdastToTex(session, mdast, references, frontmatter, null, false);
   session.log.info(toc(`📑 Exported TeX in %s, copying to ${output}`));
   // TODO: add imports and macros?
   writeFileToFolder(output, result.value);


### PR DESCRIPTION
I have been working through exporting a book in latex and do not want each page to have the glossaries output. This turns it off when there is no template.