### PR TITLE
📮 Support multiple `articles` in a single export

### DIFF
--- a/.changeset/cold-pans-lay.md
+++ b/.changeset/cold-pans-lay.md
@@ -1,0 +1,5 @@
+---
+'myst-to-tex': patch
+---
+
+Maintain preamble as structured data in myst-to-tex with funcitons to reconstruct later

--- a/.changeset/lemon-badgers-occur.md
+++ b/.changeset/lemon-badgers-occur.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Export article -> articles with coercion and erroring

--- a/.changeset/silver-walls-do.md
+++ b/.changeset/silver-walls-do.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Consume multiple articles and preamble changes in exports

--- a/.changeset/smooth-balloons-tell.md
+++ b/.changeset/smooth-balloons-tell.md
@@ -1,0 +1,5 @@
+---
+'simple-validators': patch
+---
+
+Add option to keep extra keys on validateKeys

--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -84,7 +84,10 @@ export async function runWordExport(
   clean?: boolean,
   extraLinkTransformers?: LinkTransformer[],
 ): Promise<ExportResults> {
-  const { output, article } = exportOptions;
+  const { output, articles } = exportOptions;
+  // At this point, export options are resolved to contain one-and-only-one article
+  const article = articles[0];
+  if (!article) return { tempFolders: [] };
   if (clean) cleanOutput(session, output);
   const vfile = new VFile();
   vfile.path = output;

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -26,7 +26,10 @@ export async function runJatsExport(
   extraLinkTransformers?: LinkTransformer[],
 ) {
   const toc = tic();
-  const { output, article, sub_articles } = exportOptions;
+  const { output, articles, sub_articles } = exportOptions;
+  // At this point, export options are resolved to contain one-and-only-one article
+  const article = articles[0];
+  if (!article) return { tempFolders: [] };
   if (clean) cleanOutput(session, output);
   const processedContents = (
     await getFileContent(session, [article, ...(sub_articles ?? [])], {

--- a/packages/myst-cli/src/build/md/index.ts
+++ b/packages/myst-cli/src/build/md/index.ts
@@ -24,7 +24,10 @@ export async function runMdExport(
   extraLinkTransformers?: LinkTransformer[],
 ) {
   const toc = tic();
-  const { output, article } = exportOptions;
+  const { output, articles } = exportOptions;
+  // At this point, export options are resolved to contain one-and-only-one article
+  const article = articles[0];
+  if (!article) return { tempFolders: [] };
   if (clean) cleanOutput(session, output);
   const [{ mdast, frontmatter }] = await getFileContent(session, [article], {
     projectPath,

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -155,7 +155,9 @@ export async function runMecaExport(
   extraLinkTransformers?: LinkTransformer[],
 ) {
   const toc = tic();
-  const { output, article } = exportOptions;
+  const { output, articles } = exportOptions;
+  // At this point, export options are resolved to contain zero or one articles
+  const article = articles[0];
   const vfile = new VFile();
   vfile.path = output;
   const fileCopyErrorLogFn = (m: string) => {

--- a/packages/myst-cli/src/build/tex/single.spec.ts
+++ b/packages/myst-cli/src/build/tex/single.spec.ts
@@ -42,7 +42,7 @@ describe('extractTexPart', () => {
         value: 'tagged content\n\nalso tagged content',
         imports: [],
         commands: {},
-        preamble: '',
+        preamble: { abbreviations: {}, glossary: {}, printGlossaries: false },
       },
     );
     expect(tree).toEqual({
@@ -80,7 +80,7 @@ describe('extractTexPart', () => {
       value: 'tagged content',
       imports: [],
       commands: {},
-      preamble: '',
+      preamble: { abbreviations: {}, glossary: {}, printGlossaries: false },
     });
   });
   it('exceeding max chars passes', async () => {
@@ -100,7 +100,7 @@ describe('extractTexPart', () => {
       value: 'tagged content',
       imports: [],
       commands: {},
-      preamble: '',
+      preamble: { abbreviations: {}, glossary: {}, printGlossaries: false },
     });
   });
   it('exceeding max words passes', async () => {
@@ -120,7 +120,7 @@ describe('extractTexPart', () => {
       value: 'tagged content',
       imports: [],
       commands: {},
-      preamble: '',
+      preamble: { abbreviations: {}, glossary: {}, printGlossaries: false },
     });
   });
   it('part as_list returns list', async () => {
@@ -153,13 +153,13 @@ describe('extractTexPart', () => {
         value: 'tagged content',
         imports: [],
         commands: {},
-        preamble: '',
+        preamble: { abbreviations: {}, glossary: {}, printGlossaries: false },
       },
       {
         value: 'also tagged content',
         imports: [],
         commands: {},
-        preamble: '',
+        preamble: { abbreviations: {}, glossary: {}, printGlossaries: false },
       },
     ]);
   });
@@ -206,13 +206,13 @@ describe('extractTexPart', () => {
         value: 'tagged content',
         imports: [],
         commands: {},
-        preamble: '',
+        preamble: { abbreviations: {}, glossary: {}, printGlossaries: false },
       },
       {
         value: 'also tagged content',
         imports: [],
         commands: {},
-        preamble: '',
+        preamble: { abbreviations: {}, glossary: {}, printGlossaries: false },
       },
     ]);
   });
@@ -264,7 +264,7 @@ describe('extractTexPart', () => {
           'some other stuff\n\n\\begin{itemize}\n\\item tagged content\n\\item also tagged content\n\\end{itemize}',
         imports: [],
         commands: {},
-        preamble: '',
+        preamble: { abbreviations: {}, glossary: {}, printGlossaries: false },
       },
     ]);
   });
@@ -317,13 +317,13 @@ describe('extractTexPart', () => {
           '\\begin{itemize}\n\\item tagged content\n\\item also tagged content\n\\end{itemize}',
         imports: [],
         commands: {},
-        preamble: '',
+        preamble: { abbreviations: {}, glossary: {}, printGlossaries: false },
       },
       {
         value: 'more tagged content...',
         imports: [],
         commands: {},
-        preamble: '',
+        preamble: { abbreviations: {}, glossary: {}, printGlossaries: false },
       },
     ]);
   });

