### PR TITLE
🏗 Add watch to build command

### DIFF
--- a/.changeset/brown-suits-serve.md
+++ b/.changeset/brown-suits-serve.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'mystmd': patch
+---
+
+Add watch to build command

--- a/.changeset/gorgeous-books-sip.md
+++ b/.changeset/gorgeous-books-sip.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Infer export format from output file

--- a/.changeset/metal-wolves-arrive.md
+++ b/.changeset/metal-wolves-arrive.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Watch dependency files during myst start and build

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -23,6 +23,7 @@ export type BuildOpts = {
   html?: boolean;
   all?: boolean;
   force?: boolean;
+  watch?: boolean;
   output?: string;
   checkLinks?: boolean;
 };
@@ -127,7 +128,7 @@ function extToKind(ext: string): string {
 }
 
 export async function build(session: ISession, files: string[], opts: BuildOpts) {
-  const { site, all } = opts;
+  const { site, all, watch } = opts;
   const performSiteBuild = all || (files.length === 0 && exportSite(session, opts));
   const exportOptionsList = await collectAllBuildExportOptions(session, files, opts);
   const exportLogList = exportOptionsList.map((exportOptions) => {
@@ -164,7 +165,7 @@ export async function build(session: ISession, files: string[], opts: BuildOpts)
     }
   } else {
     session.log.info(`📬 Performing exports:\n   ${exportLogList.join('\n   ')}`);
-    await localArticleExport(session, exportOptionsList, {});
+    await localArticleExport(session, exportOptionsList, { watch });
   }
   if (!performSiteBuild) return;
   const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());
