### PR TITLE
🚛 Export `ManifestProject` types

### DIFF
--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -31,7 +31,7 @@ export type SiteConfig = SiteFrontmatter & {
   template?: string;
 };
 
-type ManifestProjectItem = {
+export type ManifestProjectItem = {
   title: string;
   short_title?: string;
   level: number;
@@ -46,7 +46,7 @@ type ManifestProjectItem = {
   exports?: Export[];
 };
 
-type ManifestProject = {
+export type ManifestProject = {
   slug?: string;
   index: string;
   title: string;


### PR DESCRIPTION
Export types the myst-theme has to access via SiteManifest and re-export