### PR TITLE
🐛  Fix Inline Expressions Render

### DIFF
--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -173,11 +173,11 @@ export async function transformMdast(
 
   const pipe = unified()
     .use(reconstructHtmlPlugin) // We need to group and link the HTML first
-    .use(htmlPlugin, { htmlHandlers }) // Some of the HTML plugins need to operate on the transformed html, e.g. figure caption transforms
     .use(basicTransformationsPlugin, {
       parser: (content: string) => parseMyst(session, content, file),
     })
     .use(inlineExpressionsPlugin) // Happens before math and images!
+    .use(htmlPlugin, { htmlHandlers }) // Some of the HTML plugins need to operate on the transformed html, e.g. figure caption transforms
     .use(inlineMathSimplificationPlugin)
     .use(mathPlugin, { macros: frontmatter.math })
     .use(glossaryPlugin, { state }) // This should be before the enumerate plugins

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -173,11 +173,11 @@ export async function transformMdast(
 
   const pipe = unified()
     .use(reconstructHtmlPlugin) // We need to group and link the HTML first
+    .use(inlineExpressionsPlugin) // Happens before math and images!
+    .use(htmlPlugin, { htmlHandlers }) // Some of the HTML plugins need to operate on the transformed html, e.g. figure caption transforms
     .use(basicTransformationsPlugin, {
       parser: (content: string) => parseMyst(session, content, file),
     })
-    .use(inlineExpressionsPlugin) // Happens before math and images!
-    .use(htmlPlugin, { htmlHandlers }) // Some of the HTML plugins need to operate on the transformed html, e.g. figure caption transforms
     .use(inlineMathSimplificationPlugin)
     .use(mathPlugin, { macros: frontmatter.math })
     .use(glossaryPlugin, { state }) // This should be before the enumerate plugins

--- a/packages/myst-cli/src/transforms/inlineExpressions.ts
+++ b/packages/myst-cli/src/transforms/inlineExpressions.ts
@@ -57,8 +57,9 @@ function renderExpression(node: InlineExpression, file: VFile): StaticPhrasingCo
   if (result.status === 'ok') {
     if (result.data['text/latex']) {
       return [{ type: 'inlineMath', value: processLatex(result.data['text/latex']) }];
-    }
-    if (result.data['text/plain']) {
+    } else if (result.data['text/html']) {
+      return [{ type: 'html', value: result.data['text/html'] }];
+    } else if (result.data['text/plain']) {
       return [{ type: 'text', value: result.data['text/plain'] }];
     }
     fileWarn(file, 'Unrecognized mime bundle for inline content', {

--- a/packages/myst-directives/src/code.ts
+++ b/packages/myst-directives/src/code.ts
@@ -169,7 +169,7 @@ export const codeCellDirective: DirectiveSpec = {
       type: 'code',
       lang: data.arg as string,
       executable: true,
-      value: data.body as string,
+      value: (data.body ?? '') as string,
     };
     let tags: string[] | undefined;
     // TODO: this validation should be done in a different place

--- a/packages/myst-to-docx/src/schema.ts
+++ b/packages/myst-to-docx/src/schema.ts
@@ -528,6 +528,10 @@ const mystRole: Handler<{ type: 'mystRole' } & Parent> = (state, node) => {
   state.renderChildren(node);
 };
 
+const inlineExpression: Handler<{ type: 'inlineExpression' } & Parent> = (state, node) => {
+  state.renderChildren(node);
+};
+
 export const defaultHandlers = {
   text,
   paragraph,
@@ -571,4 +575,5 @@ export const defaultHandlers = {
   citeGroup,
   embed,
   include,
+  inlineExpression,
 };

--- a/packages/myst-to-docx/src/schema.ts
+++ b/packages/myst-to-docx/src/schema.ts
@@ -61,6 +61,7 @@ import type {
   FootnoteDefinition,
   CiteKind,
   Block,
+  InlineExpression,
 } from 'myst-spec-ext';
 import type { Handler, Mutable } from './types.js';
 import {
@@ -528,8 +529,12 @@ const mystRole: Handler<{ type: 'mystRole' } & Parent> = (state, node) => {
   state.renderChildren(node);
 };
 
-const inlineExpression: Handler<{ type: 'inlineExpression' } & Parent> = (state, node) => {
-  state.renderChildren(node);
+const inlineExpression: Handler<InlineExpression> = (state, node, parent) => {
+  if (node.children?.length) {
+    state.renderChildren(node as Parent);
+  } else {
+    inlineCode(state, { ...node, type: 'inlineCode' }, parent);
+  }
 };
 
 export const defaultHandlers = {

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -408,7 +408,13 @@ const handlers: Record<string, Handler> = {
     }
   },
   inlineExpression(node, state) {
-    state.renderChildren(node, true);
+    if (node.children?.length) {
+      state.renderChildren(node, true);
+    } else {
+      state.write('\\texttt{');
+      state.text(node.value, false);
+      state.write('}');
+    }
   },
 };
 

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -407,6 +407,9 @@ const handlers: Record<string, Handler> = {
       );
     }
   },
+  inlineExpression(node, state) {
+    state.renderChildren(node, true);
+  },
 };
 
 class TexSerializer implements ITexSerializer {


### PR DESCRIPTION
This PR fixes `Unhandled LaTeX conversion for node of "inlineExpression"` error for PDF and LaTeX output converting from JupyterLab `ipynb` via `myst` command.

Added `inlineExpression` node handler to `myst-to-tex` and `myst-to-docx` packages.

It seems that the current `eval` transformer is working fine, except handling `html` MIME type.

Fixes https://github.com/executablebooks/jupyterlab-myst/issues/194

Manually tested using [examples/inline-interactivity.ipynb](https://github.com/executablebooks/jupyterlab-myst/blob/4684bc358f7d9be3fe62baccc862c35606c9c488/examples/inline-interactivity.ipynb)