### PR TITLE
🎆 Support images in inline expressions and fix transform order

### DIFF
--- a/.changeset/bright-panthers-leave.md
+++ b/.changeset/bright-panthers-leave.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fix inline expression block metadata

--- a/.changeset/silly-bulldogs-work.md
+++ b/.changeset/silly-bulldogs-work.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Support image inline expressions

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -52,6 +52,7 @@ async function writeBase64(
   const file = `${hash}${ext}`;
   const filePath = path.join(writeFolder, file);
   session.log.debug(`Writing binary output file ${justData.length} bytes to ${filePath}`);
+  if (!fs.existsSync(writeFolder)) fs.mkdirSync(writeFolder, { recursive: true });
   fs.writeFileSync(filePath, justData, {
     encoding: 'base64',
   });


### PR DESCRIPTION
Inline expression render fix here still didn't quite get transform order correct #793 - this fixes that up by running `blockMetadataTransform` before `inlineExpressionTransform`.

I also added `images` as a supported inline expression mimetype 🚀