### PR TITLE
👩‍🎓 JATS citation / affiliation fixes

### DIFF
--- a/.changeset/gentle-socks-leave.md
+++ b/.changeset/gentle-socks-leave.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Process parts along with content during jats render

--- a/.changeset/serious-insects-wash.md
+++ b/.changeset/serious-insects-wash.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Only render used, ordered references in jats

--- a/.changeset/violet-flies-reflect.md
+++ b/.changeset/violet-flies-reflect.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Return mutable copies from redux selectors

--- a/packages/myst-cli/src/store/selectors.ts
+++ b/packages/myst-cli/src/store/selectors.ts
@@ -4,8 +4,13 @@ import type { LocalProject, LocalProjectPage } from '../project/types.js';
 import type { RootState } from './reducers.js';
 import type { BuildWarning, ExternalLinkResult } from './types.js';
 
+function mutableCopy(obj?: Record<string, any>) {
+  if (!obj) return;
+  return JSON.parse(JSON.stringify(obj));
+}
+
 export function selectLocalProject(state: RootState, path: string): LocalProject | undefined {
-  return state.local.projects[resolve(path)];
+  return mutableCopy(state.local.projects[resolve(path)]);
 }
 
 export function selectAffiliation(state: RootState, id: string): string | undefined {
@@ -13,7 +18,7 @@ export function selectAffiliation(state: RootState, id: string): string | undefi
 }
 
 export function selectLocalSiteConfig(state: RootState, path: string): SiteConfig | undefined {
-  return state.local.config.sites[resolve(path)];
+  return mutableCopy(state.local.config.sites[resolve(path)]);
 }
 
 export function selectCurrentSiteConfig(state: RootState): SiteConfig | undefined {
@@ -24,11 +29,11 @@ export function selectCurrentSiteConfig(state: RootState): SiteConfig | undefine
   return { ...config, projects: [{ path }] };
 }
 
