### PR TITLE
🔗 Match typst references and figures

### DIFF
--- a/.changeset/silver-zoos-bow.md
+++ b/.changeset/silver-zoos-bow.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Typst figures now use identifiers rather than labels and match the references!

--- a/packages/myst-to-typst/src/container.ts
+++ b/packages/myst-to-typst/src/container.ts
@@ -45,7 +45,7 @@ export const containerHandler: Handler = (node, state) => {
   state.ensureNewLine();
   const prevState = state.data.isInFigure;
   state.data.isInFigure = true;
-  const { label, kind } = node;
+  const { identifier: label, kind } = node;
   const captions = node.children?.filter(
     (child: GenericNode) => child.type === 'caption' || child.type === 'legend',
   );

--- a/packages/myst-to-typst/tests/figures.yml
+++ b/packages/myst-to-typst/tests/figures.yml
@@ -15,7 +15,7 @@ cases:
       children:
         - type: container
           kind: figure
-          label: glacier
+          identifier: glacier
           children:
             - type: image
               url: glacier.jpg
@@ -32,7 +32,7 @@ cases:
       children:
         - type: container
           kind: figure
-          label: glacier
+          identifier: glacier
           children:
             - type: image
               url: glacier.jpg


### PR DESCRIPTION
Previously the matching between a reference and figure label could fail due to case/spaces etc.