--- a/packages/myst-cli/src/build/types.ts
+++ b/packages/myst-cli/src/build/types.ts
@@ -6,7 +6,7 @@ import type { ISession } from '../session/types.js';
 import type { RendererData } from '../transforms/types.js';
 
 export type ExportWithOutput = Export & {
-  article: string;
+  articles: string[];
   output: string;
 };
 

--- a/packages/myst-frontmatter/src/exports/exports.yml
+++ b/packages/myst-frontmatter/src/exports/exports.yml
@@ -148,3 +148,111 @@ cases:
           template: default
           output: out.pdf
           a: 1
+  - title: article coerces to articles
+    raw:
+      exports:
+        - format: pdf
+          template: default
+          output: out.pdf
+          a: 1
+          article: index.md
+    normalized:
+      exports:
+        - format: pdf
+          template: default
+          output: out.pdf
+          a: 1
+          articles:
+            - index.md
+  - title: sub_article coerces to sub_articles
+    raw:
+      exports:
+        - format: jats
+          template: default
+          a: 1
+          sub_article: index.md
+    normalized:
+      exports:
+        - format: xml
+          template: default
+          a: 1
+          sub_articles:
+            - index.md
+  - title: sub_articles not allowed on non-jats
+    raw:
+      exports:
+        - format: pdf
+          template: default
+          a: 1
+          sub_article: index.md
+    normalized:
+      exports:
+        - format: pdf
+          template: default
+          a: 1
+    errors: 1
+  - title: tex/pdf/pdf+tex support multiple articles
+    raw:
+      exports:
+        - format: pdf
+          articles:
+            - a.md
+            - b.md
+            - c.md
+        - format: tex
+          articles:
+            - a.md
+            - b.md
+            - c.md
+        - format: pdf+tex
+          articles:
+            - a.md
+            - b.md
+            - c.md
+    normalized:
+      exports:
+        - format: pdf
+          articles:
+            - a.md
+            - b.md
+            - c.md
+        - format: tex
+          articles:
+            - a.md
+            - b.md
+            - c.md
+        - format: pdf+tex
+          articles:
+            - a.md
+            - b.md
+            - c.md
+  - title: md/docx/jats do not support multiple articles
+    raw:
+      exports:
+        - format: md
+          articles:
+            - a.md
+            - b.md
+            - c.md
+        - format: docx
+          articles:
+            - a.md
+            - b.md
+            - c.md
+        - format: jats
+          articles:
+            - a.md
+            - b.md
+            - c.md
+    normalized:
+      exports:
+        - format: md
+          articles:
+            - a.md
+        - format: docx
+          articles:
+            - a.md
+        - format: xml
+          articles:
+            - a.md
+    errors: 3

