### PR TITLE
🐛 Stream outputs and `remove-stdout` on cells

### DIFF
--- a/.changeset/lazy-kangaroos-peel.md
+++ b/.changeset/lazy-kangaroos-peel.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Allow to individually hide stdout/stderr on a cell using a tag

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -77,7 +77,11 @@ export function transformFilterOutputStreams(
     // There should be only one output in the block
     outputs.forEach((output) => {
       output.data = output.data.filter((data: IStream | MinifiedMimeOutput) => {
-        if (stderr !== 'show' && data.output_type === 'stream' && data.name === 'stderr') {
+        if (
+          (stderr !== 'show' || blockRemoveStderr) &&
+          data.output_type === 'stream' &&
+          data.name === 'stderr'
+        ) {
           const doRemove = stderr.includes('remove') || blockRemoveStderr;
           const doWarn = stderr.includes('warn');
           const doError = stderr.includes('error');
@@ -93,7 +97,11 @@ export function transformFilterOutputStreams(
           }
           return !doRemove;
         }
-        if (stdout !== 'show' && data.output_type === 'stream' && data.name === 'stdout') {
+        if (
+          (stdout !== 'show' || blockRemoveStdout) &&
+          data.output_type === 'stream' &&
+          data.name === 'stdout'
+        ) {
           const doRemove = stdout.includes('remove') || blockRemoveStdout;
           const doWarn = stdout.includes('warn');
           const doError = stdout.includes('error');


### PR DESCRIPTION
Small bug that skipped the if statement too early. Need to also include tags.