### PR TITLE
🐛 Pass projectPath to loadFile whenever possible

### DIFF
--- a/.changeset/forty-donkeys-care.md
+++ b/.changeset/forty-donkeys-care.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Pass projectPath to loadFile whenever possible

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -109,7 +109,7 @@ async function copyDependentFiles(
 ) {
   const cache = castSession(session);
   if (!cache.$getMdast(sourceFile)) {
-    await loadFile(session, sourceFile);
+    await loadFile(session, sourceFile, projectPath);
   }
   const pre = cache.$getMdast(sourceFile)?.pre;
   if (!pre) return;

--- a/packages/myst-cli/src/build/utils/collectExportOptions.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.ts
@@ -31,7 +31,7 @@ async function prepareExportOptions(
   if (projectPath && sourceFile === selectors.selectLocalConfigFile(state, projectPath)) {
     rawFrontmatter = selectors.selectLocalProjectConfig(state, projectPath);
   } else {
-    rawFrontmatter = await getRawFrontmatterFromFile(session, sourceFile);
+    rawFrontmatter = await getRawFrontmatterFromFile(session, sourceFile, projectPath);
   }
   let exportOptions = getExportListFromRawFrontmatter(session, formats, rawFrontmatter, sourceFile);
   // If no export options are provided in frontmatter, instantiate default options

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -81,9 +81,13 @@ export function prepareToWrite(frontmatter: { license?: Licenses }) {
   return { ...frontmatter, license: licensesToString(frontmatter.license) };
 }
 
-export async function getRawFrontmatterFromFile(session: ISession, file: string) {
+export async function getRawFrontmatterFromFile(
+  session: ISession,
+  file: string,
+  projectPath?: string,
+) {
   const cache = castSession(session);
-  if (!cache.$getMdast(file)) await loadFile(session, file);
+  if (!cache.$getMdast(file)) await loadFile(session, file, projectPath);
   const result = cache.$getMdast(file);
   if (!result || !result.pre) return undefined;
   const vfile = new VFile();


### PR DESCRIPTION
`loadFile` expects a project path in order to resolve its relative location. There were a few places where `loadFile` was called without `projectPath`, allowing full paths into the file metadata...