--- a/packages/myst-frontmatter/src/exports/types.ts
+++ b/packages/myst-frontmatter/src/exports/types.ts
@@ -12,7 +12,7 @@ export type Export = {
   format: ExportFormats;
   template?: string | null;
   output?: string;
-  article?: string;
+  articles?: string[];
   /** sub_articles are only for jats xml export */
   sub_articles?: string[];
   /** MECA: to, from later */

--- a/packages/myst-frontmatter/src/exports/validators.ts
+++ b/packages/myst-frontmatter/src/exports/validators.ts
@@ -3,24 +3,27 @@ import {
   defined,
   incrementOptions,
   validateEnum,
-  validateKeys,
   validateList,
-  validateObject,
+  validateObjectKeys,
   validateString,
   validationError,
 } from 'simple-validators';
 import type { Export } from './types.js';
 import { ExportFormats } from './types.js';
 
+const EXPORT_KEY_OBJECT = {
+  required: ['format'],
+  optional: ['template', 'output', 'id', 'name', 'renderer', 'articles', 'sub_articles'],
+  alias: {
+    article: 'articles',
+    sub_article: 'sub_articles',
+  },
+};
+
 export const RESERVED_EXPORT_KEYS = [
-  'format',
-  'template',
-  'output',
-  'id',
-  'name',
-  'renderer',
-  'article',
-  'sub_articles',
+  ...EXPORT_KEY_OBJECT.required,
+  ...EXPORT_KEY_OBJECT.optional,
+  ...Object.keys(EXPORT_KEY_OBJECT.alias),
 ];
 
 export function validateExportsList(input: any, opts: ValidationOptions): Export[] | undefined {
@@ -45,20 +48,17 @@ function validateExportFormat(input: any, opts: ValidationOptions): ExportFormat
 }
 
 export function validateExport(input: any, opts: ValidationOptions): Export | undefined {
-  let value;
   if (typeof input === 'string') {
     const format = validateExportFormat(input, opts);
     if (!format) return undefined;
-    value = { format };
-  } else {
-    value = validateObject(input, opts);
+    input = { format };
   }
+  const value = validateObjectKeys(input, EXPORT_KEY_OBJECT, {
+    ...opts,
+    suppressWarnings: true,
+    keepExtraKeys: true,
+  });
   if (value === undefined) return undefined;
-  validateKeys(
-    value,
-    { required: ['format'], optional: RESERVED_EXPORT_KEYS },
-    { ...opts, suppressWarnings: true },
-  );
   const format = validateExportFormat(value.format, incrementOptions('format', opts));
   if (format === undefined) return undefined;
   const output: Export = { ...value, format };
@@ -72,16 +72,38 @@ export function validateExport(input: any, opts: ValidationOptions): Export | un
   if (defined(value.output)) {
     output.output = validateString(value.output, incrementOptions('output', opts));
   }
-  if (defined(value.article)) {
-    output.article = validateString(value.article, incrementOptions('article', opts));
+  if (defined(value.articles)) {
+    const articles = validateList(
+      value.articles,
+      { coerce: true, ...incrementOptions('articles', opts) },
+      (item, ind) => validateString(item, incrementOptions(`articles.${ind}`, opts)),
+    );
+    if (
+      articles?.length &&
+      articles.length > 1 &&
+      ![ExportFormats.pdf, ExportFormats.tex, ExportFormats.pdftex].includes(output.format)
+    ) {
+      if (output.format === ExportFormats.xml && !defined(value.sub_articles)) {
+        validationError(
+          "multiple articles are not supported for 'jats' export - instead specify one article with additional sub_articles",
+          opts,
+        );
+      } else {
+        validationError("multiple articles are only supported for 'tex' and 'pdf' exports", opts);
+      }
+      output.articles = [articles[0]];
+    } else {
+      output.articles = articles;
+    }
   }
   if (defined(value.sub_articles)) {
     if (output.format !== ExportFormats.xml) {
-      validationError("sub_articles are only supported for exports of format 'jats'", opts);
+      validationError("sub_articles are only supported for 'jats' export", opts);
+      output.sub_articles = undefined;
     } else {
       output.sub_articles = validateList(
         value.sub_articles,
-        incrementOptions('sub_articles', opts),
+        { coerce: true, ...incrementOptions('sub_articles', opts) },
         (file, ind) => {
           return validateString(file, incrementOptions(`sub_articles.${ind}`, opts));
         },

--- a/packages/myst-frontmatter/src/project/project.yml
+++ b/packages/myst-frontmatter/src/project/project.yml
@@ -98,9 +98,11 @@ cases:
           template: default
           output: out.tex
           a: 1
-          article: my-file.md
+          articles:
+            - my-file.md
         - format: xml
-          article: my-file.md
+          articles:
+            - my-file.md
           sub_articles:
             - my-notebook.ipynb
       requirements:

--- a/packages/myst-to-tex/src/preamble.ts
+++ b/packages/myst-to-tex/src/preamble.ts
@@ -1,0 +1,118 @@
+import { writeTexLabelledComment } from 'myst-common';
+import { TexProofSerializer } from './proof.js';
+import type { PreambleData } from './types.js';
+
+class TexGlossaryAndAcronymSerializer {
+  static COMMENT_LENGTH = 50;
+
+  preamble: string;
+  printedDefinitions: string;
+
+  constructor(
+    glossaryDefinitions: Record<string, [string, string]>,
+    acronymDefinitions: Record<string, [string, string]>,
+  ) {
+    this.printedDefinitions = this.renderGlossary();
+    this.preamble = [
+      this.renderCommonImports(Object.keys(acronymDefinitions).keys.length > 0),
+      this.renderImports('glossary', this.createGlossaryDirectives(glossaryDefinitions)),
+      this.renderImports('acronyms', this.createAcronymDirectives(acronymDefinitions)),
+    ]
+      .filter((item) => !!item)
+      .join('\n');
+  }
+
+  private renderGlossary(): string {
+    const block = writeTexLabelledComment(
+      'acronyms & glossary',
+      ['\\printglossaries'], // Will print both glossary and abbreviations
+      TexGlossaryAndAcronymSerializer.COMMENT_LENGTH,
+    );
+    const percents = ''.padEnd(TexGlossaryAndAcronymSerializer.COMMENT_LENGTH, '%');
+    return `${percents}\n${block}${percents}\n`;
+  }
+
+  private renderCommonImports(withAcronym?: boolean): string {
+    const usepackage = withAcronym
+      ? '\\usepackage[acronym]{glossaries}'
+      : '\\usepackage{glossaries}';
+    const makeglossaries = '\\makeglossaries';
+    return `${usepackage}\n${makeglossaries}\n`;
+  }
+
+  private renderImports(commentTitle: string, directives: string[]): string | undefined {
+    if (!directives) return '';
+    const block = writeTexLabelledComment(
+      commentTitle,
+      directives,
+      TexGlossaryAndAcronymSerializer.COMMENT_LENGTH,
+    );
+    if (!block) return;
+    const percents = ''.padEnd(TexGlossaryAndAcronymSerializer.COMMENT_LENGTH, '%');
+    return `${percents}\n${block}${percents}\n`;
+  }
+
+  private createGlossaryDirectives(
+    glossaryDefinitions: Record<string, [string, string]>,
+  ): string[] {
+    const directives = Object.keys(glossaryDefinitions).map((k) => ({
+      key: k,
+      name: glossaryDefinitions[k][0],
+      description: glossaryDefinitions[k][1],
+    }));
+
+    const entries = directives.map(
+      (entry) =>
+        `\\newglossaryentry{${entry.key}}{name=${entry.name},description={${entry.description}}}`,
+    );
+    return entries;
+  }
+
+  private createAcronymDirectives(acronymDefinitions: Record<string, [string, string]>): string[] {
+    const directives = Object.keys(acronymDefinitions).map((k) => ({
+      key: k,
+      acronym: acronymDefinitions[k][0],
+      expansion: acronymDefinitions[k][1],
+    }));
+
+    return directives.map(
+      (entry) => `\\newacronym{${entry.key}}{${entry.acronym}}{${entry.expansion}}`,
+    );
+  }
+}
+
+export function generatePreamble(data: PreambleData): { preamble: string; suffix: string } {
+  const preambleLines: string[] = [];
+  let suffix = '';
+  if (data.hasProofs) {
+    preambleLines.push(new TexProofSerializer().preamble);
+  }
+  if (data.printGlossaries) {
+    const glossaryState = new TexGlossaryAndAcronymSerializer(data.glossary, data.abbreviations);
+    preambleLines.push(glossaryState.preamble);
+    suffix = `\n${glossaryState.printedDefinitions}`;
+  }
+  return { preamble: preambleLines.join('\n'), suffix };
+}
+
+export function mergePreambles(
+  current: PreambleData,
+  next: PreambleData,
+  warningLogFn: (message: string) => void,
+) {
+  const hasProofs = current.hasProofs || next.hasProofs;
+  const printGlossaries = current.printGlossaries || next.printGlossaries;
+  Object.keys(next.glossary).forEach((key) => {
+    if (Object.keys(current.glossary).includes(key)) {
+      warningLogFn(`duplicate glossary entry for '${key}'`);
+    }
+  });
+  Object.keys(next.abbreviations).forEach((key) => {
+    if (Object.keys(current.abbreviations).includes(key)) {
+      warningLogFn(`duplicate abbreviation definition for '${key}'`);
+    }
+  });
+  const glossary = { ...next.glossary, ...current.glossary };
+  const abbreviations = { ...next.abbreviations, ...current.abbreviations };
+  return { hasProofs, printGlossaries, glossary, abbreviations };
+}

--- a/packages/myst-to-tex/src/types.ts
+++ b/packages/myst-to-tex/src/types.ts
@@ -8,10 +8,17 @@ export const DEFAULT_PAGE_WIDTH_PIXELS = 800;
 
 export type Handler = (node: any, state: ITexSerializer, parent: any) => void;
 
+export type PreambleData = {
+  hasProofs?: boolean;
+  printGlossaries?: boolean;
+  glossary: Record<string, [string, string]>;
+  abbreviations: Record<string, [string, string]>;
+};
+
 export type LatexResult = {
   value: string;
   imports: string[];
-  preamble: string;
+  preamble: PreambleData;
   commands: Record<string, string>;
 };
 

--- a/packages/myst-to-tex/tests/glossaries.spec.ts
+++ b/packages/myst-to-tex/tests/glossaries.spec.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import yaml from 'js-yaml';
 import { unified } from 'unified';
 import type { LatexResult } from '../src';
-import mystToTex from '../src';
+import mystToTex, { generatePreamble } from '../src';
 
 type TestCase = {
   title: string;
@@ -31,13 +31,18 @@ const casesList: TestCases[] = fs
 
 casesList.forEach(({ title, latexGlossary, cases }) => {
   describe(title, () => {
-    test.each(cases.map((c): [string, string, TestCase] => [c.title, latexGlossary, c]))('%s', (_, expectedLatexGlossary, { latex, mdast, printGlossaries }) => {
-      const pipe = unified().use(mystToTex, { printGlossaries });
-      pipe.runSync(mdast as any);
-      const file = pipe.stringify(mdast as any);
-      const printedGlossary = printGlossaries ? `\n${expectedLatexGlossary}` : '';
-      const expectedResult = `${latex}${printedGlossary}`;
-      expect((file.result as LatexResult).value).toEqual(expectedResult);
-    });
+    test.each(cases.map((c): [string, string, TestCase] => [c.title, latexGlossary, c]))(
+      '%s',
+      (_, expectedLatexGlossary, { latex, mdast, printGlossaries }) => {
+        const pipe = unified().use(mystToTex, { printGlossaries });
+        pipe.runSync(mdast as any);
+        const file = pipe.stringify(mdast as any);
+        const { suffix } = generatePreamble((file.result as LatexResult).preamble);
+        const latexValue = (file.result as LatexResult).value + suffix;
+        const printedGlossary = printGlossaries ? `\n${expectedLatexGlossary}` : '';
+        const expectedResult = `${latex}${printedGlossary}`;
+        expect(latexValue).toEqual(expectedResult);
+      },
+    );
   });
 });

--- a/packages/simple-validators/src/types.ts
+++ b/packages/simple-validators/src/types.ts
@@ -17,4 +17,7 @@ export type ValidationOptions = {
   escapeFn?: (s: string) => string;
 };
 
-export type KeyOptions = ValidationOptions & { returnInvalidPartial?: boolean };
+export type KeyOptions = ValidationOptions & {
+  returnInvalidPartial?: boolean;
+  keepExtraKeys?: boolean;
+};

--- a/packages/simple-validators/src/validators.spec.ts
+++ b/packages/simple-validators/src/validators.spec.ts
@@ -326,6 +326,20 @@ describe('validateKeys', () => {
     });
     expect(opts.messages.warnings?.length).toEqual(1);
   });
+  it('extra keys filtered', () => {
+    expect(
+      validateKeys(
+        { z: 1, b: 2, c: 3 },
+        { required: ['a'], optional: ['b'], alias: { z: 'a' } },
+        { ...opts, keepExtraKeys: true },
+      ),
+    ).toEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+    });
+    expect(opts.messages.warnings?.length).toEqual(1);
+  });
 });
 
 describe('validateList', () => {

--- a/packages/simple-validators/src/validators.ts
+++ b/packages/simple-validators/src/validators.ts
@@ -268,6 +268,7 @@ export function validateKeys(
       }
     } else {
       ignored.push(k);
+      if (opts.keepExtraKeys) value[k] = input[k];
     }
   });
   if (required.length) {


### PR DESCRIPTION
- `article` is now coerced to `articles` in export frontmatter
- Multiple articles are only valid for tex/pdf - other cases raise errors
- To support this, tex `preamble` must be kept as structured data and compiled at the end (similar to how tex `imports` are already handled)