-export function selectCurrentSitePath(state: RootState) {
+export function selectCurrentSitePath(state: RootState): string | undefined {
   return state.local.config.currentSitePath;
 }
 
-export function selectCurrentSiteFile(state: RootState) {
+export function selectCurrentSiteFile(state: RootState): string | undefined {
   if (!state.local.config.currentSitePath) return undefined;
   return state.local.config.filenames[resolve(state.local.config.currentSitePath)];
 }
@@ -37,19 +42,19 @@ export function selectLocalProjectConfig(
   state: RootState,
   path: string,
 ): ProjectConfig | undefined {
-  return state.local.config.projects[resolve(path)];
+  return mutableCopy(state.local.config.projects[resolve(path)]);
 }
 
-export function selectCurrentProjectConfig(state: RootState) {
+export function selectCurrentProjectConfig(state: RootState): ProjectConfig | undefined {
   if (!state.local.config.currentProjectPath) return undefined;
-  return state.local.config.projects[resolve(state.local.config.currentProjectPath)];
+  return mutableCopy(state.local.config.projects[resolve(state.local.config.currentProjectPath)]);
 }
 
-export function selectCurrentProjectPath(state: RootState) {
+export function selectCurrentProjectPath(state: RootState): string | undefined {
   return state.local.config.currentProjectPath;
 }
 
-export function selectCurrentProjectFile(state: RootState) {
+export function selectCurrentProjectFile(state: RootState): string | undefined {
   if (!state.local.config.currentProjectPath) return undefined;
   return state.local.config.filenames[resolve(state.local.config.currentProjectPath)];
 }
@@ -61,7 +66,7 @@ export function selectLocalRawConfig(
   state: RootState,
   path: string,
 ): { raw: Record<string, any>; validated: Record<string, any> } | undefined {
-  return state.local.config.rawConfigs[resolve(path)];
+  return mutableCopy(state.local.config.rawConfigs[resolve(path)]);
 }
 
 export function selectReloadingState(state: RootState) {
@@ -100,7 +105,11 @@ export function selectFileInfo(state: RootState, path: string) {
   };
 }
 
-export function selectPageSlug(state: RootState, projectPath: string, path: string) {
+export function selectPageSlug(
+  state: RootState,
+  projectPath: string,
+  path: string,
+): string | undefined {
   const project = selectLocalProject(state, projectPath);
   if (!project) return undefined;
   if (path === project.file) return project.index;
@@ -111,11 +120,11 @@ export function selectPageSlug(state: RootState, projectPath: string, path: stri
 }
 
 export function selectLinkStatus(state: RootState, url: string): ExternalLinkResult | undefined {
-  return state.local.links[url];
+  return mutableCopy(state.local.links[url]);
 }
 
 export function selectFileWarnings(state: RootState, file: string): BuildWarning[] | undefined {
-  return state.local.warnings[file];
+  return mutableCopy(state.local.warnings[file]);
 }
 
 export function selectFileWarningsByRule(

--- a/packages/myst-to-jats/src/backmatter.ts
+++ b/packages/myst-to-jats/src/backmatter.ts
@@ -129,16 +129,16 @@ export function getRefList(
   order?: string[],
   citations?: CitationRenderer,
 ): Element[] {
-  if (!order || !citations) return [];
   const elements = order
-    .map((key) => {
-      if (!citations[key]) {
+    ?.map((key) => {
+      if (!citations?.[key]) {
         state.warn(`unknown citation ${key}`);
         return undefined;
       }
       return citeToJatsRef(state, key, citations[key].cite);
     })
     .filter((e): e is Element => !!e);
+  if (!elements?.length) return [];
   return [{ type: 'element', name: 'ref-list', elements }];
 }
 

--- a/packages/myst-to-jats/src/backmatter.ts
+++ b/packages/myst-to-jats/src/backmatter.ts
@@ -124,13 +124,21 @@ export function citeToJatsRef(state: IJatsSerializer, key: string, data: Citatio
   };
 }
 
-export function getRefList(state: IJatsSerializer, citations?: CitationRenderer): Element[] {
-  if (!citations || !Object.keys(citations).length) return [];
-  const elements = Object.keys(citations)
-    .sort()
+export function getRefList(
+  state: IJatsSerializer,
+  order?: string[],
+  citations?: CitationRenderer,
+): Element[] {
+  if (!order || !citations) return [];
+  const elements = order
     .map((key) => {
+      if (!citations[key]) {
+        state.warn(`unknown citation ${key}`);
+        return undefined;
+      }
       return citeToJatsRef(state, key, citations[key].cite);
-    });
+    })
+    .filter((e): e is Element => !!e);
   return [{ type: 'element', name: 'ref-list', elements }];
 }
 
@@ -157,15 +165,17 @@ export function getBack(
     citations,
     footnotes,
     expressions,
+    referenceOrder,
   }: {
     citations?: CitationRenderer;
     footnotes?: Element[];
     expressions?: Element[];
+    referenceOrder?: string[];
   },
 ): Element[] {
   const elements = [
     ...(state.data.backSections ?? []),
-    ...getRefList(state, citations),
+    ...getRefList(state, referenceOrder, citations),
     ...getFootnotes(footnotes),
     ...getExpressions(expressions),
     ...(state.data.acknowledgments ? [state.data.acknowledgments] : []),

--- a/packages/myst-to-jats/src/transforms/blocks.ts
+++ b/packages/myst-to-jats/src/transforms/blocks.ts
@@ -1,20 +1,38 @@
 import type { Plugin } from 'unified';
 import type { Block } from 'myst-spec-ext';
-import type { GenericParent } from 'myst-common';
+import { selectBlockParts, type GenericParent } from 'myst-common';
 import { remove } from 'unist-util-remove';
 import { selectAll } from 'unist-util-select';
+import { ABSTRACT_PARTS, ACKNOWLEDGMENT_PARTS, type Options } from '../types.js';
+
+function blocksToKeep(tree: GenericParent, opts: Options) {
+  const keepParts: string[] = [...ACKNOWLEDGMENT_PARTS];
+  if (opts.extractAbstract) {
+    keepParts.push(...(opts.abstractParts?.map(({ part }) => part).flat() ?? ABSTRACT_PARTS));
+  }
+  if (opts.backSections) {
+    keepParts.push(...opts.backSections.map(({ part }) => part).flat());
+  }
+  return selectBlockParts(tree, keepParts);
+}
 
 /**
  * This transform does the following:
- * - Removes hidden or removed blocks from the tree
+ * - Removes hidden or removed blocks from the tree except those that are consumed as front/backmatter parts
  * - Removes hidden or removed outputs from the tree
  */
-export function blockTransform(tree: GenericParent) {
+export function blockTransform(tree: GenericParent, opts: Options) {
+  // Collect blocks that will be used as parts to make sure they are not deleted
+  const doNotDelete = blocksToKeep(tree, opts);
   // This could also be an output, etc.
   (selectAll('[visibility=remove],[visibility=hide]', tree) as Block[]).forEach((node) => {
     if (node.visibility === 'remove' || node.visibility === 'hide') {
       (node as any).type = '__delete__';
     }
+  });
+  // Blocks are converted to sections - avoid doing this for part blocks
+  doNotDelete.forEach((node) => {
+    node.type = 'block-part' as any;
   });
   const removed = remove(tree, '__delete__');
   if (removed === null) {
@@ -23,6 +41,12 @@ export function blockTransform(tree: GenericParent) {
   }
 }
 
-export const blockPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree) => {
-  blockTransform(tree);
+export const blockPlugin: Plugin<[Options], GenericParent, GenericParent> = (opts) => (tree) => {
+  blockTransform(tree, opts);
 };
+
+export function restoreBlockPartTypeTransform(tree: GenericParent) {
+  selectAll('block-part', tree).forEach((node) => {
+    node.type = 'block';
+  });
+}

--- a/packages/myst-to-jats/src/transforms/index.ts
+++ b/packages/myst-to-jats/src/transforms/index.ts
@@ -4,7 +4,7 @@ import { definitionTransform } from './definitions.js';
 import { containerTransform } from './containers.js';
 import { tableTransform } from './tables.js';
 import { sectionTransform } from './sections.js';
-import { blockTransform } from './blocks.js';
+import { blockTransform, restoreBlockPartTypeTransform } from './blocks.js';
 import { citeGroupTransform } from './citations.js';
 import type { Options } from '../types.js';
 import type { GenericParent } from 'myst-common';
@@ -17,12 +17,13 @@ export { blockTransform, blockPlugin } from './blocks.js';
 export { referenceTargetTransform, referenceResolutionTransform } from './references.js';
 
 export function basicTransformations(tree: GenericParent, opts: Options) {
-  blockTransform(tree);
+  blockTransform(tree, opts);
   definitionTransform(tree);
   containerTransform(tree);
   tableTransform(tree);
   sectionTransform(tree, opts);
   citeGroupTransform(tree);
+  restoreBlockPartTypeTransform(tree);
 }
 
 export const basicTransformationsPlugin: Plugin<[Options], GenericParent, GenericParent> =

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -61,7 +61,7 @@ export interface IJatsSerializer<D extends Record<string, any> = StateData> {
   stack: Element[];
   footnotes: Element[];
   expressions: Element[];
-  render: () => IJatsSerializer;
+  render: (ignoreParts?: boolean) => IJatsSerializer;
   text: (value?: string) => void;
   renderChildren: (node: any) => void;
   renderInline: (node: GenericNode, name: string, attributes?: Attributes) => void;
@@ -70,6 +70,6 @@ export interface IJatsSerializer<D extends Record<string, any> = StateData> {
   openNode: (name: string, attributes?: Attributes) => void;
   closeNode: () => void;
   elements: () => Element[];
-  warn: (message: string, node: GenericNode, source?: string, opts?: MessageInfo) => void;
-  error: (message: string, node: GenericNode, source?: string, opts?: MessageInfo) => void;
+  warn: (message: string, node?: GenericNode, source?: string, opts?: MessageInfo) => void;
+  error: (message: string, node?: GenericNode, source?: string, opts?: MessageInfo) => void;
 }

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -22,6 +22,10 @@ export type MathPlugins = Required<PageFrontmatter>['math'];
 
 export type JatsPart = { part: string | string[]; type?: string; title?: string };
 
+export const ACKNOWLEDGMENT_PARTS = ['acknowledgments', 'acknowledgements'];
+
+export const ABSTRACT_PARTS = ['abstract'];
+
 export type Options = {
   handlers?: Record<string, Handler>;
   isNotebookArticleRep?: boolean;
@@ -61,6 +65,7 @@ export interface IJatsSerializer<D extends Record<string, any> = StateData> {
   stack: Element[];
   footnotes: Element[];
   expressions: Element[];
+  referenceOrder: string[];
   render: (ignoreParts?: boolean) => IJatsSerializer;
   text: (value?: string) => void;
   renderChildren: (node: any) => void;

--- a/packages/myst-to-jats/tests/citations.yml
+++ b/packages/myst-to-jats/tests/citations.yml
@@ -7,6 +7,21 @@ cases:
           children:
             - type: text
               value: text
+            - type: citeGroup
+              kind: narrative
+              children:
+                - type: cite
+                  label: doe_2000
+                  identifier: doe_2000
+                  children:
+                    - type: text
+                      value: doe, 2000
+                - type: cite
+                  label: example_2020
+                  identifier: example_2020
+                  children:
+                    - type: text
+                      value: example, 2020
     citations:
       doe_2000:
         cite:
@@ -30,6 +45,8 @@ cases:
           volume: '4'
       example_2020:
         cite: {}
+      example_2000:
+        cite: {}
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
@@ -38,7 +55,10 @@ cases:
           <article-meta/>
         </front>
         <body>
-          <p>text</p>
+          <p>text
+            <xref ref-type="bibr" rid="ref-1">doe, 2000</xref>, 
+            <xref ref-type="bibr" rid="ref-2">example, 2020</xref>
+          </p>
         </body>
         <back>
           <ref-list>

--- a/packages/myst-to-jats/tests/multi.yml
+++ b/packages/myst-to-jats/tests/multi.yml
@@ -55,6 +55,15 @@ cases:
           children:
             - type: text
               value: text
+            - type: citeGroup
+              kind: narrative
+              children:
+                - type: cite
+                  label: example_2020
+                  identifier: example_2020
+                  children:
+                    - type: text
+                      value: example, 2020
     citations:
       example_2020:
         cite: {}
@@ -68,6 +77,15 @@ cases:
               children:
                 - type: text
                   value: article 1
+                - type: citeGroup
+                  kind: narrative
+                  children:
+                    - type: cite
+                      label: example_2000
+                      identifier: example_2000
+                      children:
+                        - type: text
+                          value: example, 2000
         citations:
           example_2000:
             cite: {}
@@ -92,7 +110,9 @@ cases:
           </article-meta>
         </front>
         <body>
-          <p>text</p>
+          <p>text
+            <xref ref-type="bibr" rid="ref-1">example, 2020</xref>
+          </p>
         </body>
         <back>
           <ref-list>
@@ -106,7 +126,9 @@ cases:
         <sub-article>
           <front-stub/>
           <body>
-            <p>article 1</p>
+            <p>article 1
+              <xref ref-type="bibr" rid="ref-2">example, 2000</xref>
+            </p>
           </body>
           <back>
             <ref-list>


### PR DESCRIPTION
This PR addresses some of the tasks here - https://github.com/executablebooks/mystmd/issues/347:

- IDs of affiliations needs to be normalized
  - This was caused by immutable objects returned by selectors - not the first time we will be bitten by that stealthy bug. Now, selectors return mutable copies, so hopefully this will not get us again 🤞
- parts need to be rendered after the ID normalization (citation labels are not being transformed)
  - now, `parts` are left in the tree for final myst-to-jats mdast transforms, then plucked off immediately before `render`
- multiple unused references show up in the final jats
  - now, only the used references are added to the xml, not all available citations