### PR TITLE
🧱 Transform notebook blocks with captions to figures in place

### DIFF
--- a/.changeset/bright-houses-learn.md
+++ b/.changeset/bright-houses-learn.md
@@ -1,0 +1,6 @@
+---
+'myst-transforms': patch
+'myst-cli': patch
+---
+
+Pass options to basicTransforms, including myst parser for caption parsing

--- a/.changeset/dull-cooks-complain.md
+++ b/.changeset/dull-cooks-complain.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Tidy up figures referencing other figures

--- a/.changeset/light-tools-guess.md
+++ b/.changeset/light-tools-guess.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Transform blocks with captions to figures

--- a/.changeset/moody-forks-trade.md
+++ b/.changeset/moody-forks-trade.md
@@ -1,0 +1,5 @@
+---
+'myst-common': patch
+---
+
+Refactor (and test) liftChildren util

--- a/package-lock.json
+++ b/package-lock.json
@@ -13757,7 +13757,6 @@
         "myst-spec": "^0.0.4",
         "nanoid": "^4.0.0",
         "unified": "^10.1.2",
-        "unist-util-map": "^3.0.0",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.0.0",

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -71,6 +71,7 @@ import { combineCitationRenderers } from './citations.js';
 import { bibFilesInDir, selectFile } from './file.js';
 import { loadIntersphinx } from './intersphinx.js';
 import { frontmatterPartsTransform } from '../transforms/parts.js';
+import { parseMyst } from './myst.js';
 
 const LINKS_SELECTOR = 'link,card,linkBlock';
 
@@ -172,7 +173,9 @@ export async function transformMdast(
   const pipe = unified()
     .use(reconstructHtmlPlugin) // We need to group and link the HTML first
     .use(htmlPlugin, { htmlHandlers }) // Some of the HTML plugins need to operate on the transformed html, e.g. figure caption transforms
-    .use(basicTransformationsPlugin)
+    .use(basicTransformationsPlugin, {
+      parser: (content: string) => parseMyst(session, content, file),
+    })
     .use(inlineExpressionsPlugin) // Happens before math and images!
     .use(mathPlugin, { macros: frontmatter.math })
     .use(glossaryPlugin, { state }) // This should be before the enumerate plugins

--- a/packages/myst-cli/src/transforms/embed.ts
+++ b/packages/myst-cli/src/transforms/embed.ts
@@ -1,4 +1,5 @@
 import { filter } from 'unist-util-filter';
+import { remove } from 'unist-util-remove';
 import { selectAll } from 'unist-util-select';
 import type { IReferenceState, MultiPageReferenceState } from 'myst-transforms';
 import type { GenericNode, GenericParent } from 'myst-common';
@@ -70,6 +71,15 @@ export function embedTransform(
     if (containerEmbeds?.length === 1) {
       node.source = { ...containerEmbeds[0].source };
       containerEmbeds[0].type = '_lift';
+      // If the embedded content is _another_ figure, just lift out the children except caption/legend
+      if (
+        containerEmbeds[0].children?.length === 1 &&
+        containerEmbeds[0].children[0].type === 'container'
+      ) {
+        containerEmbeds[0].children[0].type = '_lift';
+        remove(containerEmbeds[0].children[0], 'caption');
+        remove(containerEmbeds[0].children[0], 'legend');
+      }
     }
   });
   liftChildren(mdast, '_lift');

--- a/packages/myst-cli/src/transforms/embed.ts
+++ b/packages/myst-cli/src/transforms/embed.ts
@@ -71,15 +71,25 @@ export function embedTransform(
     if (containerEmbeds?.length === 1) {
       node.source = { ...containerEmbeds[0].source };
       containerEmbeds[0].type = '_lift';
-      // If the embedded content is _another_ figure, just lift out the children except caption/legend
+      // If the figure's embedded content is _another_ figure, just lift out the children except caption/legend
       if (
         containerEmbeds[0].children?.length === 1 &&
         containerEmbeds[0].children[0].type === 'container'
       ) {
         containerEmbeds[0].children[0].type = '_lift';
+        // It would be nice to keep these if there is not another caption defined on 'node' but that leads to
+        // issues with the current figure enumeration resolution, since embedding happens after referencing...
         remove(containerEmbeds[0].children[0], 'caption');
         remove(containerEmbeds[0].children[0], 'legend');
       }
+    }
+  });
+  // If embed node contains a single figure, copy the source info to the figure
+  const remainingEmbedNodes = selectAll('embed', mdast) as Embed[];
+  remainingEmbedNodes.forEach((node: Embed) => {
+    if (node.children?.length === 1 && node.children[0].type === 'container') {
+      (node.children[0] as any).source = { ...node.source };
+      (node as any).type = '_lift';
     }
   });
   liftChildren(mdast, '_lift');