@@ -173,6 +174,9 @@ export async function build(session: ISession, files: string[], opts: BuildOpts)
     session.log.debug(`To build a site, first run 'myst init --site'`);
   } else {
     session.log.info(`🌎 Building MyST site`);
+    if (watch) {
+      session.log.warn(`Site content will not be watched and updated; use 'myst start' instead`);
+    }
     if (opts.html) {
       await buildHtml(session, opts);
     } else {

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -20,6 +20,7 @@ import { resolveAndLogErrors } from '../utils/resolveAndLogErrors.js';
 
 export async function runJatsExport(
   session: ISession,
+  sourceFile: string,
   exportOptions: ExportWithOutput,
   projectPath?: string,
   clean?: boolean,
@@ -81,6 +82,7 @@ export async function runJatsExport(
   logMessagesFromVFile(session, jats);
   session.log.info(toc(`📑 Exported JATS in %s, copying to ${output}`));
   writeFileToFolder(output, jats.result as string);
+  return { tempFolders: [] };
 }
 
 export async function localArticleToJats(
@@ -101,7 +103,14 @@ export async function localArticleToJats(
   await resolveAndLogErrors(
     session,
     exportOptionsList.map(async (exportOptions) => {
-      await runJatsExport(session, exportOptions, projectPath, opts.clean, extraLinkTransformers);
+      await runJatsExport(
+        session,
+        file,
+        exportOptions,
+        projectPath,
+        opts.clean,
+        extraLinkTransformers,
+      );
     }),
     opts.throwOnFailure,
   );

--- a/packages/myst-cli/src/build/md/index.ts
+++ b/packages/myst-cli/src/build/md/index.ts
@@ -18,6 +18,7 @@ import { getFileContent } from '../utils/getFileContent.js';
 
 export async function runMdExport(
   session: ISession,
+  sourceFile: string,
   exportOptions: ExportWithOutput,
   projectPath?: string,
   clean?: boolean,
@@ -47,6 +48,7 @@ export async function runMdExport(
   logMessagesFromVFile(session, mdOut);
   session.log.info(toc(`📑 Exported MD in %s, copying to ${output}`));
   writeFileToFolder(output, mdOut.result as string);
+  return { tempFolders: [] };
 }
 
 export async function localArticleToMd(
@@ -67,7 +69,14 @@ export async function localArticleToMd(
   await resolveAndLogErrors(
     session,
     exportOptionsList.map(async (exportOptions) => {
-      await runMdExport(session, exportOptions, projectPath, opts.clean, extraLinkTransformers);
+      await runMdExport(
+        session,
+        file,
+        exportOptions,
+        projectPath,
+        opts.clean,
+        extraLinkTransformers,
+      );
     }),
     opts.throwOnFailure,
   );

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -149,6 +149,7 @@ function writeMecaManifest(manifestItems: ManifestItem[], mecaFolder: string) {
  */
 export async function runMecaExport(
   session: ISession,
+  sourceFile: string,
   exportOptions: ExportWithOutput,
   projectPath?: string,
   clean?: boolean,
@@ -179,6 +180,7 @@ export async function runMecaExport(
     const jatsOutput = path.join(mecaFolder, 'article.xml');
     await runJatsExport(
       session,
+      sourceFile,
       { ...exportOptions, output: jatsOutput },
       projectPath,
       clean,
@@ -227,10 +229,10 @@ export async function runMecaExport(
     const jatsFiles = path.join(path.dirname(jatsOutput), 'files');
     if (fs.existsSync(jatsFiles)) {
       fs.readdirSync(jatsFiles).forEach((file) => {
-        const sourceFile = path.join(jatsFiles, file);
+        const src = path.join(jatsFiles, file);
         const fileDest = copyFileToFolder(
           session,
-          sourceFile,
+          src,
           path.join(mecaFolder, 'files'),
           fileCopyErrorLogFn,
         );
@@ -355,6 +357,7 @@ export async function runMecaExport(
   zip.writeZip(output);
   logMessagesFromVFile(session, vfile);
   session.log.info(toc(`🤐 MECA output copied and zipped to ${output} in %s`));
+  return { tempFolders: [] };
 }
 
 export async function localProjectToMeca(
@@ -375,7 +378,14 @@ export async function localProjectToMeca(
   await resolveAndLogErrors(
     session,
     exportOptionsList.map(async (exportOptions) => {
-      await runMecaExport(session, exportOptions, projectPath, opts.clean, extraLinkTransformers);
+      await runMecaExport(
+        session,
+        file,
+        exportOptions,
+        projectPath,
+        opts.clean,
+        extraLinkTransformers,
+      );
     }),
     opts.throwOnFailure,
   );

--- a/packages/myst-cli/src/build/types.ts
+++ b/packages/myst-cli/src/build/types.ts
@@ -26,6 +26,7 @@ export type ExportOptions = {
   zip?: boolean;
   force?: boolean;
   projectPath?: string;
+  watch?: boolean;
   throwOnFailure?: boolean;
   renderer?: (
     session: ISession,

--- a/packages/myst-cli/src/build/types.ts
+++ b/packages/myst-cli/src/build/types.ts
@@ -1,6 +1,7 @@
 import type { File } from 'docx';
 import type { Export } from 'myst-frontmatter';
 import type { RendererDoc } from 'myst-templates';
+import type { LinkTransformer } from 'myst-transforms';
 import type { VFile } from 'vfile';
 import type { ISession } from '../session/types.js';
 import type { RendererData } from '../transforms/types.js';
@@ -41,3 +42,12 @@ export type ExportResults = {
   tempFolders: string[];
   hasGlossaries?: boolean;
 };
+
+export type ExportFn = (
+  session: ISession,
+  file: string,
+  exportOptions: ExportWithOutput,
+  projectPath?: string,
+  clean?: boolean,
+  extraLinkTransformers?: LinkTransformer[],
+) => Promise<ExportResults>;

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -297,7 +297,7 @@ export async function postProcessMdast(
     selector: LINKS_SELECTOR,
   });
   resolveReferencesTransform(mdast, state.file as VFile, { state });
-  embedTransform(session, mdast, dependencies, state);
+  embedTransform(session, mdast, file, dependencies, state);
   const pipe = unified();
   session.plugins?.transforms.forEach((t) => {
     if (t.stage !== 'project') return;

--- a/packages/myst-cli/src/store/reducers.ts
+++ b/packages/myst-cli/src/store/reducers.ts
@@ -87,6 +87,7 @@ type WatchedFile = {
   sha256?: string | null;
   url?: string | null;
   dataUrl?: string | null;
+  localDependencies?: string[] | null;
 };
 
 export const watch = createSlice({
@@ -106,6 +107,13 @@ export const watch = createSlice({
     markFileChanged(state, action: PayloadAction<{ path: string; sha256?: string }>) {
       const { path, sha256 = null } = action.payload;
       state.files[resolve(path)] = { ...state.files[resolve(path)], sha256 };
+    },
+    addLocalDependency(state, action: PayloadAction<{ path: string; dependency: string }>) {
+      const { path, dependency } = action.payload;
+      const existingDeps = [...(state.files[resolve(path)].localDependencies ?? [])];
+      if (!existingDeps.includes(dependency)) {
+        state.files[resolve(path)].localDependencies = [...existingDeps, dependency];
+      }
     },
     updateFileInfo(
       state,

--- a/packages/myst-cli/src/store/selectors.ts
+++ b/packages/myst-cli/src/store/selectors.ts
@@ -105,6 +105,27 @@ export function selectFileInfo(state: RootState, path: string) {
   };
 }
 
+export function selectFileDependencies(state: RootState, path: string): string[] {
+  return state.local.watch.files[resolve(path)]?.localDependencies ?? [];
+}
+
+export function selectAllDependencies(state: RootState, projectPath?: string): string[] {
+  return Object.entries(state.local.watch.files)
+    .filter(([file]) => !projectPath || file.startsWith(resolve(projectPath)))
+    .map(([, value]) => value.localDependencies ?? [])
+    .flat();
+}
+
+export function selectDependentFiles(state: RootState, path: string): string[] {
+  const dependentFiles: string[] = [];
+  Object.entries(state.local.watch.files).forEach(([key, value]) => {
+    if (value.localDependencies?.includes(resolve(path))) {
+      dependentFiles.push(key);
+    }
+  });
+  return dependentFiles;
+}
+
 export function selectPageSlug(
   state: RootState,
   projectPath: string,

--- a/packages/myst-cli/src/transforms/include.ts
+++ b/packages/myst-cli/src/transforms/include.ts
@@ -6,6 +6,7 @@ import { includeDirectiveTransform } from 'myst-transforms';
 import type { VFile } from 'vfile';
 import { parseMyst } from '../process/myst.js';
 import type { ISession } from '../session/types.js';
+import { watch } from '../store/reducers.js';
 
 export async function includeFilesTransform(
   session: ISession,
@@ -22,6 +23,12 @@ export async function includeFilesTransform(
       });
       return;
     }
+    session.store.dispatch(
+      watch.actions.addLocalDependency({
+        path: baseFile,
+        dependency: fullFile,
+      }),
+    );
     return fs.readFileSync(fullFile).toString();
   };
   const parseContent = (filename: string, content: string) => {

--- a/packages/myst-frontmatter/src/exports/exports.yml
+++ b/packages/myst-frontmatter/src/exports/exports.yml
@@ -279,13 +279,13 @@ cases:
       exports:
         - format: pdf
           output: out.pdf
-  - title: export with only template validates
-    raw:
-      exports:
-        - template: template
-    normalized:
-      exports:
-        - template: template
+  # - title: export with only template validates
+  #   raw:
+  #     exports:
+  #       - template: template
+  #   normalized:
+  #     exports:
+  #       - template: template
   - title: unknown output errors
     raw:
       exports:

--- a/packages/myst-frontmatter/src/exports/exports.yml
+++ b/packages/myst-frontmatter/src/exports/exports.yml
@@ -256,3 +256,39 @@ cases:
           articles:
             - a.md
     errors: 3
+  - title: pdf filename coerces to format and output
+    raw:
+      exports:
+        - out.pdf
+    normalized:
+      exports:
+        - format: pdf
+          output: out.pdf
+  - title: pdf extension coerces to format
+    raw:
+      exports:
+        - .pdf
+    normalized:
+      exports:
+        - format: pdf
+  - title: pdf output adds format
+    raw:
+      exports:
+        - output: out.pdf
+    normalized:
+      exports:
+        - format: pdf
+          output: out.pdf
+  - title: export with only template validates
+    raw:
+      exports:
+        - template: template
+    normalized:
+      exports:
+        - template: template
+  - title: unknown output errors
+    raw:
+      exports:
+        - output: out.bad
+    normalized: {}
+    errors: 1

--- a/packages/myst-frontmatter/src/exports/types.ts
+++ b/packages/myst-frontmatter/src/exports/types.ts
@@ -10,7 +10,7 @@ export enum ExportFormats {
 }
 
 export type Export = {
-  format: ExportFormats;
+  format?: ExportFormats;
   template?: string | null;
   output?: string;
   articles?: string[];

--- a/packages/myst-frontmatter/src/exports/types.ts
+++ b/packages/myst-frontmatter/src/exports/types.ts
@@ -10,7 +10,7 @@ export enum ExportFormats {
 }
 
 export type Export = {
-  format?: ExportFormats;
+  format: ExportFormats; // TODO: Optional if template is defined
   template?: string | null;
   output?: string;
   articles?: string[];

--- a/packages/myst-frontmatter/src/exports/validators.ts
+++ b/packages/myst-frontmatter/src/exports/validators.ts
@@ -12,12 +12,26 @@ import type { Export } from './types.js';
 import { ExportFormats } from './types.js';
 
 const EXPORT_KEY_OBJECT = {
-  required: ['format'],
-  optional: ['template', 'output', 'id', 'name', 'renderer', 'articles', 'sub_articles'],
+  required: [],
+  optional: ['format', 'template', 'output', 'id', 'name', 'renderer', 'articles', 'sub_articles'],
   alias: {
     article: 'articles',
     sub_article: 'sub_articles',
   },
+};
+
+const EXT_TO_FORMAT = {
+  '.pdf': ExportFormats.pdf,
+  '.tex': ExportFormats.tex,
+  '.doc': ExportFormats.docx,
+  '.docx': ExportFormats.docx,
+  '.md': ExportFormats.md,
+  '.zip': ExportFormats.meca,
+  '.meca': ExportFormats.meca,
+  '.xml': ExportFormats.xml,
+  '.jats': ExportFormats.xml,
+  '.typ': ExportFormats.typst,
+  '.typst': ExportFormats.typst,
 };
 
 export const RESERVED_EXPORT_KEYS = [
@@ -49,9 +63,25 @@ function validateExportFormat(input: any, opts: ValidationOptions): ExportFormat
 
 export function validateExport(input: any, opts: ValidationOptions): Export | undefined {
   if (typeof input === 'string') {
-    const format = validateExportFormat(input, opts);
-    if (!format) return undefined;
-    input = { format };
+    let format: string | undefined;
+    let output: string | undefined;
+    if (input.includes('.')) {
+      Object.entries(EXT_TO_FORMAT).forEach(([ext, fmt]) => {
+        if (input === ext) {
+          format = fmt;
+        } else if (input.endsWith(ext)) {
+          output = input;
+        }
+      });
+      if (!format && !output) {
+        output = input;
+      }
+    }
+    if (!format && !output) {
+      format = validateExportFormat(input, opts);
+      if (!format) return undefined;
+    }
+    input = { format, output };
   }
   const value = validateObjectKeys(input, EXPORT_KEY_OBJECT, {
     ...opts,
@@ -59,19 +89,37 @@ export function validateExport(input: any, opts: ValidationOptions): Export | un
     keepExtraKeys: true,
   });
   if (value === undefined) return undefined;
-  const format = validateExportFormat(value.format, incrementOptions('format', opts));
-  if (format === undefined) return undefined;
-  const output: Export = { ...value, format };
+  let format: ExportFormats | undefined;
+  let output: string | undefined;
+  let template: string | null | undefined;
   if (value.template === null) {
     // It is possible for the template to explicitly be null.
     // This use no template (rather than default template).
-    output.template = null;
+    template = null;
   } else if (defined(value.template)) {
-    output.template = validateString(value.template, incrementOptions('template', opts));
+    template = validateString(value.template, incrementOptions('template', opts));
   }
   if (defined(value.output)) {
-    output.output = validateString(value.output, incrementOptions('output', opts));
+    output = validateString(value.output, incrementOptions('output', opts));
   }
+  if (defined(value.format)) {
+    format = validateExportFormat(value.format, incrementOptions('format', opts));
+    // If format is defined but invalid, validation fails
+    if (!format) return undefined;
+  } else if (output) {
+    // If output is defined, format is inferred from output
+    Object.entries(EXT_TO_FORMAT).forEach(([ext, fmt]) => {
+      if (output?.endsWith(ext)) format = fmt;
+    });
+    if (!format) {
+      return validationError(`unable to infer export format from export: ${output}`, opts);
+    }
+  } else if (!template) {
+    // If template is defined, that will tell us the format later!
+    return validationError('unable to determine export format', opts);
+  }
+  if (format === undefined && template === undefined) return undefined;
+  const validExport: Export = { ...value, format, output, template };
   if (defined(value.articles)) {
     const articles = validateList(
       value.articles,
@@ -81,9 +129,10 @@ export function validateExport(input: any, opts: ValidationOptions): Export | un
     if (
       articles?.length &&
       articles.length > 1 &&
-      ![ExportFormats.pdf, ExportFormats.tex, ExportFormats.pdftex].includes(output.format)
+      validExport.format &&
+      ![ExportFormats.pdf, ExportFormats.tex, ExportFormats.pdftex].includes(validExport.format)
     ) {
-      if (output.format === ExportFormats.xml && !defined(value.sub_articles)) {
+      if (validExport.format === ExportFormats.xml && !defined(value.sub_articles)) {
         validationError(
           "multiple articles are not supported for 'jats' export - instead specify one article with additional sub_articles",
           opts,
@@ -91,17 +140,17 @@ export function validateExport(input: any, opts: ValidationOptions): Export | un
       } else {
         validationError("multiple articles are only supported for 'tex' and 'pdf' exports", opts);
       }
-      output.articles = [articles[0]];
+      validExport.articles = [articles[0]];
     } else {
-      output.articles = articles;
+      validExport.articles = articles;
     }
   }
   if (defined(value.sub_articles)) {
-    if (output.format !== ExportFormats.xml) {
+    if (validExport.format !== ExportFormats.xml) {
       validationError("sub_articles are only supported for 'jats' export", opts);
-      output.sub_articles = undefined;
+      validExport.sub_articles = undefined;
     } else {
-      output.sub_articles = validateList(
+      validExport.sub_articles = validateList(
         value.sub_articles,
         { coerce: true, ...incrementOptions('sub_articles', opts) },
         (file, ind) => {
@@ -110,5 +159,5 @@ export function validateExport(input: any, opts: ValidationOptions): Export | un
       );
     }
   }
-  return output;
+  return validExport;
 }

--- a/packages/myst-frontmatter/src/exports/validators.ts
+++ b/packages/myst-frontmatter/src/exports/validators.ts
@@ -114,8 +114,9 @@ export function validateExport(input: any, opts: ValidationOptions): Export | un
     if (!format) {
       return validationError(`unable to infer export format from export: ${output}`, opts);
     }
-  } else if (!template) {
-    // If template is defined, that will tell us the format later!
+  } else {
+    // if (!template) {
+    // TODO: If template is defined, that will tell us the format later!
     return validationError('unable to determine export format', opts);
   }
   if (format === undefined && template === undefined) return undefined;

--- a/packages/mystmd/src/build.ts
+++ b/packages/mystmd/src/build.ts
@@ -16,6 +16,7 @@ import {
   makeMecaOptions,
   makeMdOption,
   makeTypstOption,
+  makeWatchOption,
 } from './options.js';
 
 export function makeBuildCLI(program: Command) {
@@ -32,6 +33,7 @@ export function makeBuildCLI(program: Command) {
     .addOption(makeSiteOption('Build MyST site content'))
     .addOption(makeHtmlOption('Build static HTML site content'))
     .addOption(makeAllOption('Build all exports'))
+    .addOption(makeWatchOption())
     .addOption(makeNamedExportOption('Output file for the export'))
     .addOption(makeForceOption())
     .addOption(makeCheckLinksOption())

--- a/packages/mystmd/src/options.ts
+++ b/packages/mystmd/src/options.ts
@@ -50,6 +50,10 @@ export function makeAllOption(description: string) {
   return new Option('-a, --all', description).default(false);
 }
 
+export function makeWatchOption() {
+  return new Option('--watch', 'Watch modified files and re-build on change').default(false);
+}
+
 export function makeNamedExportOption(description: string) {
   return new Option('-o, --output <output>', description);
 }


### PR DESCRIPTION
- You may now `myst build --watch` and built files will be live-reloaded
- Changing dependencies (i.e. included/embedded content) will cause dependent pages to reload (both for exports and site build)
- export format may be inferred from filename