### PR TITLE
🐛 Duplicate bibtex entries when uppercase

### DIFF
--- a/.changeset/cuddly-coats-joke.md
+++ b/.changeset/cuddly-coats-joke.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Bibtex with capital ARTICLE now no longer duplicates all entries

--- a/packages/myst-cli/src/build/utils/bibtex.ts
+++ b/packages/myst-cli/src/build/utils/bibtex.ts
@@ -10,10 +10,10 @@ import type { References } from 'myst-common';
  *
  * Look for the pattern '@article{key' then finds the closing bracket
  * and returns that substring. The "article" prefix may be any
- * lowercase alpha word.
+ * alpha word.
  */
 export function extractBibtex(key: string, bibtex: string) {
-  const match = bibtex.match(new RegExp(`@[a-z]*{${key}`, 'g'));
+  const match = bibtex.match(new RegExp(`@[a-zA-Z]*{${key}`, 'g'));
   if (!match) return;
   const start = bibtex.indexOf(match[0]);
   let bracketCount = 0;


### PR DESCRIPTION
There was a bug when `@ARTICLE` was used, it seems to work in both tex and typst, but we would render all citations when encountering it.