### PR TITLE
👩‍🎓 Add typst export to CLI and support templating through jtex

### DIFF
--- a/.changeset/beige-kiwis-care.md
+++ b/.changeset/beige-kiwis-care.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Add typst invocation to typst export from cli

--- a/.changeset/fifty-bulldogs-yell.md
+++ b/.changeset/fifty-bulldogs-yell.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Support new typst cite syntax

--- a/.changeset/great-peas-impress.md
+++ b/.changeset/great-peas-impress.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Use @ citation syntax for citation groups in typst

--- a/.changeset/khaki-oranges-sparkle.md
+++ b/.changeset/khaki-oranges-sparkle.md
@@ -1,0 +1,5 @@
+---
+'myst-templates': patch
+---
+
+Add single bibtex entry to template doc

--- a/.changeset/late-moose-design.md
+++ b/.changeset/late-moose-design.md
@@ -1,0 +1,5 @@
+---
+'jtex': patch
+---
+
+Modify jtex to support typst

--- a/.changeset/many-baboons-sing.md
+++ b/.changeset/many-baboons-sing.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Update typst export to use jtex

--- a/.changeset/ninety-fireants-happen.md
+++ b/.changeset/ninety-fireants-happen.md
@@ -1,0 +1,9 @@
+---
+'myst-frontmatter': patch
+'myst-templates': patch
+'myst-common': patch
+'myst-cli': patch
+'mystmd': patch
+---
+
+Add typst export to CLI

--- a/.changeset/shy-ducks-march.md
+++ b/.changeset/shy-ducks-march.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Write terser bibtex when exporting

--- a/.changeset/tame-donuts-hear.md
+++ b/.changeset/tame-donuts-hear.md
@@ -1,0 +1,6 @@
+---
+'myst-templates': patch
+'jtex': patch
+---
+
+Allow myst template to specify template file name

--- a/package-lock.json
+++ b/package-lock.json
@@ -11485,9 +11485,9 @@
       "link": true
     },
     "node_modules/tex-to-typst": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tex-to-typst/-/tex-to-typst-0.0.3.tgz",
