### PR TITLE
🐛 Fix error when article is not defined on meca export

### DIFF
--- a/.changeset/giant-cameras-cry.md
+++ b/.changeset/giant-cameras-cry.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fix error when article is not defined on meca export

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -157,7 +157,7 @@ export async function runMecaExport(
   const toc = tic();
   const { output, articles } = exportOptions;
   // At this point, export options are resolved to contain zero or one articles
-  const article = articles[0];
+  const article = articles?.[0];
   const vfile = new VFile();
   vfile.path = output;
   const fileCopyErrorLogFn = (m: string) => {


### PR DESCRIPTION
Addresses #802 - this bug was introduced when multiple `articles` were allowed on an export. 