### PR TITLE
🎆 No subfigures option

### DIFF
--- a/.changeset/lazy-sloths-grab.md
+++ b/.changeset/lazy-sloths-grab.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Figures created by notebook code are not given subfigures

--- a/.changeset/little-geese-joke.md
+++ b/.changeset/little-geese-joke.md
@@ -1,0 +1,7 @@
+---
+'myst-directives': patch
+'myst-transforms': patch
+'myst-spec-ext': patch
+---
+
+Add no-figures option to figure directive

--- a/packages/myst-directives/src/figure.ts
+++ b/packages/myst-directives/src/figure.ts
@@ -1,5 +1,5 @@
 import type { Image } from 'myst-spec-ext';
-import type { DirectiveSpec, GenericNode } from 'myst-common';
+import type { DirectiveSpec, GenericNode, GenericParent } from 'myst-common';
 import { normalizeLabel } from 'myst-common';
 
 export const figureDirective: DirectiveSpec = {
@@ -59,6 +59,11 @@ export const figureDirective: DirectiveSpec = {
       type: String,
       doc: 'A placeholder image when using a notebook cell as the figure contents. This will be shown in place of the Jupyter output until an execution environment is attached. It will also be used in static outputs, such as a PDF output.',
     },
+    'no-subfigures': {
+      type: Boolean,
+      doc: 'Disallow implicit subfigure creation from child nodes',
+      alias: ['no-subfig', 'no-subfigure'],
+    },
   },
   body: {
     type: 'myst',
@@ -94,7 +99,7 @@ export const figureDirective: DirectiveSpec = {
       children.push(...(data.body as GenericNode[]));
     }
     const { label, identifier } = normalizeLabel(data.options?.label as string | undefined) || {};
-    const container = {
+    const container: GenericParent = {
       type: 'container',
       kind: 'figure',
       identifier,
@@ -102,6 +107,9 @@ export const figureDirective: DirectiveSpec = {
       class: data.options?.class,
       children,
     };
+    if (data.options?.['no-subfigures']) {
+      container.noSubcontainers = true;
+    }
     return [container];
   },
 };

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -219,5 +219,6 @@ export type Container = Omit<SpecContainer, 'kind'> & {
   kind?: 'figure' | 'table' | 'quote' | 'code';
   source?: Dependency;
   subcontainer?: boolean;
+  noSubcontainers?: boolean;
   parentEnumerator?: string;
 };

--- a/packages/myst-transforms/src/blocks.spec.ts
+++ b/packages/myst-transforms/src/blocks.spec.ts
@@ -170,8 +170,8 @@ describe('Test blockToFigureTransform', () => {
           },
           [
             u('container', { kind: 'figure', label: 'my-label', identifier: 'my-label' }, [
+              u('paragraph', [u('text', 'My caption')]),
               u('paragraph', [u('text', 'value')]),
-              u('caption', [u('paragraph', [u('text', 'My caption')])]),
             ]),
           ],
         ),
@@ -202,8 +202,8 @@ describe('Test blockToFigureTransform', () => {
           },
           [
             u('container', { kind: 'figure', label: 'my-label', identifier: 'my-label' }, [
+              u('paragraph', [u('text', 'My caption')]),
               u('paragraph', [u('text', 'value')]),
-              u('caption', [u('paragraph', [u('text', 'My caption')])]),
             ]),
           ],
         ),
@@ -234,7 +234,7 @@ describe('Test blockToFigureTransform', () => {
           },
           [
             u('container', { kind: 'table', label: 'my-label', identifier: 'my-label' }, [
-              u('caption', [u('paragraph', [u('text', 'My caption')])]),
+              u('paragraph', [u('text', 'My caption')]),
               u('paragraph', [u('text', 'value')]),
             ]),
           ],
@@ -266,9 +266,42 @@ describe('Test blockToFigureTransform', () => {
           },
           [
             u('container', { kind: 'table', label: 'my-label', identifier: 'my-label' }, [
-              u('caption', [u('paragraph', [u('text', 'My caption')])]),
+              u('paragraph', [u('text', 'My caption')]),
               u('paragraph', [u('text', 'value')]),
             ]),
+          ],
+        ),
+      ]),
+    );
+  });
+  test('block data type notebook-cell results in noSubcontainers', async () => {
+    const mdast = u('root', [
+      u(
+        'block',
+        {
+          label: 'my-label',
+          identifier: 'my-label',
+          data: { 'fig-cap': 'My caption', metadata: '', type: 'notebook-code' },
+          attribute: '',
+        },
+        [u('paragraph', [u('text', 'value')])],
+      ),
+    ]) as any;
+    blockToFigureTransform(mdast);
+    expect(mdast).toEqual(
+      u('root', [
+        u(
+          'block',
+          {
+            data: { metadata: '', type: 'notebook-code' },
+            attribute: '',
+          },
+          [
+            u(
+              'container',
+              { kind: 'figure', label: 'my-label', identifier: 'my-label', noSubcontainers: true },
+              [u('paragraph', [u('text', 'My caption')]), u('paragraph', [u('text', 'value')])],
+            ),
           ],
         ),
       ]),

--- a/packages/myst-transforms/src/containers.spec.ts
+++ b/packages/myst-transforms/src/containers.spec.ts
@@ -106,4 +106,51 @@ describe('Test containerChildrenTransform', () => {
       ]),
     );
   });
+  test('figure with noSubcontainers sorts without creating subcontainers', async () => {
+    const mdast = rootContainer([
+      image(true),
+      image(),
+      u('paragraph', [u('text', 'my caption')]),
+      image(),
+    ]);
+    const fig = mdast.children[0]?.children?.[0];
+    if (fig) fig.noSubcontainers = true;
+    containerChildrenTransform(mdast, new VFile());
+    const result = rootContainer([image(), image(), image(true), caption()]);
+    const resultFig = result.children[0]?.children?.[0];
+    if (resultFig) resultFig.noSubcontainers = true;
+    expect(mdast).toEqual(result);
+  });
+  test('table container puts caption and legend first', async () => {
+    const mdast = rootContainer([
+      image(true),
+      image(),
+      image(),
+      u('paragraph', [u('text', 'my caption')]),
+      u('paragraph', [u('text', 'my legend')]),
+      u('paragraph', [u('text', 'more legend')]),
+    ]);
+    const fig = mdast.children[0]?.children?.[0];
+    if (fig) fig.kind = 'table';
+    containerChildrenTransform(mdast, new VFile());
+    expect(mdast).toEqual(
+      u('root', [
+        u('block', [
+          container(
+            [
+              caption(),
+              u('legend', [
+                u('paragraph', [u('text', 'my legend')]),
+                u('paragraph', [u('text', 'more legend')]),
+              ]),
+              container([image()], 'table'),
+              container([image()], 'table'),
+              image(true),
+            ],
+            'table',
+          ),
+        ]),
+      ]),
+    );
+  });
 });


### PR DESCRIPTION
Recent release of subfigures caused some funny behaviour with notebook cell figures: the code became the "figure" and output was unexpectedly added to the "caption"

To fix that, this adds `output` as a figure-content type. However, that change turns notebook cell figures into subfigures (a) code and (b) output. Now there is an additional `no-subfigures` option - It can be used explicitly on `figure` directives to suppress subfigure behaviour, and it comes in implicitly on notebook cell figures to keep them a single figure with both code and output.