### PR TITLE
🗺 Put table legend at end

### DIFF
--- a/.changeset/khaki-carrots-share.md
+++ b/.changeset/khaki-carrots-share.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Put legend for tables at end by default.

--- a/packages/myst-transforms/src/containers.spec.ts
+++ b/packages/myst-transforms/src/containers.spec.ts
@@ -121,7 +121,7 @@ describe('Test containerChildrenTransform', () => {
     if (resultFig) resultFig.noSubcontainers = true;
     expect(mdast).toEqual(result);
   });
-  test('table container puts caption and legend first', async () => {
+  test('table container puts caption first and legend at end', async () => {
     const mdast = rootContainer([
       image(true),
       image(),
@@ -139,13 +139,13 @@ describe('Test containerChildrenTransform', () => {
           container(
             [
               caption(),
+              container([image()], 'table'),
+              container([image()], 'table'),
+              image(true),
               u('legend', [
                 u('paragraph', [u('text', 'my legend')]),
                 u('paragraph', [u('text', 'more legend')]),
               ]),
-              container([image()], 'table'),
-              container([image()], 'table'),
-              image(true),
             ],
             'table',
           ),

--- a/packages/myst-transforms/src/containers.ts
+++ b/packages/myst-transforms/src/containers.ts
@@ -194,10 +194,10 @@ export function containerChildrenTransform(tree: GenericParent, vfile: VFile) {
     }
     const children: GenericNode[] = [...subfigures];
     if (placeholderImage) children.push(placeholderImage);
-    // Caption/legend are above tables and below all other figures
+    // Caption is above tables and below all other figures
     if (container.kind === 'table') {
-      if (legend) children.unshift(legend);
       if (caption) children.unshift(caption);
+      if (legend) children.push(legend);
     } else {
       if (caption) children.push(caption);
       if (legend) children.push(legend);


### PR DESCRIPTION
This moves the legend to the end of the container.
Rather than directly after the caption.
This is helpful for table notes, etc.

Related to #778, which changes some of the logic there @fwkoch.