### PR TITLE
🏷 Improvements to JATS tagging

### DIFF
--- a/.changeset/proud-guests-brake.md
+++ b/.changeset/proud-guests-brake.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Remove outputs that are hidden or removed in jats

--- a/.changeset/slow-geckos-love.md
+++ b/.changeset/slow-geckos-love.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Remove no-width-space in link text for jats output

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -440,7 +440,7 @@ const handlers: Handlers = {
   },
   break(node, state, parent) {
     if (parent.type === 'paragraph' || parent.type === 'listItem') {
-      state.warn(`There are no breaks allowed in ${node.type}s.`, node, 'break', {
+      state.warn(`There are no breaks allowed in ${parent.type}s.`, node, 'break', {
         url: 'https://jats.nlm.nih.gov/archiving/tag-library/1.3/element/break.html',
       });
       return;

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -87,7 +87,13 @@ import type { DefinitionItem } from './transforms/definitions.js';
 type TableCell = SpecTableCell & { colspan?: number; rowspan?: number; width?: number };
 
 function escapeForXML(text: string) {
-  return text.replace(/&(?!amp;)/g, '&amp;').replace(/</g, '&lt;');
+  return (
+    text
+      .replace(/&(?!amp;)/g, '&amp;')
+      .replace(/</g, '&lt;')
+      // eslint-disable-next-line no-irregular-whitespace
+      .replace(/​/g, '') // Replace no-width spaces, used in links
+  );
 }
 
 function referenceKindToRefType(kind?: string): RefType {

--- a/packages/myst-to-jats/src/transforms/blocks.ts
+++ b/packages/myst-to-jats/src/transforms/blocks.ts
@@ -1,0 +1,28 @@
+import type { Plugin } from 'unified';
+import type { Block } from 'myst-spec-ext';
+import type { GenericParent } from 'myst-common';
+import { remove } from 'unist-util-remove';
+import { selectAll } from 'unist-util-select';
+
+/**
+ * This transform does the following:
+ * - Removes hidden or removed blocks from the tree
+ * - Removes hidden or removed outputs from the tree
+ */
+export function blockTransform(tree: GenericParent) {
+  // This could also be an output, etc.
+  (selectAll('[visibility=remove],[visibility=hide]', tree) as Block[]).forEach((node) => {
+    if (node.visibility === 'remove' || node.visibility === 'hide') {
+      (node as any).type = '__delete__';
+    }
+  });
+  const removed = remove(tree, '__delete__');
+  if (removed === null) {
+    // remove is unhappy if all children are removed - this forces it through
+    tree.children = [];
+  }
+}
+
+export const blockPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
+  blockTransform(tree);
+};

--- a/packages/myst-to-jats/src/transforms/definitions.ts
+++ b/packages/myst-to-jats/src/transforms/definitions.ts
@@ -38,7 +38,9 @@ export function definitionTransform(mdast: GenericParent) {
   const defDescriptions = selectAll('definitionDescription', mdast) as DefinitionDescription[];
   defDescriptions.forEach((node) => {
     const allParagraphs = node.children.reduce((b, n) => b && n.type === 'paragraph', true);
-    if (allParagraphs) return;
+    const oneParagraph = !!node.children.find((n) => n.type === 'paragraph');
+    // If there isn't any paragraph, it is likely text/inline content and we can handle this in the renderer
+    if (allParagraphs || !oneParagraph) return;
     node.children = node.children.map((child) => {
       if (child.type === 'paragraph') return child;
       return { type: 'paragraph', children: [child] };

--- a/packages/myst-to-jats/src/transforms/index.ts
+++ b/packages/myst-to-jats/src/transforms/index.ts
@@ -4,6 +4,7 @@ import { definitionTransform } from './definitions.js';
 import { containerTransform } from './containers.js';
 import { tableTransform } from './tables.js';
 import { sectionTransform } from './sections.js';
+import { blockTransform } from './blocks.js';
 import { citeGroupTransform } from './citations.js';
 import type { Options } from '../types.js';
 import type { GenericParent } from 'myst-common';
@@ -12,9 +13,11 @@ export { definitionTransform, definitionPlugin } from './definitions.js';
 export { containerTransform, containerPlugin } from './containers.js';
 export { tableTransform, tablePlugin } from './tables.js';
 export { sectionTransform, sectionPlugin } from './sections.js';
+export { blockTransform, blockPlugin } from './blocks.js';
 export { referenceTargetTransform, referenceResolutionTransform } from './references.js';
 
 export function basicTransformations(tree: GenericParent, opts: Options) {
+  blockTransform(tree);
   definitionTransform(tree);
   containerTransform(tree);
   tableTransform(tree);


### PR DESCRIPTION
- remove hidden blocks and outputs
- remove link zero-width spaces
- fix def-list nesting in paragraphs