-      "integrity": "sha512-aNR+mi4i/n/O7GiTtElFaklvj4nKyoSlN+gEB55atgQYMnUAI1cjZHXJ0L/r5u/yB3RZdmg9oYx3hrhH+TjdTA==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tex-to-typst/-/tex-to-typst-0.0.4.tgz",
+      "integrity": "sha512-6rHYjSAcHGEea228LuWRg+PEJ3RHIhG6lPLRCU3xS146GuZaqgWB+XlWrT3awvlNLukeC1yl4sic/gc4B9BIoA==",
       "dependencies": {
         "@unified-latex/unified-latex": "^1.4.0",
         "@unified-latex/unified-latex-util-arguments": "^1.4.0",
@@ -14143,7 +14143,7 @@
         "myst-common": "^1.1.10",
         "myst-frontmatter": "^1.1.10",
         "myst-spec-ext": "^1.1.10",
-        "tex-to-typst": "^0.0.3",
+        "tex-to-typst": "^0.0.4",
         "unist-util-select": "^4.0.3",
         "vfile-reporter": "^7.0.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13526,6 +13526,7 @@
         "myst-to-jats": "^1.0.19",
         "myst-to-md": "^1.0.9",
         "myst-to-tex": "^1.0.15",
+        "myst-to-typst": "^0.0.6",
         "myst-transforms": "^1.1.16",
         "nanoid": "^4.0.0",
         "nbtx": "^0.2.3",

--- a/packages/jtex/src/index.ts
+++ b/packages/jtex/src/index.ts
@@ -1,4 +1,4 @@
-export * from './export.js';
-export * from './imports.js';
+export * from './tex/index.js';
+export * from './typst/index.js';
 export * from './jtex.js';
 export * from './types.js';

--- a/packages/jtex/src/jtex.ts
+++ b/packages/jtex/src/jtex.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { extname, dirname } from 'node:path';
 import { TemplateKind } from 'myst-common';
 import type MystTemplate from 'myst-templates';
-import { TEMPLATE_FILENAME } from 'myst-templates';
+import { KIND_TO_EXT } from 'myst-templates';
 import nunjucks from 'nunjucks';
 import { renderImports } from './render.js';
 import type { TexRenderer, TypstTemplateImports, TexTemplateImports } from './types.js';
@@ -29,13 +29,6 @@ function getDefaultEnv(template: MystTemplate) {
     .addFilter('len', (array) => array.length);
   return env;
 }
-
-const KIND_TO_EXT: Record<TemplateKind, string | undefined> = {
-  tex: '.tex',
-  typst: '.typ',
-  docx: undefined,
-  site: undefined,
-};
 
 function commentSymbol(kind: string) {
   if (kind === TemplateKind.typst) return '//';
@@ -97,7 +90,7 @@ export function renderTemplate(
     IMPORTS: importsContent,
   };
   const env = getDefaultEnv(template);
-  const rendered = env.render(TEMPLATE_FILENAME, renderer);
+  const rendered = env.render(template.getTemplateFilename(), renderer);
   const outputDirectory = dirname(opts.outputPath);
   ensureDirectoryExists(outputDirectory);
   template.copyTemplateFiles(dirname(opts.outputPath), { force: opts.force });

--- a/packages/jtex/src/render.ts
+++ b/packages/jtex/src/render.ts
@@ -1,0 +1,18 @@
+import { TemplateKind } from 'myst-common';
+import type { TexTemplateImports, TypstTemplateImports } from './types.js';
+import { renderTexImports } from './tex/imports.js';
+import { renderTypstImports } from './typst/imports.js';
+
+export function renderImports(
+  kind: TemplateKind,
+  output: string,
+  imports?: TexTemplateImports | TypstTemplateImports | undefined,
+  packages?: string[],
+  preamble?: string,
+) {
+  if (kind === TemplateKind.tex) {
+    return renderTexImports(imports as TexTemplateImports, packages, preamble);
+  } else if (kind === TemplateKind.typst) {
+    return renderTypstImports(output, imports as TypstTemplateImports, preamble);
+  }
+}

--- a/packages/jtex/src/tex/export.ts
+++ b/packages/jtex/src/tex/export.ts
@@ -1,7 +1,8 @@
 import path from 'node:path';
 import type MystTemplate from 'myst-templates';
+import { createCommand } from '../utils.js';
 
-export function pdfExportCommand(
+export function pdfTexExportCommand(
   texFile: string,
   logFile: string,
   template?: MystTemplate,
@@ -18,10 +19,4 @@ export function texMakeGlossariesCommand(texFile: string, logFile: string): stri
   const baseCommand = `makeglossaries ${fileNameNoExt}`;
 
   return createCommand(baseCommand, logFile);
-}
-
-function createCommand(baseCommand: string, logFile: string): string {
-  return process.platform === 'win32'
-    ? `${baseCommand} 1> ${logFile} 2>&1`
-    : `${baseCommand} &> ${logFile}`;
 }

--- a/packages/jtex/src/tex/index.ts
+++ b/packages/jtex/src/tex/index.ts
@@ -1,0 +1,2 @@
+export * from './export.js';
+export * from './imports.js';

--- a/packages/jtex/src/types.ts
+++ b/packages/jtex/src/types.ts
@@ -1,7 +1,12 @@
 import type { RendererDoc } from 'myst-templates';
 
-export type TemplateImports = {
+export type TexTemplateImports = {
   imports: string[];
+  commands: Record<string, string>;
+};
+
+export type TypstTemplateImports = {
+  macros: string[];
   commands: Record<string, string>;
 };
 

--- a/packages/jtex/src/typst/export.ts
+++ b/packages/jtex/src/typst/export.ts
@@ -1,0 +1,6 @@
+import { createCommand } from '../utils.js';
+
+export function pdfTypstExportCommand(texFile: string, logFile: string): string {
+  const baseCommand = `typst compile ${texFile}`;
+  return createCommand(baseCommand, logFile);
+}

--- a/packages/jtex/src/typst/imports.ts
+++ b/packages/jtex/src/typst/imports.ts
@@ -1,0 +1,37 @@
+import path from 'node:path';
+import type { TypstTemplateImports } from '../types.js';
+import { writeFileToFolder } from 'myst-cli-utils';
+
+export function renderTypstImports(
+  output: string,
+  templateImports?: TypstTemplateImports,
+  preamble?: string,
+): string {
+  const { macros, commands } = templateImports ?? {};
+  const importStatements: string[] = [];
+  if (macros && macros.length > 0) {
+    const mystTypst = path.join(path.dirname(output), 'myst.typ');
+    importStatements.push('#import "myst.typ": *');
+    writeFileToFolder(mystTypst, macros.join('\n\n'));
+  }
+  importStatements.push('#set math.equation(numbering: "(1)")');
+  if (commands && Object.keys(commands).length > 0) {
+    importStatements.push('', '/* Math Macros */');
+    Object.entries(commands).forEach(([k, v]) => {
+      // Won't work for math with args
+      importStatements.push(`#let ${k} = $${v.trim()}$`);
+    });
+  }
+  if (preamble) importStatements.push(preamble);
+  return importStatements.join('\n');
+}
+
+export function mergeTypstTemplateImports(
+  current?: Partial<TypstTemplateImports>,
+  next?: Partial<TypstTemplateImports>,
+): TypstTemplateImports {
+  return {
+    commands: { ...current?.commands, ...next?.commands },
+    macros: [...new Set([...(current?.macros ?? []), ...(next?.macros ?? [])])],
+  };
+}

--- a/packages/jtex/src/typst/index.ts
+++ b/packages/jtex/src/typst/index.ts
@@ -1,0 +1,2 @@
+export * from './export.js';
+export * from './imports.js';

--- a/packages/jtex/src/utils.ts
+++ b/packages/jtex/src/utils.ts
@@ -1,0 +1,5 @@
+export function createCommand(baseCommand: string, logFile: string): string {
+  return process.platform === 'win32'
+    ? `${baseCommand} 1> ${logFile} 2>&1`
+    : `${baseCommand} &> ${logFile}`;
+}

--- a/packages/jtex/tests/download.spec.ts
+++ b/packages/jtex/tests/download.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import { TemplateKind } from 'myst-common';
 import MystTemplate, { downloadTemplate, resolveInputs, Session } from 'myst-templates';
-import { renderTex } from '../src';
+import { renderTemplate } from '../src';
 
 describe(
   'Download Template',
@@ -26,8 +26,11 @@ describe(
       expect(() => jtex.prepare({} as any)).toThrow(/does not exist/);
     });
     it('Render out the template', async () => {
-      const jtex = new MystTemplate(new Session(), { template: `${__dirname}/example` });
-      renderTex(jtex, {
+      const jtex = new MystTemplate(new Session(), {
+        kind: TemplateKind.tex,
+        template: `${__dirname}/example`,
+      });
+      renderTemplate(jtex, {
         contentOrPath: `${__dirname}/test.tex`,
         outputPath: '_build/out/article.tex',
         frontmatter: {

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -84,6 +84,7 @@
     "myst-to-jats": "^1.0.19",
     "myst-to-md": "^1.0.9",
     "myst-to-tex": "^1.0.15",
+    "myst-to-typst": "^0.0.6",
     "myst-transforms": "^1.1.16",
     "nanoid": "^4.0.0",
     "nbtx": "^0.2.3",

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -16,6 +16,7 @@ export type BuildOpts = {
   docx?: boolean;
   pdf?: boolean;
   tex?: boolean;
+  typst?: boolean;
   xml?: boolean;
   md?: boolean;
   meca?: boolean;
@@ -27,18 +28,19 @@ export type BuildOpts = {
 };
 
 export function hasAnyExplicitExportFormat(opts: BuildOpts): boolean {
-  const { docx, pdf, tex, xml, md, meca } = opts;
-  return docx || pdf || tex || xml || md || meca || false;
+  const { docx, pdf, tex, typst, xml, md, meca } = opts;
+  return docx || pdf || tex || typst || xml || md || meca || false;
 }
 
 export function getExportFormats(opts: BuildOpts & { explicit?: boolean; extension?: string }) {
-  const { docx, pdf, tex, xml, md, meca, all, explicit, extension } = opts;
+  const { docx, pdf, tex, typst, xml, md, meca, all, explicit, extension } = opts;
   const formats = [];
   const any = hasAnyExplicitExportFormat(opts);
   const override = all || (!any && explicit && !extension);
   if (docx || override || extension === '.docx') formats.push(ExportFormats.docx);
   if (pdf || override || extension === '.pdf') formats.push(ExportFormats.pdf);
   if (tex || override || extension === '.tex') formats.push(ExportFormats.tex);
+  if (typst || override || extension === '.typ') formats.push(ExportFormats.typst);
   if (xml || override || extension === '.xml') formats.push(ExportFormats.xml);
   if (md || override || extension === '.md') formats.push(ExportFormats.md);
   if (meca || override) formats.push(ExportFormats.meca);
@@ -46,11 +48,9 @@ export function getExportFormats(opts: BuildOpts & { explicit?: boolean; extensi
 }
 
 export function exportSite(session: ISession, opts: BuildOpts) {
-  const { docx, pdf, tex, xml, md, meca, force, site, html, all } = opts;
+  const { force, site, html, all } = opts;
   const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());
-  return (
-    site || html || all || (siteConfig && !force && !docx && !pdf && !tex && !xml && !md && !meca)
-  );
+  return site || html || all || (siteConfig && !force && !hasAnyExplicitExportFormat(opts));
 }
 
 export function getProjectPaths(session: ISession) {

--- a/packages/myst-cli/src/build/index.ts
+++ b/packages/myst-cli/src/build/index.ts
@@ -9,3 +9,4 @@ export * from './types.js';
 export * from './utils/index.js';
 export * from './html/index.js';
 export * from './meca/index.js';
+export * from './typst.js';

--- a/packages/myst-cli/src/build/pdf/create.ts
+++ b/packages/myst-cli/src/build/pdf/create.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import util from 'util';
 import chalk from 'chalk';
-import { pdfExportCommand, texMakeGlossariesCommand } from 'jtex';
+import { pdfTexExportCommand, texMakeGlossariesCommand } from 'jtex';
 import { exec, tic } from 'myst-cli-utils';
 import { RuleId, TemplateKind, fileError, fileWarn } from 'myst-common';
 import MystTemplate from 'myst-templates';
@@ -271,7 +271,7 @@ async function runPdfBuildCommand(
 
   let buildCommand: string;
   if (!template) {
-    buildCommand = pdfExportCommand(texFile, texLogFile);
+    buildCommand = pdfTexExportCommand(texFile, texLogFile);
   } else {
     const mystTemplate = new MystTemplate(session, {
       kind: TemplateKind.tex,
@@ -284,7 +284,7 @@ async function runPdfBuildCommand(
         fileWarn(vfile, message, { ruleId: RuleId.pdfBuilds });
       },
     });
-    buildCommand = pdfExportCommand(texFile, texLogFile, mystTemplate);
+    buildCommand = pdfTexExportCommand(texFile, texLogFile, mystTemplate);
   }
 
   let buildError = false;

--- a/packages/myst-cli/src/build/typst.ts
+++ b/packages/myst-cli/src/build/typst.ts
@@ -1,0 +1,408 @@
+import AdmZip from 'adm-zip';
+import fs from 'node:fs';
+import path from 'node:path';
+import { tic, writeFileToFolder } from 'myst-cli-utils';
+import type { References, GenericParent } from 'myst-common';
+import { extractPart, RuleId, TemplateKind } from 'myst-common';
+import type { PageFrontmatter } from 'myst-frontmatter';
+import { ExportFormats } from 'myst-frontmatter';
+import type { TemplatePartDefinition, TemplateYml } from 'myst-templates';
+import MystTemplate from 'myst-templates';
+import mystToTypst from 'myst-to-typst';
+import type { TypstResult } from 'myst-to-typst';
+import type { LinkTransformer } from 'myst-transforms';
+import { unified } from 'unified';
+import { selectAll } from 'unist-util-select';
+import { findCurrentProjectAndLoad } from '../config.js';
+import { finalizeMdast } from '../process/mdast.js';
+import { loadProjectFromDisk } from '../project/load.js';
+import { castSession } from '../session/cache.js';
+import type { ISession } from '../session/types.js';
+import { selectors } from '../store/index.js';
+import { ImageExtensions } from '../utils/resolveExtension.js';
+import { logMessagesFromVFile } from '../utils/logMessagesFromVFile.js';
+import { getFileContent } from './utils/getFileContent.js';
+import { addWarningForFile } from '../utils/addWarningForFile.js';
+import { createTempFolder } from '../utils/createTempFolder.js';
+import version from '../version.js';
+import { cleanOutput } from './utils/cleanOutput.js';
+import type { ExportWithOutput, ExportOptions, ExportResults } from './types.js';
+import { collectTexExportOptions } from './utils/collectExportOptions.js';
+import { resolveAndLogErrors } from './utils/resolveAndLogErrors.js';
+
+export const DEFAULT_BIB_FILENAME = 'main.bib';
+const TYPST_IMAGE_EXTENSIONS = [
+  ImageExtensions.pdf,
+  ImageExtensions.png,
+  ImageExtensions.jpg,
+  ImageExtensions.jpeg,
+];
+
+export function mdastToTypst(
+  session: ISession,
+  mdast: GenericParent,
+  references: References,
+  frontmatter: PageFrontmatter,
+  templateYml: TemplateYml | null,
+  printGlossaries: boolean,
+) {
+  const pipe = unified().use(mystToTypst, {
+    math: frontmatter?.math,
+    // citestyle: templateYml?.style?.citation,
+    // bibliography: templateYml?.style?.bibliography,
+    // printGlossaries,
+    // references,
+    // ...frontmatter.settings?.myst_to_tex,
+  });
+  const result = pipe.runSync(mdast as any);
+  const typ = pipe.stringify(result);
+  logMessagesFromVFile(session, typ);
+  return typ.result as TypstResult;
+}
+
+export function extractTypstPart(
+  session: ISession,
+  mdast: GenericParent,
+  references: References,
+  partDefinition: TemplatePartDefinition,
+  frontmatter: PageFrontmatter,
+  templateYml: TemplateYml,
+): TypstResult | TypstResult[] | undefined {
+  const part = extractPart(mdast, partDefinition.id);
+  if (!part) return undefined;
+  if (!partDefinition.as_list) {
+    // Do not build glossaries when extracting parts: references cannot be mapped to definitions
+    return mdastToTypst(session, part, references, frontmatter, templateYml, false);
+  }
+  if (
+    part.children.length === 1 &&
+    part.children[0]?.children?.length === 1 &&
+    part.children[0].children[0].type === 'list'
+  ) {
+    const items = selectAll('listItem', part) as GenericParent[];
+    return items.map((item: GenericParent) => {
+      return mdastToTypst(
+        session,
+        { type: 'root', children: item.children },
+        references,
+        frontmatter,
+        templateYml,
+        false,
+      );
+    });
+  }
+  return part.children.map((block) => {
+    return mdastToTypst(
+      session,
+      { type: 'root', children: [block] },
+      references,
+      frontmatter,
+      templateYml,
+      false,
+    );
+  });
+}
+
+export async function localArticleToTypstRaw(
+  session: ISession,
+  templateOptions: ExportWithOutput,
+  projectPath?: string,
+  extraLinkTransformers?: LinkTransformer[],
+): Promise<ExportResults> {
+  const { articles, output } = templateOptions;
+  const content = await getFileContent(session, articles, {
+    projectPath,
+    imageExtensions: TYPST_IMAGE_EXTENSIONS,
+    extraLinkTransformers,
+  });
+
+  const toc = tic();
+  const results = await Promise.all(
+    content.map(async ({ mdast, frontmatter, references }, ind) => {
+      const article = articles[ind];
+      await finalizeMdast(session, mdast, frontmatter, article, {
+        imageWriteFolder: path.join(path.dirname(output), 'files'),
+        imageAltOutputFolder: 'files/',
+        imageExtensions: TYPST_IMAGE_EXTENSIONS,
+        simplifyFigures: true,
+      });
+      return mdastToTypst(session, mdast, references, frontmatter, null, false);
+    }),
+  );
+  session.log.info(toc(`📑 Exported typst in %s, copying to ${output}`));
+  if (results.length === 1) {
+    writeFileToFolder(output, results[0].value);
+  } else {
+    const { dir, name, ext } = path.parse(output);
+    const includeFileBases = results.map((result, ind) => {
+      const base = `${name}-${content[ind]?.slug ?? ind}${ext}`;
+      const includeFile = path.format({ dir, ext, base });
+      writeFileToFolder(includeFile, result.value);
+      return base;
+    });
+    const includeContent = includeFileBases.map((base) => `\\include{${base}}`).join('\n');
+    writeFileToFolder(output, includeContent);
+  }
+  // TODO: add imports and macros?
+  return { tempFolders: [] };
+}
+
+function writeBibtexFromCitationRenderers(session: ISession, output: string) {
+  const cache = castSession(session);
+  const allBibtexContent = Object.values(cache.$citationRenderers)
+    .map((renderers) => {
+      return Object.values(renderers).map((renderer) => {
+        const bibtexContent = (renderer.cite._graph as any[]).find((item) => {
+          return item.type === '@biblatex/text';
+        });
+        return bibtexContent?.data;
+      });
+    })
+    .flat()
+    .filter((item) => !!item);
+  const bibtexContent = [...new Set(allBibtexContent)].join('\n');
+  if (!fs.existsSync(output)) fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, bibtexContent);
+}
+
+function merge(
+  current?: { macros: string[]; commands: Record<string, string> },
+  next?: { macros: string[]; commands: Record<string, string> },
+): { macros: string[]; commands: Record<string, string> } {
+  return {
+    commands: { ...current?.commands, ...next?.commands },
+    macros: [...new Set([...(current?.macros ?? []), ...(next?.macros ?? [])])],
+  };
+}
+
+export async function localArticleToTypstTemplated(
+  session: ISession,
+  file: string,
+  templateOptions: ExportWithOutput,
+  projectPath?: string,
+  force?: boolean,
+  extraLinkTransformers?: LinkTransformer[],
+): Promise<ExportResults> {
+  const { output, articles, template } = templateOptions;
+  const filesPath = path.join(path.dirname(output), 'files');
+  const content = await getFileContent(session, articles, {
+    projectPath,
+    imageExtensions: TYPST_IMAGE_EXTENSIONS,
+    extraLinkTransformers,
+  });
+  writeBibtexFromCitationRenderers(session, path.join(path.dirname(output), DEFAULT_BIB_FILENAME));
+
+  const warningLogFn = (message: string) => {
+    addWarningForFile(session, file, message, 'warn', {
+      ruleId: RuleId.texRenders,
+    });
+  };
+  const mystTemplate = new MystTemplate(session, {
+    kind: TemplateKind.typst,
+    template: template || undefined,
+    buildDir: session.buildPath(),
+    errorLogFn: (message: string) => {
+      addWarningForFile(session, file, message, 'error', {
+        ruleId: RuleId.texRenders,
+      });
+    },
+    warningLogFn,
+  });
+  await mystTemplate.ensureTemplateExistsOnPath();
+  const toc = tic();
+  const templateYml = mystTemplate.getValidatedTemplateYml();
+  const partDefinitions = templateYml?.parts || [];
+  const parts: Record<string, string | string[]> = {};
+  let collected: { macros: string[]; commands: Record<string, string> } = {
+    macros: [],
+    commands: {},
+  };
+  const hasGlossaries = false;
+  const results = await Promise.all(
+    content.map(async ({ mdast, frontmatter, references }, ind) => {
+      const article = articles[ind];
+      await finalizeMdast(session, mdast, frontmatter, article, {
+        imageWriteFolder: filesPath,
+        imageAltOutputFolder: 'files/',
+        imageExtensions: TYPST_IMAGE_EXTENSIONS,
+        simplifyFigures: true,
+      });
+
+      partDefinitions.forEach((def) => {
+        const part = extractTypstPart(session, mdast, references, def, frontmatter, templateYml);
+        if (part && parts[def.id]) {
+          addWarningForFile(
+            session,
+            file,
+            `multiple values for part '${def.id}' found; ignoring value from ${article}`,
+            'error',
+            { ruleId: RuleId.texRenders },
+          );
+        } else if (Array.isArray(part)) {
+          // This is the case if def.as_list is true
+          part.forEach((item) => {
+            collected = merge(collected, item);
+          });
+          parts[def.id] = part.map(({ value }) => value);
+        } else if (part != null) {
+          collected = merge(collected, part);
+          parts[def.id] = part?.value ?? '';
+        }
+      });
+      const result = mdastToTypst(session, mdast, references, frontmatter, templateYml, true);
+      collected = merge(collected, result);
+      return result;
+    }),
+  );
+
+  let frontmatter: Record<string, any>;
+  let typstContent: string;
+  if (results.length === 1) {
+    frontmatter = content[0].frontmatter;
+    typstContent = results[0].value;
+  } else {
+    const state = session.store.getState();
+    frontmatter = selectors.selectLocalProjectConfig(state, projectPath ?? '.') ?? {};
+    const { dir, name, ext } = path.parse(output);
+    const includeFileBases = results.map((result, ind) => {
+      const base = `${name}-${content[ind]?.slug ?? ind}${ext}`;
+      const includeFile = path.format({ dir, ext, base });
+      writeFileToFolder(includeFile, result.value);
+      return base;
+    });
+    typstContent = includeFileBases.map((base) => `#include "${base}"`).join('\n');
+  }
+  session.log.info(toc(`📑 Exported typst in %s, copying to ${output}`));
+  renderTypst(typstContent, collected.macros, collected.commands, output);
+  return { tempFolders: [], hasGlossaries };
+}
+
+function renderTypst(
+  content: string,
+  macros: string[],
+  commands: Record<string, string>,
+  output: string,
+) {
+  const importStatements: string[] = [];
+  if (macros.length > 0) {
+    const mystTypst = path.join(path.dirname(output), 'myst.typ');
+    importStatements.push('#import "myst.typ": *');
+    writeFileToFolder(mystTypst, macros.join('\n\n'));
+  }
+  importStatements.push('#set math.equation(numbering: "(1)")');
+  if (Object.keys(commands).length > 0) {
+    importStatements.push('', '/* Math Macros */');
+    Object.entries(commands).forEach(([k, v]) => {
+      // Won't work for math with args
+      importStatements.push(`#let ${k} = $${v.trim()}$`);
+    });
+  }
+  const bib = `
+
+
+#show bibliography: set text(8pt)
+#bibliography("${DEFAULT_BIB_FILENAME}", title: text(10pt)[References], style: "ieee")`;
+  const typst = `/* Written by MyST v${version} */\n\n${importStatements.join(
+    '\n',
+  )}\n\n${content}${bib}`;
+  writeFileToFolder(output, typst);
+}
+
+export async function runTypstExport( // DBG: Must return an info on whether glossaries are present
+  session: ISession,
+  file: string,
+  exportOptions: ExportWithOutput,
+  projectPath?: string,
+  clean?: boolean,
+  extraLinkTransformers?: LinkTransformer[],
+): Promise<ExportResults> {
+  if (clean) cleanOutput(session, exportOptions.output);
+  let result: ExportResults;
+  if (exportOptions.template === null) {
+    result = await localArticleToTypstRaw(
+      session,
+      exportOptions,
+      projectPath,
+      extraLinkTransformers,
+    );
+  } else {
+    result = await localArticleToTypstTemplated(
+      session,
+      file,
+      exportOptions,
+      projectPath,
+      clean,
+      extraLinkTransformers,
+    );
+  }
+  return result;
+}
+
+export async function runTypstZipExport(
+  session: ISession,
+  file: string,
+  exportOptions: ExportWithOutput,
+  projectPath?: string,
+  clean?: boolean,
+  extraLinkTransformers?: LinkTransformer[],
+): Promise<ExportResults> {
+  if (clean) cleanOutput(session, exportOptions.output);
+  const zipOutput = exportOptions.output;
+  const texFolder = createTempFolder(session);
+  exportOptions.output = path.join(
+    texFolder,
+    `${path.basename(zipOutput, path.extname(zipOutput))}.tex`,
+  );
+  await runTypstExport(session, file, exportOptions, projectPath, false, extraLinkTransformers);
+  session.log.info(`🤐 Zipping typst outputs to ${zipOutput}`);
+  const zip = new AdmZip();
+  zip.addLocalFolder(texFolder);
+  zip.writeZip(zipOutput);
+  return { tempFolders: [texFolder] };
+}
+
+export async function localArticleToTypst(
+  session: ISession,
+  file: string,
+  opts: ExportOptions,
+  templateOptions?: Record<string, any>,
+  extraLinkTransformers?: LinkTransformer[],
+): Promise<ExportResults> {
+  let { projectPath } = opts;
+  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
+  if (projectPath) await loadProjectFromDisk(session, projectPath);
+  const exportOptionsList = (
+    await collectTexExportOptions(session, file, 'typ', [ExportFormats.tex], projectPath, opts)
+  ).map((exportOptions) => {
+    return { ...exportOptions, ...templateOptions };
+  });
+  const results: ExportResults = { tempFolders: [] };
+  await resolveAndLogErrors(
+    session,
+    exportOptionsList.map(async (exportOptions) => {
+      let exportResults: ExportResults;
+      if (path.extname(exportOptions.output) === '.zip') {
+        exportResults = await runTypstZipExport(
+          session,
+          file,
+          exportOptions,
+          projectPath,
+          opts.clean,
+          extraLinkTransformers,
+        );
+      } else {
+        exportResults = await runTypstExport(
+          session,
+          file,
+          exportOptions,
+          projectPath,
+          opts.clean,
+          extraLinkTransformers,
+        );
+      }
+      results.tempFolders.push(...exportResults.tempFolders);
+    }),
+    opts.throwOnFailure,
+  );
+  return results;
+}

--- a/packages/myst-cli/src/build/utils/bibtex.spec.ts
+++ b/packages/myst-cli/src/build/utils/bibtex.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { extractBibtex } from './bibtex';
+
+describe('extractBibtex', () => {
+  it('no key returns undefined', async () => {
+    expect(extractBibtex('cite-key', 'bad bibtex data')).toEqual(undefined);
+  });
+  it('misformated key returns undefined', async () => {
+    expect(extractBibtex('cite-key', '@article { cite-key }')).toEqual(undefined);
+  });
+  it('minimal entry returns', async () => {
+    expect(extractBibtex('cite-key', '@article{cite-key}')).toEqual('@article{cite-key}');
+  });
+  it('minimal entry returns', async () => {
+    expect(extractBibtex('cite-key', '@article{a}\n@article{cite-key}\n@article{b}')).toEqual(
+      '@article{cite-key}',
+    );
+  });
+  it('entry with nested brackets returns', async () => {
+    expect(
+      extractBibtex(
+        'cite-key',
+        '@article{a}\n@article{cite-key, \n\tabstract = {my abs},\n\ttitle = {test {title}}}\n@article{b}',
+      ),
+    ).toEqual('@article{cite-key, \n\tabstract = {my abs},\n\ttitle = {test {title}}}');
+  });
+  it('entry with mismatched brackets returns undefined', async () => {
+    expect(
+      extractBibtex(
+        'cite-key',
+        '@article{a}\n@article{cite-key, \n\tabstract = {my abs},\n\ttitle = {test {title}}\n@article{b}',
+      ),
+    ).toEqual(undefined);
+  });
+});

--- a/packages/myst-cli/src/build/utils/bibtex.ts
+++ b/packages/myst-cli/src/build/utils/bibtex.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { castSession } from '../../session/cache.js';
+import type { ISession } from '../../session/types.js';
+import { addWarningForFile } from '../../utils/addWarningForFile.js';
+import type { References } from 'myst-common';
+
+/**
+ * Extract a single entry from the entire content of a bibtex file
+ *
+ * Look for the pattern '@article{key' then finds the closing bracket
+ * and returns that substring. The "article" prefix may be any
+ * lowercase alpha word.
+ */
+export function extractBibtex(key: string, bibtex: string) {
+  const match = bibtex.match(new RegExp(`@[a-z]*{${key}`, 'g'));
+  if (!match) return;
+  const start = bibtex.indexOf(match[0]);
+  let bracketCount = 0;
+  let ind = start + match[0].length;
+  while (bibtex[ind] && (bibtex[ind] !== '}' || bracketCount !== 0)) {
+    if (bibtex[ind - 1] && bibtex[ind - 1] !== '\\') {
+      if (bibtex[ind] === '{') bracketCount++;
+      if (bibtex[ind] === '}') bracketCount--;
+    }
+    ind++;
+  }
+  return bibtex[ind] ? bibtex.substring(start, ind + 1) : undefined;
+}
+
+export function writeBibtexFromCitationRenderers(
+  session: ISession,
+  output: string,
+  content: { references: References }[],
+) {
+  const order = content
+    .map(({ references }) => {
+      return references.cite?.order ?? [];
+    })
+    .flat();
+  if (!order.length) return;
+  const cache = castSession(session);
+  const citationLookup: Record<string, string> = {};
+  Object.values(cache.$citationRenderers).forEach((renderers) => {
+    Object.entries(renderers).forEach(([key, renderer]) => {
+      const bibtexContent = (renderer.cite._graph as any[]).find((item) => {
+        return item.type === '@biblatex/text';
+      });
+      if (bibtexContent?.data) {
+        citationLookup[key] = extractBibtex(key, bibtexContent.data) ?? bibtexContent.data;
+      }
+    });
+  });
+  const bibtexContent: string[] = [];
+  order.forEach((key) => {
+    if (bibtexContent.includes(citationLookup[key])) return;
+    if (citationLookup[key]) {
+      bibtexContent.push(citationLookup[key]);
+    }
+    addWarningForFile(session, output, `unknown citation ${key}`);
+  });
+  if (!fs.existsSync(output)) fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, bibtexContent.join('\n'));
+}

--- a/packages/myst-cli/src/build/utils/bibtex.ts
+++ b/packages/myst-cli/src/build/utils/bibtex.ts
@@ -28,6 +28,11 @@ export function extractBibtex(key: string, bibtex: string) {
   return bibtex[ind] ? bibtex.substring(start, ind + 1) : undefined;
 }
 
+/**
+ * Write new bibtex file from citation renderer data and reference order
+ *
+ * Returns true if file was written
+ */
 export function writeBibtexFromCitationRenderers(
   session: ISession,
   output: string,
@@ -38,7 +43,7 @@ export function writeBibtexFromCitationRenderers(
       return references.cite?.order ?? [];
     })
     .flat();
-  if (!order.length) return;
+  if (!order.length) return false;
   const cache = castSession(session);
   const citationLookup: Record<string, string> = {};
   Object.values(cache.$citationRenderers).forEach((renderers) => {
@@ -59,6 +64,8 @@ export function writeBibtexFromCitationRenderers(
     }
     addWarningForFile(session, output, `unknown citation ${key}`);
   });
+  if (!bibtexContent.length) return false;
   if (!fs.existsSync(output)) fs.mkdirSync(path.dirname(output), { recursive: true });
   fs.writeFileSync(output, bibtexContent.join('\n'));
+  return true;
 }

--- a/packages/myst-cli/src/build/utils/bibtex.ts
+++ b/packages/myst-cli/src/build/utils/bibtex.ts
@@ -61,8 +61,9 @@ export function writeBibtexFromCitationRenderers(
     if (bibtexContent.includes(citationLookup[key])) return;
     if (citationLookup[key]) {
       bibtexContent.push(citationLookup[key]);
+    } else {
+      addWarningForFile(session, output, `unknown citation ${key}`);
     }
-    addWarningForFile(session, output, `unknown citation ${key}`);
   });
   if (!bibtexContent.length) return false;
   if (!fs.existsSync(output)) fs.mkdirSync(path.dirname(output), { recursive: true });

--- a/packages/myst-cli/src/build/utils/collectExportOptions.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.ts
@@ -135,7 +135,11 @@ function getOutput(
       session,
       sourceFile,
       projectPath,
-      formats.includes(ExportFormats.tex) ? 'tex' : undefined,
+      formats.includes(ExportFormats.tex)
+        ? 'tex'
+        : formats.includes(ExportFormats.typst)
+        ? 'typ'
+        : undefined,
     );
   }
   if (!path.extname(output)) {
@@ -177,7 +181,8 @@ export async function collectTexExportOptions(
   const resolvedExportOptions: ExportWithOutput[] = filterAndMakeUnique(
     exportOptions.map((exp): ExportWithOutput | undefined => {
       const rawOutput = filename || exp.output || '';
-      const useZip = extension === 'tex' && (zip || path.extname(rawOutput) === '.zip');
+      const useZip =
+        (extension === 'tex' || extension === 'typ') && (zip || path.extname(rawOutput) === '.zip');
       const expExtension = useZip ? 'zip' : extension;
       const output = getOutput(
         session,
@@ -323,6 +328,18 @@ export async function collectExportOptions(
             file,
             'tex',
             [ExportFormats.tex],
+            fileProjectPath,
+            opts,
+          )),
+        );
+      }
+      if (formats.includes(ExportFormats.typst)) {
+        fileExportOptionsList.push(
+          ...(await collectTexExportOptions(
+            session,
+            file,
+            'typ',
+            [ExportFormats.typst],
             fileProjectPath,
             opts,
           )),

--- a/packages/myst-cli/src/build/utils/defaultNames.ts
+++ b/packages/myst-cli/src/build/utils/defaultNames.ts
@@ -30,10 +30,11 @@ export function getDefaultExportFolder(
   session: ISession,
   file: string,
   projectPath?: string,
-  ext?: 'tex',
+  ext?: 'tex' | 'typ',
 ) {
   const subpaths = [projectPath || path.parse(file).dir, '_build', 'exports'];
   // Extra folder for tex export content
   if (ext === 'tex') subpaths.push(`${getDefaultExportFilename(session, file, projectPath)}_tex`);
+  if (ext === 'typ') subpaths.push(`${getDefaultExportFilename(session, file, projectPath)}_typst`);
   return path.join(...subpaths);
 }

--- a/packages/myst-cli/src/build/utils/index.ts
+++ b/packages/myst-cli/src/build/utils/index.ts
@@ -4,3 +4,4 @@ export * from './defaultNames.js';
 export * from './getFileContent.js';
 export * from './localArticleExport.js';
 export * from './resolveAndLogErrors.js';
+export * from './bibtex.js';

--- a/packages/myst-cli/src/build/utils/localArticleExport.ts
+++ b/packages/myst-cli/src/build/utils/localArticleExport.ts
@@ -6,6 +6,7 @@ import type { ISession } from '../../session/index.js';
 import type { ExportOptions, ExportResults, ExportWithInputOutput } from '../types.js';
 import { resolveAndLogErrors } from './resolveAndLogErrors.js';
 import { runTexZipExport, runTexExport } from '../tex/single.js';
+import { runTypstExport, runTypstZipExport } from '../typst.js';
 import { runWordExport } from '../docx/single.js';
 import { runJatsExport } from '../jats/single.js';
 import { texExportOptionsFromPdf } from '../pdf/single.js';
@@ -43,6 +44,24 @@ async function _localArticleExport(
           );
         } else {
           exportResults = await runTexExport(
+            sessionClone,
+            $file,
+            exportOptions,
+            fileProjectPath,
+            clean,
+          );
+        }
+      } else if (format === ExportFormats.typst) {
+        if (path.extname(output) === '.zip') {
+          exportResults = await runTypstZipExport(
+            sessionClone,
+            $file,
+            exportOptions,
+            fileProjectPath,
+            clean,
+          );
+        } else {
+          exportResults = await runTypstExport(
             sessionClone,
             $file,
             exportOptions,

--- a/packages/myst-common/src/templates.ts
+++ b/packages/myst-common/src/templates.ts
@@ -1,5 +1,6 @@
 export enum TemplateKind {
   tex = 'tex',
+  typst = 'typst',
   docx = 'docx',
   site = 'site',
 }

--- a/packages/myst-frontmatter/src/exports/types.ts
+++ b/packages/myst-frontmatter/src/exports/types.ts
@@ -2,6 +2,7 @@ export enum ExportFormats {
   pdf = 'pdf',
   tex = 'tex',
   pdftex = 'pdf+tex',
+  typst = 'typst',
   docx = 'docx',
   xml = 'xml',
   md = 'md',

--- a/packages/myst-templates/src/download.ts
+++ b/packages/myst-templates/src/download.ts
@@ -1,5 +1,5 @@
 import fs, { createWriteStream, mkdirSync } from 'node:fs';
-import { join, parse, sep } from 'node:path';
+import { extname, join, parse, sep } from 'node:path';
 import { createHash } from 'node:crypto';
 import AdmZip from 'adm-zip';
 import { glob } from 'glob';
@@ -10,8 +10,14 @@ import fetch from 'node-fetch';
 import { validateUrl } from 'simple-validators';
 import type { TemplateYmlListResponse, TemplateYmlResponse, ISession } from './types.js';
 
-export const TEMPLATE_FILENAME = 'template.tex';
 export const TEMPLATE_YML = 'template.yml';
+
+export const KIND_TO_EXT: Record<TemplateKind, string | undefined> = {
+  tex: '.tex',
+  typst: '.typ',
+  docx: undefined,
+  site: undefined,
+};
 
 const DEFAULT_TEMPLATES = {
   tex: 'tex/myst/curvenote',
@@ -85,7 +91,10 @@ export function resolveInputs(
   // Handle case where template already exists locally
   if (opts.template && fs.existsSync(opts.template)) {
     const { base, dir } = parse(opts.template);
-    if (base === TEMPLATE_YML || base === TEMPLATE_FILENAME) {
+    if (
+      base === TEMPLATE_YML ||
+      Object.values(KIND_TO_EXT).filter(Boolean).includes(extname(base))
+    ) {
       templatePath = dir;
     } else if (fs.lstatSync(opts.template).isDirectory()) {
       if (fs.existsSync(join(opts.template, TEMPLATE_YML))) {

--- a/packages/myst-templates/src/download.ts
+++ b/packages/myst-templates/src/download.ts
@@ -15,6 +15,7 @@ export const TEMPLATE_YML = 'template.yml';
 
 const DEFAULT_TEMPLATES = {
   tex: 'tex/myst/curvenote',
+  typst: 'typst/myst/default',
   docx: 'docx/myst/default',
   site: 'site/myst/book-theme',
 };

--- a/packages/myst-templates/src/frontmatter.ts
+++ b/packages/myst-templates/src/frontmatter.ts
@@ -87,6 +87,10 @@ export function extendFrontmatter(frontmatter: PageFrontmatter): RendererDoc {
     .map((aff, index) => {
       return { ...aff, value: aff, ...indexAndLetter(index) };
     });
+  const bibtex =
+    frontmatter.bibliography?.length === 1 && frontmatter.bibliography[0].endsWith('.bib')
+      ? frontmatter.bibliography[0]
+      : undefined;
   const doc: RendererDoc = {
     ...frontmatter,
     date: {
@@ -98,6 +102,7 @@ export function extendFrontmatter(frontmatter: PageFrontmatter): RendererDoc {
     affiliations,
     collaborations,
     bibliography: undefinedIfEmpty(frontmatter.bibliography),
+    bibtex,
   };
   return doc;
 }

--- a/packages/myst-templates/src/template.ts
+++ b/packages/myst-templates/src/template.ts
@@ -17,6 +17,7 @@ import {
 
 class MystTemplate {
   session: ISession;
+  kind: TemplateKind;
   templatePath: string;
   templateUrl: string | undefined;
   validatedTemplateYml: TemplateYml | undefined;
@@ -34,8 +35,8 @@ class MystTemplate {
    */
   constructor(
     session: ISession,
-    opts?: {
-      kind?: TemplateKind;
+    opts: {
+      kind: TemplateKind;
       template?: string;
       buildDir?: string;
       errorLogFn?: (message: string) => void;
@@ -50,6 +51,7 @@ class MystTemplate {
     this.errorLogFn = opts?.errorLogFn ?? errorLogger(this.session);
     this.warningLogFn = opts?.warningLogFn ?? warningLogger(this.session);
     this.debugLogFn = opts?.debugLogFn ?? debugLogger(this.session);
+    this.kind = opts.kind;
   }
 
   getTemplateYmlPath() {
@@ -189,7 +191,7 @@ class MystTemplate {
     frontmatter: any;
     parts: any;
     options: any;
-    bibliography?: string[];
+    bibliography?: string;
     outputPath?: string;
     sourceFile?: string;
     filesPath?: string;
@@ -206,7 +208,7 @@ class MystTemplate {
     const docFrontmatter = this.validateDoc(
       opts.frontmatter,
       options,
-      opts.bibliography,
+      opts.bibliography ? [opts.bibliography] : [],
       opts.sourceFile,
     );
     const doc = extendFrontmatter(docFrontmatter);

--- a/packages/myst-templates/src/template.ts
+++ b/packages/myst-templates/src/template.ts
@@ -3,7 +3,7 @@ import { join, dirname } from 'node:path';
 import yaml from 'js-yaml';
 import type { TemplateKind } from 'myst-common';
 import type { ValidationOptions } from 'simple-validators';
-import { downloadTemplate, resolveInputs, TEMPLATE_FILENAME, TEMPLATE_YML } from './download.js';
+import { downloadTemplate, KIND_TO_EXT, resolveInputs, TEMPLATE_YML } from './download.js';
 import { extendFrontmatter } from './frontmatter.js';
 import type { TemplateYml, ISession } from './types.js';
 import { debugLogger, errorLogger, warningLogger } from './utils.js';
@@ -14,6 +14,8 @@ import {
   validateTemplateParts,
   validateTemplateYml,
 } from './validators.js';
+
+const TEMPLATE_FILENAME_BASE = 'template';
 
 class MystTemplate {
   session: ISession;
@@ -87,6 +89,11 @@ class MystTemplate {
       this.validatedTemplateYml = templateYml;
     }
     return this.validatedTemplateYml;
+  }
+
+  getTemplateFilename() {
+    const templateYml = this.getValidatedTemplateYml();
+    return templateYml.template ?? `${TEMPLATE_FILENAME_BASE}${KIND_TO_EXT[this.kind]}`;
   }
 
   validateOptions(options: any, file?: string, fileOpts?: FileOptions) {
@@ -218,7 +225,7 @@ class MystTemplate {
   copyTemplateFiles(outputDir: string, opts?: { force?: boolean }) {
     const templateYml = this.getValidatedTemplateYml();
     templateYml.files?.forEach((file) => {
-      if (file === TEMPLATE_FILENAME) return;
+      if (file === this.getTemplateFilename()) return;
       const source = join(this.templatePath, ...file.split('/'));
       const dest = join(outputDir, ...file.split('/'));
       if (fs.existsSync(dest)) {

--- a/packages/myst-templates/src/types.ts
+++ b/packages/myst-templates/src/types.ts
@@ -108,6 +108,7 @@ type TemplateYmlPartial = {
   options?: TemplateOptionDefinition[];
   packages?: string[];
   files?: string[];
+  template?: string;
 };
 
 type TemplateYmlIdLinks = {

--- a/packages/myst-templates/src/types.ts
+++ b/packages/myst-templates/src/types.ts
@@ -39,6 +39,7 @@ export type RendererDoc = Omit<
   authors: RendererAuthor[];
   affiliations: ValueAndIndex[];
   collaborations: ValueAndIndex[];
+  bibtex?: string;
 };
 
 export const RENDERER_DOC_KEYS = ['affiliations', 'collaborations'].concat(PAGE_FRONTMATTER_KEYS);

--- a/packages/myst-to-typst/package.json
+++ b/packages/myst-to-typst/package.json
@@ -40,7 +40,7 @@
     "myst-common": "^1.1.10",
     "myst-frontmatter": "^1.1.10",
     "myst-spec-ext": "^1.1.10",
-    "tex-to-typst": "^0.0.3",
+    "tex-to-typst": "^0.0.4",
     "unist-util-select": "^4.0.3",
     "vfile-reporter": "^7.0.4"
   }

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -255,7 +255,7 @@ const handlers: Record<string, Handler> = {
   },
   cite(node, state, parent) {
     if (parent.type === 'citeGroup') {
-      state.write(`"${node.label}"`);
+      state.write(`<${node.label}>`);
     } else {
       state.write(`@${node.label}`);
     }

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -249,16 +249,10 @@ const handlers: Record<string, Handler> = {
     state.write(`@${id}`);
   },
   citeGroup(node, state) {
-    state.write('#cite(');
-    state.renderChildren(node, true, ', ');
-    state.write(')');
+    state.renderChildren(node, true, ' ');
   },
-  cite(node, state, parent) {
-    if (parent.type === 'citeGroup') {
-      state.write(`<${node.label}>`);
-    } else {
-      state.write(`@${node.label}`);
-    }
+  cite(node, state) {
+    state.write(`@${node.label}`);
   },
   embed(node, state) {
     state.renderChildren(node, true);

--- a/packages/myst-to-typst/tests/cite.yml
+++ b/packages/myst-to-typst/tests/cite.yml
@@ -23,4 +23,4 @@ cases:
                 - type: cite
                   label: jon85
     typst: |-
-      #cite("cockett2015", "jon85")
+      #cite(<cockett2015>, <jon85>)

--- a/packages/myst-to-typst/tests/cite.yml
+++ b/packages/myst-to-typst/tests/cite.yml
@@ -23,4 +23,4 @@ cases:
                 - type: cite
                   label: jon85
     typst: |-
-      #cite(<cockett2015>, <jon85>)
+      @cockett2015 @jon85

--- a/packages/mystmd/src/build.ts
+++ b/packages/mystmd/src/build.ts
@@ -15,6 +15,7 @@ import {
   makeHtmlOption,
   makeMecaOptions,
   makeMdOption,
+  makeTypstOption,
 } from './options.js';
 
 export function makeBuildCLI(program: Command) {
@@ -23,6 +24,7 @@ export function makeBuildCLI(program: Command) {
     .argument('[files...]', 'list of files to export')
     .addOption(makePdfOption('Build PDF output'))
     .addOption(makeTexOption('Build LaTeX outputs'))
+    .addOption(makeTypstOption('Build Typst outputs'))
     .addOption(makeDocxOption('Build Docx output'))
     .addOption(makeMdOption('Build MD output'))
     .addOption(makeJatsOption('Build JATS xml output'))

--- a/packages/mystmd/src/clean.ts
+++ b/packages/mystmd/src/clean.ts
@@ -11,6 +11,7 @@ import {
   makePdfOption,
   makeSiteOption,
   makeTexOption,
+  makeTypstOption,
   makeYesOption,
 } from './options.js';
 
@@ -41,6 +42,7 @@ export function makeCleanCLI(program: Command) {
     .argument('[files...]', 'list of files to clean corresponding outputs')
     .addOption(makePdfOption('Clean PDF output'))
     .addOption(makeTexOption('Clean LaTeX outputs'))
+    .addOption(makeTypstOption('Clean typst output'))
     .addOption(makeDocxOption('Clean Docx output'))
     .addOption(makeMdOption('Clean MD output'))
     .addOption(makeJatsOption('Clean JATS xml output'))

--- a/packages/mystmd/src/options.ts
+++ b/packages/mystmd/src/options.ts
@@ -14,6 +14,10 @@ export function makeTexOption(description: string) {
   return new Option('--tex', description).default(false);
 }
 
+export function makeTypstOption(description: string) {
+  return new Option('--typst', description).default(false);
+}
+
 export function makeDocxOption(description: string) {
   return new Option('--word, --docx', description).default(false);
 }


### PR DESCRIPTION
We should maybe consider renaming `jtex` -> `myst-render` or something? It is basically just an extension of `myst-templates` now, with an extra dependency or two.

This also has some improvements to bibtex rendering, which apply to tex and typst:
- when mystmd writes a new bibtex file, it attempts to only write the citations used in the article
- if no citations are present, this is passed to the template renderer, so we can avoid empty references sections