### PR TITLE
🐛 Prevent undefined children in myst-roles

### DIFF
--- a/.changeset/eleven-melons-cry.md
+++ b/.changeset/eleven-melons-cry.md
@@ -1,0 +1,5 @@
+---
+'myst-roles': patch
+---
+
+Prevent undefined children in myst-roles

--- a/packages/myst-roles/src/doc.ts
+++ b/packages/myst-roles/src/doc.ts
@@ -1,4 +1,4 @@
-import type { RoleSpec } from 'myst-common';
+import type { GenericNode, RoleSpec } from 'myst-common';
 import { fileWarn, RuleId } from 'myst-common';
 
 const REF_PATTERN = /^(.+?)<([^<>]+)>$/; // e.g. 'Labeled Document <doc>'
@@ -23,12 +23,8 @@ export const docRole: RoleSpec = {
         ruleId: RuleId.roleBodyCorrect,
       },
     );
-    return [
-      {
-        type: 'link',
-        url,
-        children: modified ? [{ type: 'text', value: modified.trim() }] : undefined,
-      },
-    ];
+    const link: GenericNode = { type: 'link', url };
+    if (modified) link.children = [{ type: 'text', value: modified.trim() }];
+    return [link];
   },
 };

--- a/packages/myst-roles/src/download.ts
+++ b/packages/myst-roles/src/download.ts
@@ -1,4 +1,4 @@
-import type { RoleSpec } from 'myst-common';
+import type { GenericNode, RoleSpec } from 'myst-common';
 
 const REF_PATTERN = /^(.+?)<([^<>]+)>$/; // e.g. 'Labeled Download <file.zip>'
 
@@ -13,13 +13,12 @@ export const downloadRole: RoleSpec = {
     const match = REF_PATTERN.exec(body);
     const [, modified, rawLabel] = match ?? [];
     const url = rawLabel ?? body;
-    return [
-      {
-        type: 'link',
-        url,
-        children: modified ? [{ type: 'text', value: modified.trim() }] : undefined,
-        static: true, // Indicate that this should be treated as a static download
-      },
-    ];
+    const link: GenericNode = {
+      type: 'link',
+      url,
+      static: true, // Indicate that this should be treated as a static download
+    };
+    if (modified) link.children = [{ type: 'text', value: modified.trim() }];
+    return [link];
   },
 };

--- a/packages/myst-roles/src/reference.ts
+++ b/packages/myst-roles/src/reference.ts
@@ -15,14 +15,8 @@ export const refRole: RoleSpec = {
     const match = REF_PATTERN.exec(body);
     const [, modified, rawLabel] = match ?? [];
     const { label, identifier } = normalizeLabel(rawLabel ?? body) || {};
-    return [
-      {
-        type: 'crossReference',
-        kind: data.name,
-        identifier,
-        label,
-        children: modified ? [{ type: 'text', value: modified.trim() }] : undefined,
-      },
-    ];
+    const crossRef: GenericNode = { type: 'crossReference', kind: data.name, identifier, label };
+    if (modified) crossRef.children = [{ type: 'text', value: modified.trim() }];
+    return [crossRef];
   },
 };

--- a/packages/myst-roles/src/term.ts
+++ b/packages/myst-roles/src/term.ts
@@ -1,4 +1,4 @@
-import type { RoleSpec } from 'myst-common';
+import type { GenericNode, RoleSpec } from 'myst-common';
 import { fileWarn, normalizeLabel, RuleId } from 'myst-common';
 
 const REF_PATTERN = /^(.+?)<([^<>]+)>$/; // e.g. 'Labeled Term <term>'
@@ -21,13 +21,12 @@ export const termRole: RoleSpec = {
         ruleId: RuleId.roleBodyCorrect,
       });
     }
-    return [
-      {
-        type: 'crossReference',
-        label,
-        identifier: `term-${identifier}`,
-        children: modified ? [{ type: 'text', value: modified.trim() }] : undefined,
-      },
-    ];
+    const crossRef: GenericNode = {
+      type: 'crossReference',
+      label,
+      identifier: `term-${identifier}`,
+    };
+    if (modified) crossRef.children = [{ type: 'text', value: modified.trim() }];
+    return [crossRef];
   },
 };


### PR DESCRIPTION
This fixes the bug here: https://github.com/executablebooks/mystmd/issues/807

Some unist operations have trouble with `children: undefined` (as opposed to the `children` key just not existing).