--- a/packages/myst-common/package.json
+++ b/packages/myst-common/package.json
@@ -24,7 +24,6 @@
     "myst-spec": "^0.0.4",
     "nanoid": "^4.0.0",
     "unified": "^10.1.2",
-    "unist-util-map": "^3.0.0",
     "unist-util-remove": "^3.1.0",
     "unist-util-select": "^4.0.3",
     "vfile": "^5.0.0",

--- a/packages/myst-common/src/utils.spec.ts
+++ b/packages/myst-common/src/utils.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest';
 import { u } from 'unist-builder';
-import { mergeTextNodes, toText } from './utils';
+import { liftChildren, mergeTextNodes, toText } from './utils';
 
-describe('Test math trasformations', () => {
+describe('Test text utils', () => {
   test('toText', () => {
     const para = u('paragraph', [u('text', { value: 'hello ' }), u('strong', { value: 'there' })]);
     expect(toText(para)).toBe('hello there');
@@ -21,5 +21,48 @@ describe('Test math trasformations', () => {
     expect(x.children?.[0].value).toBe('hihum');
     expect(x.children?.[0].position?.end).toBe('yes'); // Obviously a real position, but you get the idea
     expect(x.children?.[2].value).toBe('xy');
+  });
+});
+
+describe('Test liftChildren', () => {
+  test('liftChildren does not modify tree', () => {
+    const before = u('root', [u('block', [u('paragraph', [u('text', 'value')])])]);
+    const after = u('root', [u('block', [u('paragraph', [u('text', 'value')])])]);
+    liftChildren(before, '_lift');
+    expect(before).toEqual(after);
+  });
+  test('liftChildren lifts one child', () => {
+    const before = u('root', [u('block', [u('paragraph', [u('text', 'value')])])]);
+    const after = u('root', [u('block', [u('text', 'value')])]);
+    liftChildren(before, 'paragraph');
+    expect(before).toEqual(after);
+  });
+  test('liftChildren lifts adjacent node children', () => {
+    const before = u('root', [
+      u('block', [u('paragraph', [u('text', 'one')]), u('paragraph', [u('text', 'two')])]),
+    ]);
+    const after = u('root', [u('block', [u('text', 'one'), u('text', 'two')])]);
+    liftChildren(before, 'paragraph');
+    expect(before).toEqual(after);
+  });
+  test('liftChildren lifts nested node children', () => {
+    const before = u('root', [
+      u('block', [u('paragraph', [u('paragraph', [u('paragraph', [u('text', 'value')])])])]),
+    ]);
+    const after = u('root', [u('block', [u('text', 'value')])]);
+    liftChildren(before, 'paragraph');
+    expect(before).toEqual(after);
+  });
+  test('liftChildren does not lift root', () => {
+    const before = u('root', [u('block', [u('paragraph', [u('text', 'value')])])]);
+    const after = u('root', [u('block', [u('paragraph', [u('text', 'value')])])]);
+    liftChildren(before, 'root');
+    expect(before).toEqual(after);
+  });
+  test('liftChildren does not lift leaf', () => {
+    const before = u('root', [u('block', [u('paragraph', [u('text', 'value')])])]);
+    const after = u('root', [u('block', [u('paragraph', [u('text', 'value')])])]);
+    liftChildren(before, 'text');
+    expect(before).toEqual(after);
   });
 });

--- a/packages/myst-transforms/src/basic.ts
+++ b/packages/myst-transforms/src/basic.ts
@@ -13,7 +13,7 @@ import { codeBlockToDirectiveTransform } from './code.js';
 import type { GenericParent } from 'myst-common';
 import { removeUnicodeTransform } from './removeUnicode.js';
 
-export function basicTransformations(tree: GenericParent, file: VFile) {
+export function basicTransformations(tree: GenericParent, file: VFile, opts: Record<string, any>) {
   // lifting roles and directives must happen before the mystTarget transformation
   liftMystDirectivesAndRolesTransform(tree);
   // Some specifics about the ordering are noted below
@@ -32,14 +32,17 @@ export function basicTransformations(tree: GenericParent, file: VFile) {
   blockNestingTransform(tree);
   // Block metadata may contain labels/html_ids
   blockMetadataTransform(tree, file);
-  blockToFigureTransform(tree);
+  blockToFigureTransform(tree, opts);
   htmlIdsTransform(tree);
   imageAltTextTransform(tree);
   blockquoteTransform(tree);
   removeUnicodeTransform(tree);
 }
 
-export const basicTransformationsPlugin: Plugin<[], GenericParent, GenericParent> =
-  () => (tree, file) => {
-    basicTransformations(tree, file);
-  };
+export const basicTransformationsPlugin: Plugin<
+  [Record<string, any>],
+  GenericParent,
+  GenericParent
+> = (opts) => (tree, file) => {
+  basicTransformations(tree, file, opts);
+};

--- a/packages/myst-transforms/src/basic.ts
+++ b/packages/myst-transforms/src/basic.ts
@@ -4,7 +4,7 @@ import { liftMystDirectivesAndRolesTransform } from './liftMystDirectivesAndRole
 import { mystTargetsTransform, headingLabelTransform } from './targets.js';
 import { captionParagraphTransform } from './caption.js';
 import { admonitionBlockquoteTransform, admonitionHeadersTransform } from './admonitions.js';
-import { blockMetadataTransform, blockNestingTransform } from './blocks.js';
+import { blockMetadataTransform, blockNestingTransform, blockToFigureTransform } from './blocks.js';
 import { htmlIdsTransform } from './htmlIds.js';
 import { imageAltTextTransform } from './images.js';
 import { mathLabelTransform, mathNestingTransform, subequationTransform } from './math.js';
@@ -32,6 +32,7 @@ export function basicTransformations(tree: GenericParent, file: VFile) {
   blockNestingTransform(tree);
   // Block metadata may contain labels/html_ids
   blockMetadataTransform(tree, file);
+  blockToFigureTransform(tree);
   htmlIdsTransform(tree);
   imageAltTextTransform(tree);
   blockquoteTransform(tree);

--- a/packages/myst-transforms/src/blocks.spec.ts
+++ b/packages/myst-transforms/src/blocks.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { u } from 'unist-builder';
 import { VFile } from 'vfile';
-import { blockMetadataTransform, blockNestingTransform } from './blocks';
+import { blockMetadataTransform, blockNestingTransform, blockToFigureTransform } from './blocks';
 
 describe('Test blockMetadataTransform', () => {
   test.each([
@@ -138,6 +138,73 @@ describe('Test blockMetadataTransform', () => {
           [
             u('output', { identifier: 'my_label-output-0' }, 'We know what we are'),
             u('output', { identifier: 'my_label-output-1' }, 'but know not what we may be.'),
+          ],
+        ),
+      ]),
+    );
+  });
+});
+
+describe('Test blockToFigureTransform', () => {
+  test('block metadata is propagated to new figure', async () => {
+    const mdast = u('root', [
+      u(
+        'block',
+        {
+          label: 'my-label',
+          identifier: 'my-label',
+          data: { caption: 'My caption', metadata: '' },
+          attribute: '',
+        },
+        [u('paragraph', [u('text', 'value')])],
+      ),
+    ]) as any;
+    blockToFigureTransform(mdast);
+    expect(mdast).toEqual(
+      u('root', [
+        u(
+          'block',
+          {
+            data: { metadata: '' },
+            attribute: '',
+          },
+          [
+            u('container', { kind: 'figure', label: 'my-label', identifier: 'my-label' }, [
+              u('paragraph', [u('text', 'value')]),
+              u('caption', [u('paragraph', [u('text', 'My caption')])]),
+            ]),
+          ],
+        ),
+      ]),
+    );
+  });
+  test('fig-cap coerces to caption for block-to-figure', async () => {
+    const mdast = u('root', [
+      u(
+        'block',
+        {
+          label: 'my-label',
+          identifier: 'my-label',
+          data: { 'fig-cap': 'My caption', metadata: '' },
+          attribute: '',
+        },
+        [u('paragraph', [u('text', 'value')])],
+      ),
+    ]) as any;
+    blockToFigureTransform(mdast);
+    expect(mdast).toEqual(
+      u('root', [
+        u(
+          'block',
+          {
+            data: { metadata: '' },
+            attribute: '',
+          },
+          [
+            u('container', { kind: 'figure', label: 'my-label', identifier: 'my-label' }, [
+              u('paragraph', [u('text', 'value')]),
+              u('caption', [u('paragraph', [u('text', 'My caption')])]),
+            ]),
           ],
         ),
       ]),

--- a/packages/myst-transforms/src/blocks.spec.ts
+++ b/packages/myst-transforms/src/blocks.spec.ts
@@ -210,4 +210,68 @@ describe('Test blockToFigureTransform', () => {
       ]),
     );
   });
+  test('tbl-cap coerces to caption for block-to-figure', async () => {
+    const mdast = u('root', [
+      u(
+        'block',
+        {
+          label: 'my-label',
+          identifier: 'my-label',
+          data: { 'tbl-cap': 'My caption', metadata: '' },
+          attribute: '',
+        },
+        [u('paragraph', [u('text', 'value')])],
+      ),
+    ]) as any;
+    blockToFigureTransform(mdast);
+    expect(mdast).toEqual(
+      u('root', [
+        u(
+          'block',
+          {
+            data: { metadata: '' },
+            attribute: '',
+          },
+          [
+            u('container', { kind: 'table', label: 'my-label', identifier: 'my-label' }, [
+              u('paragraph', [u('text', 'value')]),
+              u('caption', [u('paragraph', [u('text', 'My caption')])]),
+            ]),
+          ],
+        ),
+      ]),
+    );
+  });
+  test('block kind is applied to figure block-to-figure', async () => {
+    const mdast = u('root', [
+      u(
+        'block',
+        {
+          label: 'my-label',
+          identifier: 'my-label',
+          data: { 'fig-cap': 'My caption', metadata: '', kind: 'table' },
+          attribute: '',
+        },
+        [u('paragraph', [u('text', 'value')])],
+      ),
+    ]) as any;
+    blockToFigureTransform(mdast);
+    expect(mdast).toEqual(
+      u('root', [
+        u(
+          'block',
+          {
+            data: { metadata: '' },
+            attribute: '',
+          },
+          [
+            u('container', { kind: 'table', label: 'my-label', identifier: 'my-label' }, [
+              u('paragraph', [u('text', 'value')]),
+              u('caption', [u('paragraph', [u('text', 'My caption')])]),
+            ]),
+          ],
+        ),
+      ]),
+    );
+  });
 });

--- a/packages/myst-transforms/src/blocks.spec.ts
+++ b/packages/myst-transforms/src/blocks.spec.ts
@@ -234,8 +234,8 @@ describe('Test blockToFigureTransform', () => {
           },
           [
             u('container', { kind: 'table', label: 'my-label', identifier: 'my-label' }, [
-              u('paragraph', [u('text', 'value')]),
               u('caption', [u('paragraph', [u('text', 'My caption')])]),
+              u('paragraph', [u('text', 'value')]),
             ]),
           ],
         ),
@@ -266,8 +266,8 @@ describe('Test blockToFigureTransform', () => {
           },
           [
             u('container', { kind: 'table', label: 'my-label', identifier: 'my-label' }, [
-              u('paragraph', [u('text', 'value')]),
               u('caption', [u('paragraph', [u('text', 'My caption')])]),
+              u('paragraph', [u('text', 'value')]),
             ]),
           ],
         ),

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -107,12 +107,13 @@ const defaultCaptionParser = (caption: string): GenericNode => {
 export function blockToFigureTransform(mdast: GenericParent, captionParser = defaultCaptionParser) {
   const blocks = selectAll('block', mdast) as any[];
   blocks.forEach((block) => {
-    const caption = block.data?.caption ?? block.data?.['fig-cap'];
+    const caption = block.data?.caption ?? block.data?.['fig-cap'] ?? block.data?.['tbl-cap'];
     if (caption) {
+      const kind = block.data?.kind ?? (block.data?.['tbl-cap'] ? 'table' : 'figure');
       block.children = [
         {
           type: 'container',
-          kind: 'figure',
+          kind,
           label: block.label,
           identifier: block.identifier,
           children: [...block.children, captionParser(caption)],
@@ -120,6 +121,8 @@ export function blockToFigureTransform(mdast: GenericParent, captionParser = def
       ];
       delete block.data.caption;
       delete block.data['fig-cap'];
+      delete block.data['tbl-cap'];
+      delete block.data.kind;
       delete block.label;
       delete block.identifier;
     }

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -106,9 +106,10 @@ const defaultParser = (caption: string): GenericParent => {
  */
 export function blockToFigureTransform(
   mdast: GenericParent,
-  { parser = defaultParser }: { parser?: (caption: string) => GenericNode },
+  opts?: { parser?: (caption: string) => GenericNode },
 ) {
   const blocks = selectAll('block', mdast) as any[];
+  const parser = opts?.parser ?? defaultParser;
   blocks.forEach((block) => {
     const caption = block.data?.caption ?? block.data?.['fig-cap'] ?? block.data?.['tbl-cap'];
     if (caption) {

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -114,14 +114,21 @@ export function blockToFigureTransform(
     const caption = block.data?.caption ?? block.data?.['fig-cap'] ?? block.data?.['tbl-cap'];
     if (caption) {
       const kind = block.data?.kind ?? (block.data?.['tbl-cap'] ? 'table' : 'figure');
-      const parsedCaption = parser(caption);
+      const children = [...block.children];
+      const { children: captionChildren } = parser(caption);
+      const parsedCaption = { type: 'caption', children: captionChildren };
+      if (kind === 'table') {
+        children.unshift(parsedCaption);
+      } else {
+        children.push(parsedCaption);
+      }
       block.children = [
         {
           type: 'container',
           kind,
           label: block.label,
           identifier: block.identifier,
-          children: [...block.children, { type: 'caption', children: parsedCaption.children }],
+          children,
         },
       ];
       delete block.data.caption;

--- a/packages/myst-transforms/src/images.ts
+++ b/packages/myst-transforms/src/images.ts
@@ -4,6 +4,9 @@ import { select, selectAll } from 'unist-util-select';
 import type { GenericParent } from 'myst-common';
 import { toText } from 'myst-common';
 
+/**
+ * Generate image alt text from figure caption
+ */
 export function imageAltTextTransform(tree: GenericParent) {
   const containers = selectAll('container', tree) as Container[];
   containers.forEach((container) => {
@@ -11,7 +14,7 @@ export function imageAltTextTransform(tree: GenericParent) {
     if (!image || image.alt) return;
     const para = select('caption > paragraph', container) as Paragraph;
     if (!para) return;
-    // Get rid of the captionNumber
+    // Do not write the captionNumber to image alt text
     const content = para.children?.filter((n) => (n.type as string) !== 'captionNumber');
     if (!content || content.length < 1) return;
     image.alt = toText(content as PhrasingContent[]);


### PR DESCRIPTION
This PR enables creating a figure directly inside a notebook by adding a caption to a cell:

```python
#| caption: My figure caption
...
plt.show()
```

This modifies the block structure from:

```
block > code/output
```
to
```
block > figure > code/output
```

This PR also cleans up figures referencing other figures (e.g. if you want to include a "notebook figure" created as described above in a separate markdown page). Referencing a figure from another figure removes the original caption / figure number. If you want to keep the original caption / figure number, you may `embed` the figure instead.

For full functionality with thebe, this requires https://github.com/executablebooks/myst-theme/pull/272

TODO:
- [x] Fix up embedding these figures to make sure they are computable
- [x] Allow kind to be table
- [x] Follow through caption parsing

There is still a little bit of wonkiness with resolving embedded content and figure references simultaneously, but those issues are mostly encountered in edge cases - I think for now this is good enough!