### PR TITLE
🔦 Revive `beamer` option as `myst_to_tex` setting

### DIFF
--- a/.changeset/dry-parents-sit.md
+++ b/.changeset/dry-parents-sit.md
@@ -1,0 +1,6 @@
+---
+'myst-frontmatter': patch
+'myst-to-tex': patch
+---
+
+Move beamer option to myst_to_tex settings

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -45,3 +45,10 @@ code_style
     - `"verbatim"` (default): Use the `\begin{verbatim}` environment
     - `"minted"`: Use the `\begin{minted}` environment with the language of the code block used
     - `"listings"`: Use the `\begin{listings}` environment with the language of the code block used
+
+(setting:myst_to_tex:beamer)=
+beamer
+: Indicate you are building a beamer presentation.
+
+    - `true`: Add `\begin{frame}` environment for each block, delimited by `+++`, and enable presentation outline with block metadata `+++ {"outline":true}`
+    - `false` (default): No extra `\begin{frame}` environment will be used

--- a/packages/myst-frontmatter/src/settings/mystToTex.yml
+++ b/packages/myst-frontmatter/src/settings/mystToTex.yml
@@ -25,3 +25,28 @@ cases:
           code_style: unknown
     errors: 1
     normalized: {}
+  - title: beamer true
+    raw:
+      settings:
+        mystToTex:
+          beamer: true
+    normalized:
+      settings:
+        myst_to_tex:
+          beamer: true
+  - title: beamer false
+    raw:
+      settings:
+        mystToTex:
+          beamer: false
+    normalized:
+      settings:
+        myst_to_tex:
+          beamer: false
+  - title: beamer invalid
+    raw:
+      settings:
+        mystToTex:
+          beamer: invalid
+    errors: 1
+    normalized: {}

--- a/packages/myst-frontmatter/src/settings/types.ts
+++ b/packages/myst-frontmatter/src/settings/types.ts
@@ -2,6 +2,7 @@ type OutputRemovalOptions = 'show' | 'remove' | 'remove-warn' | 'remove-error' |
 
 export type MystToTexSettings = {
   codeStyle?: 'verbatim' | 'minted' | 'listings';
+  beamer?: boolean;
 };
 
 export type ProjectSettings = {

--- a/packages/myst-frontmatter/src/settings/validatorsMystToTex.ts
+++ b/packages/myst-frontmatter/src/settings/validatorsMystToTex.ts
@@ -1,8 +1,14 @@
 import type { ValidationOptions } from 'simple-validators';
-import { defined, incrementOptions, validateChoice, validateObjectKeys } from 'simple-validators';
+import {
+  defined,
+  incrementOptions,
+  validateBoolean,
+  validateChoice,
+  validateObjectKeys,
+} from 'simple-validators';
 import type { MystToTexSettings } from './types.js';
 
-export const MYST_TO_TEX_SETTINGS = ['codeStyle'];
+export const MYST_TO_TEX_SETTINGS = ['codeStyle', 'beamer'];
 export const MYST_TO_TEX_SETTINGS_ALIAS = {
   code_style: 'codeStyle',
 };
@@ -24,6 +30,9 @@ export function validateMystToTexSettings(
       choices: ['verbatim', 'minted', 'listings'],
     });
     if (codeStyle) output.codeStyle = codeStyle;
+  }
+  if (defined(settings.beamer)) {
+    output.beamer = validateBoolean(settings.beamer, incrementOptions('beamer', opts));
   }
   // if (defined(settings.printGlossaries)) {
   //   const printGlossaries = validateBoolean(

--- a/packages/myst-frontmatter/src/settings/validatorsMystToTex.ts
+++ b/packages/myst-frontmatter/src/settings/validatorsMystToTex.ts
@@ -32,7 +32,8 @@ export function validateMystToTexSettings(
     if (codeStyle) output.codeStyle = codeStyle;
   }
   if (defined(settings.beamer)) {
-    output.beamer = validateBoolean(settings.beamer, incrementOptions('beamer', opts));
+    const beamer = validateBoolean(settings.beamer, incrementOptions('beamer', opts));
+    if (beamer != null) output.beamer = beamer;
   }
   // if (defined(settings.printGlossaries)) {
   //   const printGlossaries = validateBoolean(

--- a/packages/myst-to-tex/src/types.ts
+++ b/packages/myst-to-tex/src/types.ts
@@ -26,7 +26,6 @@ export type MathPlugins = Required<PageFrontmatter>['math'];
 
 export type Options = MystToTexSettings & {
   handlers?: Record<string, Handler>;
-  beamer?: boolean;
   math?: MathPlugins;
   bibliography?: 'natbib' | 'biblatex';
   printGlossaries?: boolean;


### PR DESCRIPTION
Passing `beamer: true` to `myst-to-tex` will cause blocks to be converted into tex `\begin{frame}` environments. You can also define a presentation outline, as described here: https://mystmd.org/jtex/create-a-beamer-template

This PR adds `beamer` to `myst_to_tex.settings` so it may be used directly from the MyST CLI, with frontmatter:

```yaml
settings:
  myst_to_tex:
    beamer: true
```

This feature is still in development, and there are no official beamer templates - but there has been some work started here: https://github.com/executablebooks/mystmd/issues/97