### PR TITLE
🍽 Support tables in typst

### DIFF
--- a/.changeset/cool-tools-clean.md
+++ b/.changeset/cool-tools-clean.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Support tables in typst export

--- a/.changeset/few-plants-accept.md
+++ b/.changeset/few-plants-accept.md
@@ -1,0 +1,5 @@
+---
+'myst-directives': patch
+---
+
+Make table directive less opinionated

--- a/.changeset/rotten-kangaroos-raise.md
+++ b/.changeset/rotten-kangaroos-raise.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Support thematic break in typst

--- a/packages/myst-directives/src/table.ts
+++ b/packages/myst-directives/src/table.ts
@@ -1,6 +1,5 @@
 import type { DirectiveSpec, DirectiveData, GenericNode } from 'myst-common';
 import { fileError, normalizeLabel, RuleId } from 'myst-common';
-import { select } from 'unist-util-select';
 import type { VFile } from 'vfile';
 
 export const tableDirective: DirectiveSpec = {
@@ -29,19 +28,12 @@ export const tableDirective: DirectiveSpec = {
     type: 'myst',
     required: true,
   },
-  run(data, vfile): GenericNode[] {
+  run(data): GenericNode[] {
     const children = [];
     if (data.arg) {
       children.push({
         type: 'caption',
         children: [{ type: 'paragraph', children: data.arg as GenericNode[] }],
-      });
-    }
-    const body = data.body as GenericNode[];
-    if (!select('table', { type: 'root', children: body })) {
-      fileError(vfile, 'table directive does not include a markdown table in the body', {
-        node: data.node,
-        ruleId: RuleId.directiveBodyCorrect,
       });
     }
     children.push(...(data.body as GenericNode[]));

--- a/packages/myst-to-typst/src/container.ts
+++ b/packages/myst-to-typst/src/container.ts
@@ -42,15 +42,23 @@ export const containerHandler: Handler = (node, state) => {
   const { label } = node;
   const caption = select('caption', node);
   const image = select('image', node);
-  if (!image) {
-    fileError(state.file, `Figure only supports image children at the moment!`, {
+  const table = select('table', node);
+  if (!image && !table) {
+    fileError(state.file, `Figure only supports image or table children at the moment!`, {
+      node,
+      source: 'myst-to-typst',
+    });
+    return;
+  }
+  if (image && table) {
+    fileError(state.file, `Figure only supports single image or table child at the moment!`, {
       node,
       source: 'myst-to-typst',
     });
     return;
   }
   state.write('#figure(\n  ');
-  state.renderChildren({ children: [image] }, true);
+  state.renderChildren({ children: [image ?? table] }, true);
   state.trimEnd();
   state.write(',');
   if (caption) {

--- a/packages/myst-to-typst/src/container.ts
+++ b/packages/myst-to-typst/src/container.ts
@@ -51,7 +51,7 @@ export const containerHandler: Handler = (node, state) => {
       note: `Figure "${label ?? 'unlabeled'}" may not render correctly`,
     });
   }
-  if (imagesAndTables.length > 0) {
+  if (imagesAndTables.length > 1) {
     state.write('#figure((\n  ');
     imagesAndTables.forEach((item) => {
       state.renderChildren({ children: [item] });
@@ -59,6 +59,11 @@ export const containerHandler: Handler = (node, state) => {
     });
     state.trimEnd();
     state.write(').join(),');
+  } else if (imagesAndTables.length === 1) {
+    state.write('#figure(\n  ');
+    state.renderChildren({ children: [imagesAndTables[0]] });
+    state.trimEnd();
+    state.write(',');
   } else {
     state.write('#figure([\n  ');
     state.renderChildren(node, true);

--- a/packages/myst-to-typst/src/container.ts
+++ b/packages/myst-to-typst/src/container.ts
@@ -1,7 +1,6 @@
-import { fileError, type GenericNode } from 'myst-common';
+import { fileWarn, type GenericNode } from 'myst-common';
 import type { Image, Table, Code, Math } from 'myst-spec';
-import { select } from 'unist-util-select';
-// import { getColumnWidths } from './tables.js';
+import { selectAll } from 'unist-util-select';
 import type { Handler } from './types.js';
 
 export enum CaptionKind {
@@ -39,33 +38,50 @@ export const containerHandler: Handler = (node, state) => {
   state.ensureNewLine();
   const prevState = state.data.isInFigure;
   state.data.isInFigure = true;
-  const { label } = node;
-  const caption = select('caption', node);
-  const image = select('image', node);
-  const table = select('table', node);
-  if (!image && !table) {
-    fileError(state.file, `Figure only supports image or table children at the moment!`, {
+  const { label, kind } = node;
+  const captions = selectAll('caption,legend', node);
+  const imagesAndTables = selectAll('image,table', node);
+  if (label === 'table10') {
+    console.log(imagesAndTables);
+  }
+  if (imagesAndTables.length !== 1) {
+    fileWarn(state.file, `Typst best supports figures with single image or table`, {
       node,
       source: 'myst-to-typst',
+      note: `Figure "${label ?? 'unlabeled'}" may not render correctly`,
     });
-    return;
   }
-  if (image && table) {
-    fileError(state.file, `Figure only supports single image or table child at the moment!`, {
-      node,
-      source: 'myst-to-typst',
+  if (imagesAndTables.length > 0) {
+    state.write('#figure((\n  ');
+    imagesAndTables.forEach((item) => {
+      state.renderChildren({ children: [item] });
+      state.write(',');
     });
-    return;
-  }
-  state.write('#figure(\n  ');
-  state.renderChildren({ children: [image ?? table] }, true);
-  state.trimEnd();
-  state.write(',');
-  if (caption) {
-    state.write('\n  caption: [');
-    state.renderChildren(caption, true);
+    state.trimEnd();
+    state.write(').join(),');
+  } else {
+    state.write('#figure([\n  ');
+    state.renderChildren(node, true);
     state.trimEnd();
     state.write('],');
+  }
+  if (captions.length) {
+    state.write('\n  caption: [');
+    state.renderChildren(
+      {
+        children: captions
+          .map((cap: GenericNode) => cap.children)
+          .filter(Boolean)
+          .flat(),
+      },
+      true,
+    );
+    state.trimEnd();
+    state.write('],');
+  }
+  if (kind) {
+    state.write(`\n  kind: "${kind}",`);
+    state.write(`\n  supplement: [${kind[0].toUpperCase() + kind.substring(1)}],`);
   }
   state.write('\n)');
   if (label) state.write(` <${label}>`);

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -227,7 +227,11 @@ const handlers: Record<string, Handler> = {
   admonitionTitle() {
     return;
   },
-  // table: renderNodeToLatex,
+  table(node, state) {
+    const command = state.data.isInFigure ? 'table' : '#table';
+    node;
+    state.write(`${command}("${src}", width: ${width})`);
+  },
   image(node, state) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { width: nodeWidth, url: nodeSrc, align } = node;

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -121,10 +121,10 @@ const handlers: Record<string, Handler> = {
     state.renderChildren(node, true);
     state.write('\n');
   },
-  // thematicBreak(node, state) {
-  //   state.write('\n\\bigskip\n\\centerline{\\rule{13cm}{0.4pt}}\n\\bigskip');
-  //   state.closeBlock(node);
-  // },
+  thematicBreak(node, state) {
+    state.write('#line(length: 100%, stroke: gray)');
+    state.closeBlock(node);
+  },
   ...MATH_HANDLERS,
   mystRole(node, state) {
     state.renderChildren(node, true);

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -15,6 +15,7 @@ import {
 import MATH_HANDLERS, { withRecursiveCommands } from './math.js';
 import { select, selectAll } from 'unist-util-select';
 import type { Admonition, FootnoteDefinition } from 'myst-spec-ext';
+import { tableCellHandler, tableHandler, tableRowHandler } from './table.js';
 
 export type { TypstResult } from './types.js';
 
@@ -56,6 +57,18 @@ const blockquote = `#let blockquote(node, color: gray) = {
 }`;
 
 const INDENT = '  ';
+
+const linkHandler = (node: any, state: ITypstSerializer) => {
+  const href = node.url;
+  state.write('#link("');
+  state.write(hrefToLatexText(href));
+  state.write('")');
+  if (node.children.length && node.children[0].value !== href) {
+    state.write('[');
+    state.renderChildren(node, true);
+    state.write(']');
+  }
+};
 
 const handlers: Record<string, Handler> = {
   text(node, state) {
@@ -188,17 +201,7 @@ const handlers: Record<string, Handler> = {
     // https://www.overleaf.com/learn/latex/glossaries
     state.renderChildren(node, true);
   },
-  link(node, state) {
-    const href = node.url;
-    state.write('#link("');
-    state.write(hrefToLatexText(href));
-    state.write('")');
-    if (node.children[0]?.value !== href) {
-      state.write('[');
-      state.renderChildren(node, true);
-      state.write(']');
-    }
-  },
+  link: linkHandler,
   admonition(node: Admonition, state) {
     state.useMacro(admonition);
     state.ensureNewLine();
@@ -227,11 +230,9 @@ const handlers: Record<string, Handler> = {
   admonitionTitle() {
     return;
   },
-  table(node, state) {
-    const command = state.data.isInFigure ? 'table' : '#table';
-    node;
-    state.write(`${command}("${src}", width: ${width})`);
-  },
+  table: tableHandler,
+  tableRow: tableRowHandler,
+  tableCell: tableCellHandler,
   image(node, state) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { width: nodeWidth, url: nodeSrc, align } = node;
@@ -243,6 +244,7 @@ const handlers: Record<string, Handler> = {
   },
   container: containerHandler,
   caption: captionHandler,
+  legend: captionHandler,
   captionNumber: () => undefined,
   crossReference(node, state) {
     // Look up reference and add the text
@@ -256,7 +258,11 @@ const handlers: Record<string, Handler> = {
     state.renderChildren(node, true, ' ');
   },
   cite(node, state) {
-    state.write(`@${node.label}`);
+    if (node.protocol === 'doi' || node.label?.startsWith('https://doi.org')) {
+      linkHandler(node, state);
+    } else {
+      state.write(`@${node.label}`);
+    }
   },
   embed(node, state) {
     state.renderChildren(node, true);
@@ -361,9 +367,7 @@ class TypstSerializer implements ITypstSerializer {
     if (!inline) this.closeBlock(node);
   }
 
-  renderEnvironment(node: any, env: string, opts?: { parameters?: string; arguments?: string[] }) {
-    // const optsInBrackets = opts?.parameters ? `[${opts.parameters}]` : '';
-    // const optsInBraces = opts?.arguments ? `{${opts.arguments.join('}{')}}` : '';
+  renderEnvironment(node: any, env: string) {
     this.file.result += `#${env}[\n`;
     this.renderChildren(node, true);
     this.trimEnd();

--- a/packages/myst-to-typst/src/table.ts
+++ b/packages/myst-to-typst/src/table.ts
@@ -1,0 +1,58 @@
+import type { Handler } from './types.js';
+import { fileError, type GenericNode } from 'myst-common';
+
+function countColumns(table: GenericNode) {
+  const firstRow = table.children?.find((child) => child.type === 'tableRow');
+  const columns = firstRow?.children
+    ?.filter((cell: GenericNode) => cell.type === 'tableCell')
+    .reduce((val: number, cell: GenericNode) => val + (cell.colspan ?? 1), 0);
+  return columns;
+}
+
+function isHeaderRow(node: GenericNode) {
+  if (node.type !== 'tableRow') return false;
+  return node.children
+    ?.filter((child) => child.type === 'tableCell')
+    .every((child) => child.header);
+}
+
+function countHeaderRows(table: GenericNode) {
+  const headerRows = table.children?.filter((child) => isHeaderRow(child));
+  return headerRows?.length ?? 0;
+}
+
+export const tableHandler: Handler = (node, state) => {
+  const command = state.data.isInFigure ? 'tablex' : '#tablex';
+  const columns = countColumns(node);
+  if (!columns) {
+    fileError(state.file, 'Unable to count table columns', {
+      node,
+      source: 'myst-to-typst',
+    });
+    return;
+  }
+  state.useMacro('#import "@preview/tablex:0.0.7": tablex, cellx');
+  state.write(`${command}(columns: ${columns}, header-rows: ${countHeaderRows(node)},\n`);
+  state.renderChildren(node);
+  state.write(')\n');
+};
+
+export const tableRowHandler: Handler = (node, state) => {
+  state.renderChildren(node);
+};
+
+export const tableCellHandler: Handler = (node, state) => {
+  if (node.rowspan || node.colspan) {
+    state.write('cellx(');
+    if (node.rowspan) {
+      state.write(`rowspan: ${node.rowspan}, `);
+    }
+    if (node.colspan) {
+      state.write(`colspan: ${node.colspan}, `);
+    }
+    state.write(')');
+  }
+  state.write('[');
+  state.renderChildren(node);
+  state.write('],');
+};

--- a/packages/myst-to-typst/src/types.ts
+++ b/packages/myst-to-typst/src/types.ts
@@ -21,7 +21,7 @@ export type Options = {
 };
 
 export type StateData = {
-  isInTable?: boolean;
+  tableColumns?: number;
   isInFigure?: boolean;
   longFigure?: boolean;
   nextCaptionNumbered?: boolean;

--- a/packages/myst-to-typst/src/utils.ts
+++ b/packages/myst-to-typst/src/utils.ts
@@ -218,7 +218,7 @@ export function stringToLatexText(text: string) {
     .replace(new RegExp(BACKSLASH_SPACE, 'g'), '\\\\ ')
     .replace(new RegExp(BACKSLASH, 'g'), '\\\\')
     .replace(new RegExp(COMMENT, 'g'), '\\/\\/')
-    .replace(new RegExp(TILDE, 'g'), '#sym.tilde');
+    .replace(new RegExp(TILDE, 'g'), '$tilde$');
   return cleanWhitespaceChars(final, '~');
 }
 

--- a/packages/myst-to-typst/tests/basic.yml
+++ b/packages/myst-to-typst/tests/basic.yml
@@ -227,7 +227,7 @@ cases:
           children:
             - type: text
               value: 'This is a tilde: ~ and backslash \\ cool!'
-    typst: 'This is a tilde: #sym.tilde and backslash \\\\ cool!'
+    typst: 'This is a tilde: $tilde$ and backslash \\\\ cool!'
   - title: escaped *
     mdast:
       type: root

--- a/packages/myst-to-typst/tests/figures.yml
+++ b/packages/myst-to-typst/tests/figures.yml
@@ -23,6 +23,8 @@ cases:
     typst: |-
       #figure(
         image("glacier.jpg", width: 62.5%),
+        kind: "figure",
+        supplement: [Figure],
       ) <glacier>
   - title: figure directive - with caption
     mdast:
@@ -45,4 +47,6 @@ cases:
       #figure(
         image("glacier.jpg", width: 62.5%),
         caption: [A curious figure.],
+        kind: "figure",
+        supplement: [Figure],
       ) <glacier>


### PR DESCRIPTION
This uses `tablex` to support tables with col/row spans in typst exports. Other small fixes included in this PR:

- `table` directive is less opinionated. The container children transform added here https://github.com/executablebooks/mystmd/pull/770 deals with tables, so we can make the directive pretty permissive and let that transform error/warn if there are issues.
- DOI citations in typst were converted back to links - we may want to do something better long-term (e.g. pull doi citations into bib) but for now, this fixes broken typst builds
- thematic breaks are now supported in typst
- multi-image figures and legends now work slightly better in typst