### PR TITLE
🔧 More small typst improvements

### DIFF
--- a/.changeset/few-pants-trade.md
+++ b/.changeset/few-pants-trade.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Handle nested definition lists in typst

--- a/.changeset/tame-experts-drive.md
+++ b/.changeset/tame-experts-drive.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Enable typst figures with image/content + other node types

--- a/.changeset/warm-drinks-promise.md
+++ b/.changeset/warm-drinks-promise.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Typst citation support: narrative and suffix

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -17,7 +17,6 @@ import { ensureString, extFromMimeType, minifyCellOutput, walkOutputs } from 'nb
 import { castSession } from '../session/cache.js';
 import type { ISession } from '../session/types.js';
 import { resolveOutputPath } from './images.js';
-import { htmlTransform } from 'myst-transforms';
 
 function getFilename(hash: string, contentType: string) {
   return `${hash}${extFromMimeType(contentType)}`;

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -17,6 +17,7 @@ import { ensureString, extFromMimeType, minifyCellOutput, walkOutputs } from 'nb
 import { castSession } from '../session/cache.js';
 import type { ISession } from '../session/types.js';
 import { resolveOutputPath } from './images.js';
+import { htmlTransform } from 'myst-transforms';
 
 function getFilename(hash: string, contentType: string) {
   return `${hash}${extFromMimeType(contentType)}`;

--- a/packages/myst-to-typst/src/container.ts
+++ b/packages/myst-to-typst/src/container.ts
@@ -35,8 +35,8 @@ export function determineCaptionKind(node: GenericNode): CaptionKind | null {
 
 function renderFigureChild(node: GenericNode, state: ITypstSerializer) {
   const useBrackets = node.type !== 'image' && node.type !== 'table';
-  if (useBrackets) state.write('[');
-  state.write('\n');
+  if (useBrackets) state.write('[\n');
+  else state.write('\n  ');
   state.renderChildren({ children: [node] });
   if (useBrackets) state.write('\n]');
 }

--- a/packages/myst-to-typst/src/container.ts
+++ b/packages/myst-to-typst/src/container.ts
@@ -1,6 +1,6 @@
-import { fileError, fileWarn, type GenericNode } from 'myst-common';
+import { fileError, type GenericNode } from 'myst-common';
 import type { Image, Table, Code, Math } from 'myst-spec';
-import type { Handler } from './types.js';
+import type { Handler, ITypstSerializer } from './types.js';
 
 export enum CaptionKind {
   fig = 'fig',
@@ -33,6 +33,14 @@ export function determineCaptionKind(node: GenericNode): CaptionKind | null {
   return kind;
 }
 
+function renderFigureChild(node: GenericNode, state: ITypstSerializer) {
+  const useBrackets = node.type !== 'image' && node.type !== 'table';
+  if (useBrackets) state.write('[');
+  state.write('\n');
+  state.renderChildren({ children: [node] });
+  if (useBrackets) state.write('\n]');
+}
+
 export const containerHandler: Handler = (node, state) => {
   if (state.data.isInTable) {
     fileError(state.file, 'Unable to render typst figure inside table', {
@@ -41,7 +49,9 @@ export const containerHandler: Handler = (node, state) => {
     });
     return;
   }
-  state.useMacro('#show figure: set block(breakable: true)');
+
+  state.ensureNewLine();
+  state.write('#show figure: set block(breakable: true)');
   state.ensureNewLine();
   const prevState = state.data.isInFigure;
   state.data.isInFigure = true;
@@ -49,32 +59,31 @@ export const containerHandler: Handler = (node, state) => {
   const captions = node.children?.filter(
     (child: GenericNode) => child.type === 'caption' || child.type === 'legend',
   );
-  const imagesAndTables = node.children?.filter(
-    (child: GenericNode) => child.type === 'image' || child.type === 'table',
+  const nonCaptions = node.children?.filter(
+    (child: GenericNode) => child.type !== 'caption' && child.type !== 'legend',
   );
-  if (!imagesAndTables || imagesAndTables.length !== 1) {
-    fileWarn(state.file, `Typst best supports figures with single image or table`, {
+  if (!nonCaptions || nonCaptions.length === 0) {
+    fileError(state.file, `Figure with no non-caption content: ${label}`, {
       node,
       source: 'myst-to-typst',
-      note: `Figure "${label ?? 'unlabeled'}" may not render correctly`,
     });
   }
-  if (imagesAndTables && imagesAndTables.length > 1) {
-    state.write('#figure((\n  ');
-    imagesAndTables.forEach((item: GenericNode) => {
-      state.renderChildren({ children: [item] }, 1);
-      state.write(',');
+  if (nonCaptions && nonCaptions.length > 1) {
+    state.write('#figure((');
+    nonCaptions.forEach((item: GenericNode) => {
+      renderFigureChild(item, state);
+      state.write('\n, ');
     });
-    state.write(').join(),');
-  } else if (imagesAndTables && imagesAndTables.length === 1) {
-    state.write('#figure(\n  ');
-    state.renderChildren({ children: [imagesAndTables[0]] });
-    state.write(',');
+    state.write(').join()');
+  } else if (nonCaptions && nonCaptions.length === 1) {
+    state.write('#figure(');
+    renderFigureChild(nonCaptions[0], state);
   } else {
     state.write('#figure([\n  ');
     state.renderChildren(node, 1);
-    state.write('],');
+    state.write(']');
   }
+  state.write(',');
   if (captions?.length) {
     state.write('\n  caption: [\n');
     state.renderChildren({

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -104,7 +104,17 @@ const handlers: Record<string, Handler> = {
     state.renderEnvironment(node, 'blockquote');
   },
   definitionList(node, state) {
-    state.renderChildren(node);
+    let dedent = false;
+    if (!state.data.definitionIndent) {
+      state.data.definitionIndent = 2;
+    } else {
+      state.write(`#set terms(indent: ${state.data.definitionIndent}em)`);
+      state.data.definitionIndent += 2;
+      dedent = true;
+    }
+    state.renderChildren(node, 1);
+    state.data.definitionIndent -= 2;
+    if (dedent) state.write(`#set terms(indent: ${state.data.definitionIndent - 2}em)\n`);
   },
   definitionTerm(node, state) {
     state.ensureNewLine();

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -279,7 +279,11 @@ const handlers: Record<string, Handler> = {
     if (node.protocol === 'doi' || node.label?.startsWith('https://doi.org')) {
       linkHandler(node, state);
     } else {
-      state.write(`@${node.label}`);
+      state.write(`#cite(<${node.label}>`);
+      if (node.kind === 'narrative') state.write(`, form: "prose"`);
+      // node.prefix not supported by typst: see https://github.com/typst/typst/issues/1139
+      if (node.suffix) state.write(`, supplement: [${node.suffix}]`);
+      state.write(`)`);
     }
   },
   embed(node, state) {

--- a/packages/myst-to-typst/src/table.ts
+++ b/packages/myst-to-typst/src/table.ts
@@ -34,7 +34,9 @@ export const tableHandler: Handler = (node, state) => {
     return;
   }
   state.useMacro('#import "@preview/tablex:0.0.7": tablex, cellx');
-  state.write(`${command}(columns: ${columns}, header-rows: ${countHeaderRows(node)},\n`);
+  state.write(
+    `${command}(columns: ${columns}, header-rows: ${countHeaderRows(node)}, repeat-header: true,\n`,
+  );
   state.renderChildren(node, 1);
   state.write(')\n');
   state.data.isInTable = prevState;

--- a/packages/myst-to-typst/src/types.ts
+++ b/packages/myst-to-typst/src/types.ts
@@ -25,6 +25,7 @@ export type StateData = {
   isInFigure?: boolean;
   isInTable?: boolean;
   longFigure?: boolean;
+  definitionIndent?: number;
   nextCaptionNumbered?: boolean;
   nextHeadingIsFrameTitle?: boolean;
   nextCaptionId?: string;

--- a/packages/myst-to-typst/tests/cite.yml
+++ b/packages/myst-to-typst/tests/cite.yml
@@ -9,7 +9,7 @@ cases:
             - type: cite
               label: cockett2015
     typst: |-
-      @cockett2015
+      #cite(<cockett2015>)
   - title: cite multiple
     mdast:
       type: root
@@ -23,4 +23,26 @@ cases:
                 - type: cite
                   label: jon85
     typst: |-
-      @cockett2015 @jon85
+      #cite(<cockett2015>) #cite(<jon85>)
+  - title: cite narrative
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: cite
+              label: cockett2015
+              kind: narrative
+    typst: |-
+      #cite(<cockett2015>, form: "prose")
+  - title: cite suffix
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: cite
+              label: cockett2015
+              suffix: page 1
+    typst: |-
+      #cite(<cockett2015>, supplement: [page 1])

--- a/packages/myst-to-typst/tests/figures.yml
+++ b/packages/myst-to-typst/tests/figures.yml
@@ -21,6 +21,7 @@ cases:
               url: glacier.jpg
               width: 500px
     typst: |-
+      #show figure: set block(breakable: true)
       #figure(
         image("glacier.jpg", width: 62.5%),
         kind: "figure",
@@ -44,6 +45,7 @@ cases:
                     - type: text
                       value: A curious figure.
     typst: |-
+      #show figure: set block(breakable: true)
       #figure(
         image("glacier.jpg", width: 62.5%),
         caption: [

--- a/packages/myst-to-typst/tests/tables.yml
+++ b/packages/myst-to-typst/tests/tables.yml
@@ -31,7 +31,7 @@ cases:
                       value: Row 1, Column 2
 
     typst: |-
-      #tablex(columns: 2, header-rows: 1,
+      #tablex(columns: 2, header-rows: 1, repeat-header: true,
       [
       Head 1, Column 1
       ],
@@ -78,7 +78,7 @@ cases:
                       value: Row 1, Column 2
 
     typst: |-
-      #tablex(columns: 2, header-rows: 1,
+      #tablex(columns: 2, header-rows: 1, repeat-header: true,
       [
       Head 1, Column 1
       ],
@@ -119,7 +119,7 @@ cases:
                       value: Row 1, Column 2
 
     typst: |-
-      #tablex(columns: 2, header-rows: 0,
+      #tablex(columns: 2, header-rows: 0, repeat-header: true,
       cellx(rowspan: 2, )[
       Head 1, Column 1
       ],
@@ -156,7 +156,7 @@ cases:
                       value: Row 1, Column 2
 
     typst: |-
-      #tablex(columns: 2, header-rows: 0,
+      #tablex(columns: 2, header-rows: 0, repeat-header: true,
       cellx(colspan: 2, )[
       Head 1, Column 1
       ],


### PR DESCRIPTION
- Citations: now narrative vs parenthetical is respected, and suffixes are supported
- Figures are fixed to allow images/tables plus other content - this allows jupyter notebook figures display both code and output image
- Nested definition lists indent correctly