### PR TITLE
feat: add build-time execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13923,7 +13923,7 @@
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/nbformat": "3.5.2",
-        "@jupyterlab/services": "^7.0.10",
+        "@jupyterlab/services": "^7.0.0",
         "@reduxjs/toolkit": "^1.7.2",
         "adm-zip": "^0.5.10",
         "boxen": "^7.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -977,6 +977,37 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
+    "node_modules/@jupyter/ydoc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@jupyter/ydoc/-/ydoc-1.1.1.tgz",
+      "integrity": "sha512-fXx9CbUwUlXBsJo83tBQL3T0MgWT4YYz2ozcSFj0ymZSohAnI1uo7N9CPpVe4/nmc9uG1lFdlXC4XQBevi2jSA==",
+      "dependencies": {
+        "@jupyterlab/nbformat": "^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0",
+        "@lumino/coreutils": "^1.11.0 || ^2.0.0",
+        "@lumino/disposable": "^1.10.0 || ^2.0.0",
+        "@lumino/signaling": "^1.10.0 || ^2.0.0",
+        "y-protocols": "^1.0.5",
+        "yjs": "^13.5.40"
+      }
+    },
+    "node_modules/@jupyterlab/coreutils": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-6.0.10.tgz",
+      "integrity": "sha512-bx7RPhaJmSx9IfPZrP/OoVOXBTZcx2fWx1NXuNU7E8KAUfkbpcDQ2PYGxxpgTFhrLGH5h0U+vvzigJloaMCvIA==",
+      "dependencies": {
+        "@lumino/coreutils": "^2.1.2",
+        "@lumino/disposable": "^2.1.2",
+        "@lumino/signaling": "^2.1.2",
+        "minimist": "~1.2.0",
+        "path-browserify": "^1.0.0",
+        "url-parse": "~1.5.4"
+      }
+    },
+    "node_modules/@jupyterlab/coreutils/node_modules/@lumino/coreutils": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-2.1.2.tgz",
+      "integrity": "sha512-vyz7WzchTO4HQ8iVAxvSUmb5o/8t3cz1vBo8V4ZIaPGada0Jx0xe3tKQ8bXp4pjHc+AEhMnkCnlUyVYMWbnj4A=="
+    },
     "node_modules/@jupyterlab/nbformat": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-3.5.2.tgz",
@@ -985,12 +1016,207 @@
         "@lumino/coreutils": "^1.11.0"
       }
     },
+    "node_modules/@jupyterlab/services": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-7.0.10.tgz",
+      "integrity": "sha512-TPqqRNTX8dG0Kmj2lRWDaOKm232goMZArpBhgqqQkU87QAGuiaBu+dOqytfPV4X8cQTnJTO1yw+RbuR8uL+FOg==",
+      "dependencies": {
+        "@jupyter/ydoc": "^1.1.1",
+        "@jupyterlab/coreutils": "^6.0.10",
+        "@jupyterlab/nbformat": "^4.0.10",
+        "@jupyterlab/settingregistry": "^4.0.10",
+        "@jupyterlab/statedb": "^4.0.10",
+        "@lumino/coreutils": "^2.1.2",
+        "@lumino/disposable": "^2.1.2",
+        "@lumino/polling": "^2.1.2",
+        "@lumino/properties": "^2.0.1",
+        "@lumino/signaling": "^2.1.2",
+        "ws": "^8.11.0"
+      }
+    },
+    "node_modules/@jupyterlab/services/node_modules/@jupyterlab/nbformat": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-4.0.10.tgz",
+      "integrity": "sha512-KUzBmllf5GqbUJCPeH7365TMhwC1LtSD0zITskFXqW3Q4rznLTc+tOp1yMfuruc6xhp4KtJ6WoExmb7bBq/PAw==",
+      "dependencies": {
+        "@lumino/coreutils": "^2.1.2"
+      }
+    },
+    "node_modules/@jupyterlab/services/node_modules/@lumino/coreutils": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-2.1.2.tgz",
+      "integrity": "sha512-vyz7WzchTO4HQ8iVAxvSUmb5o/8t3cz1vBo8V4ZIaPGada0Jx0xe3tKQ8bXp4pjHc+AEhMnkCnlUyVYMWbnj4A=="
+    },
+    "node_modules/@jupyterlab/settingregistry": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-4.0.10.tgz",
+      "integrity": "sha512-BZDPYHdRoUdUYJNwwfu+cR1obwnxLfsa6gOl5FDbtA5UHcOG2ogJYYXzUWVJgRtFU6iRXpVA91zFBh/Ccd3cQw==",
+      "dependencies": {
+        "@jupyterlab/nbformat": "^4.0.10",
+        "@jupyterlab/statedb": "^4.0.10",
+        "@lumino/commands": "^2.1.3",
+        "@lumino/coreutils": "^2.1.2",
+        "@lumino/disposable": "^2.1.2",
+        "@lumino/signaling": "^2.1.2",
+        "@rjsf/utils": "^5.1.0",
+        "ajv": "^8.12.0",
+        "json5": "^2.2.3"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/@jupyterlab/settingregistry/node_modules/@jupyterlab/nbformat": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-4.0.10.tgz",
+      "integrity": "sha512-KUzBmllf5GqbUJCPeH7365TMhwC1LtSD0zITskFXqW3Q4rznLTc+tOp1yMfuruc6xhp4KtJ6WoExmb7bBq/PAw==",
+      "dependencies": {
+        "@lumino/coreutils": "^2.1.2"
+      }
+    },
+    "node_modules/@jupyterlab/settingregistry/node_modules/@lumino/coreutils": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-2.1.2.tgz",
+      "integrity": "sha512-vyz7WzchTO4HQ8iVAxvSUmb5o/8t3cz1vBo8V4ZIaPGada0Jx0xe3tKQ8bXp4pjHc+AEhMnkCnlUyVYMWbnj4A=="
+    },
+    "node_modules/@jupyterlab/settingregistry/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@jupyterlab/settingregistry/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@jupyterlab/settingregistry/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jupyterlab/statedb": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-4.0.10.tgz",
+      "integrity": "sha512-t5XXnyhAIqvxsorsnEb5beqafA5pMDVLyO8HHiJohSTOvlxPhjR6u0GWBuR7wm2SI/vJTz8+cPejZhCVcD3LTw==",
+      "dependencies": {
+        "@lumino/commands": "^2.1.3",
+        "@lumino/coreutils": "^2.1.2",
+        "@lumino/disposable": "^2.1.2",
+        "@lumino/properties": "^2.0.1",
+        "@lumino/signaling": "^2.1.2"
+      }
+    },
+    "node_modules/@jupyterlab/statedb/node_modules/@lumino/coreutils": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-2.1.2.tgz",
+      "integrity": "sha512-vyz7WzchTO4HQ8iVAxvSUmb5o/8t3cz1vBo8V4ZIaPGada0Jx0xe3tKQ8bXp4pjHc+AEhMnkCnlUyVYMWbnj4A=="
+    },
+    "node_modules/@lumino/algorithm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-2.0.1.tgz",
+      "integrity": "sha512-iA+uuvA7DeNFB0/cQpIWNgO1c6z4pOSigifjstLy+rxf1U5ZzxIq+xudnEuTbWgKSTviG02j4cKwCyx1PO6rzA=="
+    },
+    "node_modules/@lumino/commands": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-2.2.0.tgz",
+      "integrity": "sha512-xm+4rFithAd/DLZheQcS0GJaI3m0gVg07mCEZAWBLolN5e7w6XTr17VuD7J6KSjdBygMKZ3n8GlEkpcRNWEajA==",
+      "dependencies": {
+        "@lumino/algorithm": "^2.0.1",
+        "@lumino/coreutils": "^2.1.2",
+        "@lumino/disposable": "^2.1.2",
+        "@lumino/domutils": "^2.0.1",
+        "@lumino/keyboard": "^2.0.1",
+        "@lumino/signaling": "^2.1.2",
+        "@lumino/virtualdom": "^2.0.1"
+      }
+    },
+    "node_modules/@lumino/commands/node_modules/@lumino/coreutils": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-2.1.2.tgz",
+      "integrity": "sha512-vyz7WzchTO4HQ8iVAxvSUmb5o/8t3cz1vBo8V4ZIaPGada0Jx0xe3tKQ8bXp4pjHc+AEhMnkCnlUyVYMWbnj4A=="
+    },
     "node_modules/@lumino/coreutils": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.12.1.tgz",
       "integrity": "sha512-JLu3nTHzJk9N8ohZ85u75YxemMrmDzJdNgZztfP7F7T7mxND3YVNCkJG35a6aJ7edu1sIgCjBxOvV+hv27iYvQ==",
       "peerDependencies": {
         "crypto": "1.0.1"
+      }
+    },
+    "node_modules/@lumino/disposable": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-2.1.2.tgz",
+      "integrity": "sha512-0qmB6zPt9+uj4SVMTfISn0wUOjYHahtKotwxDD5flfcscj2gsXaFCXO4Oqot1zcsZbg8uJmTUhEzAvFW0QhFNA==",
+      "dependencies": {
+        "@lumino/signaling": "^2.1.2"
+      }
+    },
+    "node_modules/@lumino/domutils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-2.0.1.tgz",
+      "integrity": "sha512-tbcfhsdKH04AMjSgYAYGD2xE80YcjrqKnfMTeU2NHt4J294Hzxs1GvEmSMk5qJ3Bbgwx6Z4BbQ7apnFg8Gc6cA=="
+    },
+    "node_modules/@lumino/keyboard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-2.0.1.tgz",
+      "integrity": "sha512-R2mrH9HCEcv/0MSAl7bEUbjCNOnhrg49nXZBEVckg//TEG+sdayCsyrbJNMPcZ07asIPKc6mq3v7DpAmDKqh+w=="
+    },
+    "node_modules/@lumino/polling": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lumino/polling/-/polling-2.1.2.tgz",
+      "integrity": "sha512-hv6MT7xuSrw2gW4VIoiz3L366ZdZz4oefht+7HIW/VUB6seSDp0kVyZ4P9P4I4s/LauuzPqru3eWr7QAsFZyGA==",
+      "dependencies": {
+        "@lumino/coreutils": "^2.1.2",
+        "@lumino/disposable": "^2.1.2",
+        "@lumino/signaling": "^2.1.2"
+      }
+    },
+    "node_modules/@lumino/polling/node_modules/@lumino/coreutils": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-2.1.2.tgz",
+      "integrity": "sha512-vyz7WzchTO4HQ8iVAxvSUmb5o/8t3cz1vBo8V4ZIaPGada0Jx0xe3tKQ8bXp4pjHc+AEhMnkCnlUyVYMWbnj4A=="
+    },
+    "node_modules/@lumino/properties": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-2.0.1.tgz",
+      "integrity": "sha512-RPtHrp8cQqMnTC915lOIdrmsbPDCC7PhPOZb2YY7/Jj6dEdwmGhoMthc2tBEYWoHP+tU/hVm8UR/mEQby22srQ=="
+    },
+    "node_modules/@lumino/signaling": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-2.1.2.tgz",
+      "integrity": "sha512-KtwKxx+xXkLOX/BdSqtvnsqBTPKDIENFBKeYkMTxstQc3fHRmyTzmaVoeZES+pr1EUy3e8vM4pQFVQpb8VsDdA==",
+      "dependencies": {
+        "@lumino/algorithm": "^2.0.1",
+        "@lumino/coreutils": "^2.1.2"
+      }
+    },
+    "node_modules/@lumino/signaling/node_modules/@lumino/coreutils": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-2.1.2.tgz",
+      "integrity": "sha512-vyz7WzchTO4HQ8iVAxvSUmb5o/8t3cz1vBo8V4ZIaPGada0Jx0xe3tKQ8bXp4pjHc+AEhMnkCnlUyVYMWbnj4A=="
+    },
+    "node_modules/@lumino/virtualdom": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-2.0.1.tgz",
+      "integrity": "sha512-WNM+uUZX7vORhlDRN9NmhEE04Tz1plDjtbwsX+i/51pQj2N2r7+gsVPY/gR4w+I5apmC3zG8/BojjJYIwi8ogA==",
+      "dependencies": {
+        "@lumino/algorithm": "^2.0.1"
       }
     },
     "node_modules/@manypkg/find-root": {
@@ -1211,6 +1437,29 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rjsf/utils": {
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.16.1.tgz",
+      "integrity": "sha512-zJ8WopscMl46QBjlIalIoPERs7kgSfUwIZ5zx4OMBRp0O+m7Scx0F+4iHqLnRuHEfaCNA5D7IKxmx1whOG/x1Q==",
+      "dependencies": {
+        "json-schema-merge-allof": "^0.8.1",
+        "jsonpointer": "^5.0.1",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || >=17"
+      }
+    },
+    "node_modules/@rjsf/utils/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.3.2",
@@ -3367,6 +3616,27 @@
         "node": ">=14"
       }
     },
+    "node_modules/compute-gcd": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "node_modules/compute-lcm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
+      "dependencies": {
+        "compute-gcd": "^1.2.1",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5225,8 +5495,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -7217,6 +7486,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.1.tgz",
@@ -7268,8 +7546,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -7298,6 +7575,27 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "dependencies": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/json-schema-merge-allof": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
+      "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
+      "dependencies": {
+        "compute-lcm": "^1.1.2",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.20"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -7336,6 +7634,14 @@
       "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -7458,6 +7764,25 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lib0": {
+      "version": "0.2.88",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.88.tgz",
+      "integrity": "sha512-KyroiEvCeZcZEMx5Ys+b4u4eEBbA1ch7XUaBhYpwa/nPMrzTjUhI4RfcytmQfYoTBPcdyx+FX6WFNIoNuJzJfQ==",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -7570,6 +7895,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -7674,7 +8004,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -9502,6 +9831,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -9886,7 +10220,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9904,6 +10237,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -9973,6 +10311,18 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10319,11 +10669,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/reselect": {
       "version": "4.1.8",
@@ -12224,9 +12587,17 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -12268,6 +12639,38 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "node_modules/validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg=="
+    },
+    "node_modules/validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
+    },
+    "node_modules/validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
+      "dependencies": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "node_modules/validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "node_modules/validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -13229,6 +13632,25 @@
         "xml-js": "bin/cli.js"
       }
     },
+    "node_modules/y-protocols": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
+      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -13331,6 +13753,22 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.10",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.10.tgz",
+      "integrity": "sha512-1JcyQek1vaMyrDm7Fqfa+pvHg/DURSbVo4VmeN7wjnTKB/lZrfIPhdCj7d8sboK6zLfRBJXegTjc9JlaDd8/Zw==",
+      "dependencies": {
+        "lib0": "^0.2.86"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {
@@ -13485,6 +13923,7 @@
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/nbformat": "3.5.2",
+        "@jupyterlab/services": "^7.0.10",
         "@reduxjs/toolkit": "^1.7.2",
         "adm-zip": "^0.5.10",
         "boxen": "^7.1.1",

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@jupyterlab/nbformat": "3.5.2",
-    "@jupyterlab/services": "^7.0.10",
+    "@jupyterlab/services": "^7.0.0",
     "@reduxjs/toolkit": "^1.7.2",
     "adm-zip": "^0.5.10",
     "boxen": "^7.1.1",

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@jupyterlab/nbformat": "3.5.2",
+    "@jupyterlab/services": "^7.0.10",
     "@reduxjs/toolkit": "^1.7.2",
     "adm-zip": "^0.5.10",
     "boxen": "^7.1.1",

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -225,7 +225,10 @@ export async function transformMdast(
   // Combine file-specific citation renderers with project renderers from bib files
   const fileCitationRenderer = combineCitationRenderers(cache, ...rendererFiles);
 
-  const serverSettings = ServerConnection.makeSettings();
+  const serverSettings = ServerConnection.makeSettings({
+    baseUrl: process.env.JUPYTER_BASE_URL,
+    token: process.env.JUPYTER_TOKEN,
+  });
   const kernelManager = new KernelManager({ serverSettings });
   const sessionManager = new SessionManager({ kernelManager, serverSettings });
   await transformKernelExecution(sessionManager, mdast, frontmatter, file, true);

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -74,6 +74,8 @@ import { bibFilesInDir, selectFile } from './file.js';
 import { loadIntersphinx } from './intersphinx.js';
 import { frontmatterPartsTransform } from '../transforms/parts.js';
 import { parseMyst } from './myst.js';
+import { transformKernelExecution } from '../transforms/execute.js';
+import { ServerConnection, KernelManager, SessionManager } from '@jupyterlab/services';
 
 const LINKS_SELECTOR = 'link,card,linkBlock';
 
@@ -222,6 +224,11 @@ export async function transformMdast(
   }
   // Combine file-specific citation renderers with project renderers from bib files
   const fileCitationRenderer = combineCitationRenderers(cache, ...rendererFiles);
+
+  const serverSettings = ServerConnection.makeSettings();
+  const kernelManager = new KernelManager({ serverSettings });
+  const sessionManager = new SessionManager({ kernelManager, serverSettings });
+  await transformKernelExecution(sessionManager, mdast, frontmatter, file, true);
 
   transformFilterOutputStreams(mdast, vfile, frontmatter.settings);
   await transformOutputsToCache(session, mdast, kind, { minifyMaxCharacters });

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -65,7 +65,8 @@ import {
   transformImagesWithoutExt,
   transformImagesToDisk,
   transformFilterOutputStreams,
-  transformLiftCodeBlocksInJupytext, renderInlineExpressionsTransform
+  transformLiftCodeBlocksInJupytext,
+  renderInlineExpressionsTransform,
 } from '../transforms/index.js';
 import type { ImageExtensions } from '../utils/resolveExtension.js';
 import { logMessagesFromVFile } from '../utils/logMessagesFromVFile.js';
@@ -74,7 +75,12 @@ import { bibFilesInDir, selectFile } from './file.js';
 import { loadIntersphinx } from './intersphinx.js';
 import { frontmatterPartsTransform } from '../transforms/parts.js';
 import { parseMyst } from './myst.js';
-import { transformKernelExecution } from '../transforms/execute.js';
+import {
+  findExistingJupyterServer,
+  JupyterServerSettings,
+  launchJupyterServer,
+  transformKernelExecution,
+} from '../transforms/execute.js';
 import { ServerConnection, KernelManager, SessionManager } from '@jupyterlab/services';
 
 const LINKS_SELECTOR = 'link,card,linkBlock';
@@ -225,13 +231,7 @@ export async function transformMdast(
   // Combine file-specific citation renderers with project renderers from bib files
   const fileCitationRenderer = combineCitationRenderers(cache, ...rendererFiles);
 
-  const serverSettings = ServerConnection.makeSettings({
-    baseUrl: process.env.JUPYTER_BASE_URL,
-    token: process.env.JUPYTER_TOKEN,
-  });
-  const kernelManager = new KernelManager({ serverSettings });
-  const sessionManager = new SessionManager({ kernelManager, serverSettings });
-  await transformKernelExecution(session, sessionManager, mdast, frontmatter, false, vfile, false);
+  await transformKernelExecution(session, mdast, frontmatter, false, vfile, false);
 
   transformFilterOutputStreams(mdast, vfile, frontmatter.settings);
   await transformOutputsToCache(session, mdast, kind, { minifyMaxCharacters });

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -231,7 +231,7 @@ export async function transformMdast(
   });
   const kernelManager = new KernelManager({ serverSettings });
   const sessionManager = new SessionManager({ kernelManager, serverSettings });
-  await transformKernelExecution(sessionManager, mdast, frontmatter, file, true);
+  await transformKernelExecution(sessionManager, mdast, frontmatter, file, true, vfile);
 
   transformFilterOutputStreams(mdast, vfile, frontmatter.settings);
   await transformOutputsToCache(session, mdast, kind, { minifyMaxCharacters });

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -319,7 +319,7 @@ export async function postProcessMdast(
   });
   await pipe.run(mdast, vfile);
 
-  // Ensure there are keys on every node after post processing
+  // Ensure there are keys on every node after post-processing
   keysTransform(mdast);
   logMessagesFromVFile(session, fileState.file);
   logMessagesFromVFile(session, vfile);

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -65,7 +65,7 @@ import {
   transformImagesWithoutExt,
   transformImagesToDisk,
   transformFilterOutputStreams,
-  transformLiftCodeBlocksInJupytext,
+  transformLiftCodeBlocksInJupytext, renderInlineExpressionsTransform
 } from '../transforms/index.js';
 import type { ImageExtensions } from '../utils/resolveExtension.js';
 import { logMessagesFromVFile } from '../utils/logMessagesFromVFile.js';
@@ -235,6 +235,7 @@ export async function transformMdast(
 
   transformFilterOutputStreams(mdast, vfile, frontmatter.settings);
   await transformOutputsToCache(session, mdast, kind, { minifyMaxCharacters });
+
   transformCitations(mdast, fileCitationRenderer, references);
   await unified()
     .use(codePlugin, { lang: frontmatter?.kernelspec?.language })
@@ -358,6 +359,7 @@ export async function finalizeMdast(
       altOutputFolder: simplifyFigures ? undefined : imageAltOutputFolder,
     });
   }
+  renderInlineExpressionsTransform(mdast, vfile);
   transformOutputsToFile(session, mdast, imageWriteFolder, {
     altOutputFolder: simplifyFigures ? undefined : imageAltOutputFolder,
     vfile,

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -231,7 +231,7 @@ export async function transformMdast(
   });
   const kernelManager = new KernelManager({ serverSettings });
   const sessionManager = new SessionManager({ kernelManager, serverSettings });
-  await transformKernelExecution(session, sessionManager, mdast, frontmatter, file, false, vfile);
+  await transformKernelExecution(session, sessionManager, mdast, frontmatter, false, vfile, false);
 
   transformFilterOutputStreams(mdast, vfile, frontmatter.settings);
   await transformOutputsToCache(session, mdast, kind, { minifyMaxCharacters });

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -231,7 +231,7 @@ export async function transformMdast(
   });
   const kernelManager = new KernelManager({ serverSettings });
   const sessionManager = new SessionManager({ kernelManager, serverSettings });
-  await transformKernelExecution(sessionManager, mdast, frontmatter, file, true, vfile);
+  await transformKernelExecution(session, sessionManager, mdast, frontmatter, file, false, vfile);
 
   transformFilterOutputStreams(mdast, vfile, frontmatter.settings);
   await transformOutputsToCache(session, mdast, kind, { minifyMaxCharacters });

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -9,6 +9,7 @@ import {
   basicTransformationsPlugin,
   htmlPlugin,
   footnotesPlugin,
+  blockMetadataPlugin,
   ReferenceState,
   MultiPageReferenceState,
   resolveReferencesTransform,
@@ -53,7 +54,6 @@ import {
   transformImageFormats,
   transformThumbnail,
   StaticFileTransformer,
-  inlineExpressionsPlugin,
   propagateBlockDataToCode,
   transformBanner,
   reduceOutputs,
@@ -176,7 +176,7 @@ export async function transformMdast(
 
   const pipe = unified()
     .use(reconstructHtmlPlugin) // We need to group and link the HTML first
-    .use(inlineExpressionsPlugin) // Happens before math and images!
+    .use(blockMetadataPlugin) // Happens before math and images!
     .use(htmlPlugin, { htmlHandlers }) // Some of the HTML plugins need to operate on the transformed html, e.g. figure caption transforms
     .use(basicTransformationsPlugin, {
       parser: (content: string) => parseMyst(session, content, file),

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -118,19 +118,14 @@ export async function processNotebook(
           value: ensureString(cell.source),
         };
 
-        const output: { type: 'output'; id: string; data: MinifiedOutput[] } = {
+        const output: { type: 'output'; id: string; data: IOutput[] } = {
           type: 'output',
           id: nanoid(),
           data: [],
         };
 
         if (cell.outputs && (cell.outputs as IOutput[]).length > 0) {
-          const minified: MinifiedOutput[] = await minifyCellOutput(
-            cell.outputs as IOutput[],
-            cache.$outputs,
-            { computeHash, maxCharacters: opts?.minifyMaxCharacters },
-          );
-          output.data = minified;
+          output.data = cell.outputs as IOutput[];
         }
         return acc.concat(blockParent(cell, [code, output]));
       }

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -173,7 +173,10 @@ export class Session implements ISession {
       const partialServerSettings = await new Promise<JupyterServerSettings>(
         async (resolve, reject) => {
           if (process.env.JUPYTER_BASE_URL === undefined) {
-            resolve(findExistingJupyterServer() || (await launchJupyterServer(this.contentPath(), this.log)));
+            resolve(
+              findExistingJupyterServer() ||
+                (await launchJupyterServer(this.contentPath(), this.log)),
+            );
           } else {
             resolve({
               baseUrl: process.env.JUPYTER_BASE_URL,

--- a/packages/myst-cli/src/session/types.ts
+++ b/packages/myst-cli/src/session/types.ts
@@ -8,6 +8,7 @@ import type { Store } from 'redux';
 
 import type { BuildWarning, RootState } from '../store/index.js';
 import type { PreRendererData, RendererData, SingleCitationRenderer } from '../transforms/types.js';
+import { SessionManager } from '@jupyterlab/services';
 
 export type ISession = {
   API_URL: string;
@@ -24,6 +25,7 @@ export type ISession = {
   plugins: MystPlugin | undefined;
   loadPlugins(): Promise<MystPlugin>;
   getAllWarnings(ruleId: RuleId): (BuildWarning & { file: string })[];
+  jupyterSessionManager(): Promise<SessionManager | undefined>;
 };
 
 export type ISessionWithCache = ISession & {

--- a/packages/myst-cli/src/transforms/execute.ts
+++ b/packages/myst-cli/src/transforms/execute.ts
@@ -1,0 +1,184 @@
+import { selectAll } from 'unist-util-select';
+import type { PageFrontmatter } from 'myst-frontmatter';
+import { Kernel, KernelMessage, SessionManager } from '@jupyterlab/services';
+import type { IExpressionResult } from 'myst-cli';
+import type { Code, InlineExpression } from 'myst-spec-ext';
+import assert from 'node:assert';
+import type { IOutput } from '@jupyterlab/nbformat';
+import path from 'node:path';
+import type { GenericParent } from 'myst-common';
+
+/**
+ * Interpret an IOPub message as an IOutput object
+ *
+ * @param msg IOPub message
+ */
+function IOPubAsOutput(msg: KernelMessage.IIOPubMessage): IOutput {
+  return {
+    output_type: msg.header.msg_type,
+    ...msg.content,
+  };
+}
+
+/**
+ * Execute a code string in the given kernel, returning any outputs.
+ *
+ * @param kernel connection to an active kernel
+ * @param code code to execute
+ */
+async function executeCode(kernel: Kernel.IKernelConnection, code: string) {
+  const future = kernel.requestExecute({
+    code: code,
+  });
+
+  const outputs: IOutput[] = [];
+  future.onIOPub = (msg: KernelMessage.IIOPubMessage) => {
+    // Only listen for replies to this execution
+    if (
+      msg.parent_header.msg_id !== future.msg.header.msg_id ||
+      msg.parent_header.msg_type !== 'execute_request'
+    ) {
+      console.debug('Ignoring IOPub reply');
+      return;
+    }
+    switch (msg.header.msg_type) {
+      case 'stream':
+      case 'execute_result':
+      case 'error':
+      case 'display_data':
+        outputs.push(IOPubAsOutput(msg));
+        break;
+      default:
+        console.debug('Ignoring IOPub reply (unexpected message type)');
+        return;
+    }
+  };
+  let status: 'abort' | 'error' | 'ok' | undefined;
+  future.onReply = (msg: KernelMessage.IExecuteReplyMsg) => {
+    status = msg.content.status;
+  };
+  assert(status !== undefined);
+
+  await future.done;
+  return { status, outputs };
+}
+
+/**
+ * Evaluate an expression string in the given kernel, returning the singular result.
+ *
+ * @param kernel connection to an active kernel
+ * @param code code to execute
+ */
+async function executeExpression(kernel: Kernel.IKernelConnection, expr: string) {
+  // TODO: batch user expressions by cell?
+  const future = kernel.requestExecute({
+    code: '',
+    user_expressions: {
+      expr: expr,
+    },
+  });
+  let result: IExpressionResult | undefined;
+  future.onReply = (msg: KernelMessage.IExecuteReplyMsg) => {
+    switch (msg.content.status) {
+      case 'ok':
+        // Pull out expr
+        result = (msg.content.user_expressions as unknown as Record<string, IExpressionResult>)[
+          'expr'
+        ];
+        break;
+      case 'error':
+        assert(false); // We shouldn't hit this, because we don't evaluate expressions AND code simultaneously.
+        break;
+      default:
+        break;
+    }
+  };
+  await future.done;
+  // It doesn't make sense for this to be undefined instead of an error
+  assert(result !== undefined);
+  return { status: result.status, result };
+}
+
+type CacheKey = any;
+type CacheItem = (Code | InlineExpression)[];
+
+function buildCacheKey(mdast: (Code | InlineExpression)[]): any {
+  return undefined;
+}
+
+function getCache(key: CacheKey): CacheItem | undefined {
+  return undefined;
+}
+
+function setCache(key: CacheKey, value: CacheItem) {}
+
+/**
+ * Transform an AST to include the outputs of executing the given notebook
+ *
+ * @param sessionManager
+ * @param mdast
+ * @param frontmatter
+ * @param filePath
+ */
+async function transformKernelExecution(
+  sessionManager: SessionManager,
+  mdast: GenericParent,
+  frontmatter: PageFrontmatter,
+  filePath: string,
+  ignoreCache: boolean,
+) {
+  const options = {
+    path: filePath,
+    type: 'notebook',
+    name: path.basename(filePath),
+    kernel: {
+      name: frontmatter?.kernelspec?.name ?? 'python3',
+    },
+  };
+
+  // Boot up a kernel, and execute each cell
+  return await sessionManager.startNew(options).then(async (conn) => {
+    const kernel = conn.kernel;
+    assert(kernel);
+
+    console.log(`Connected to kernel ${kernel.name}`);
+    // Pull out code-like nodes
+    const codeOrEvalNodes = selectAll('code[executable=true],inlineExpression', mdast) as (
+      | Code
+      | InlineExpression
+    )[];
+
+    // Execute notebook!
+    const cacheKey = buildCacheKey(codeOrEvalNodes);
+    let rehydratedNodes: (Code | InlineExpression)[] | undefined = getCache(cacheKey);
+    if (ignoreCache || rehydratedNodes === undefined) {
+      try {
+        rehydratedNodes = []; // TODO
+        for (const matchedNode of codeOrEvalNodes) {
+          if (matchedNode.type === 'code') {
+            const { status, outputs } = await executeCode(kernel, matchedNode.value);
+            // TODO: minify output
+            // (matchedNode as Code).data = ...
+          } else {
+            const { status, result } = await executeExpression(kernel, matchedNode.value);
+            (matchedNode as InlineExpression).result = result;
+            // TODO: (matchedNode as InlineExpression).children = ...
+          }
+        }
+        // Populate cache
+        setCache(cacheKey, rehydratedNodes);
+      } catch {
+        console.error('Execution failed');
+        throw new Error();
+      } finally {
+        // Shutdown kernel
+        await kernel.shutdown();
+      }
+    }
+
+    // let rehydratedNodes: (Code | InlineExpression)[] | undefined;
+    // if (!ignoreCache) {
+    //   rehydratedNodes = getCachedExecution(codeOrEvalNodes);
+    // }
+  });
+}

--- a/packages/myst-cli/src/transforms/execute.ts
+++ b/packages/myst-cli/src/transforms/execute.ts
@@ -191,8 +191,10 @@ export async function transformKernelExecution(
       mdast,
     ) as (ICellBlock | InlineExpression)[];
 
+    // See if we already cached this execution
     const cacheKey = buildCacheKey(codeOrEvalNodes);
     let cachedResults: (IExpressionResult | IOutput[])[] | undefined = getCache(cacheKey);
+
     // Execute notebook?
     if (ignoreCache || cachedResults === undefined) {
       try {
@@ -235,7 +237,10 @@ export async function transformKernelExecution(
       } else if (isInlineExpression(matchedNode)) {
         assert(cachedResults.length > 0);
         // Set data of expression
-        matchedNode.result = cachedResults.shift()! as IExpressionResult;
+        matchedNode.data = cachedResults.shift()! as unknown as Record<string, unknown>;
+      } else {
+        // This should never happen
+        assert(false);
       }
     }
 

--- a/packages/myst-cli/src/transforms/execute.ts
+++ b/packages/myst-cli/src/transforms/execute.ts
@@ -1,6 +1,6 @@
 import { selectAll } from 'unist-util-select';
 import type { PageFrontmatter } from 'myst-frontmatter';
-import { Kernel, KernelMessage, SessionManager } from '@jupyterlab/services';
+import type { Kernel, KernelMessage, SessionManager } from '@jupyterlab/services';
 import type { IExpressionResult } from './inlineExpressions.js';
 import type { Code, InlineExpression } from 'myst-spec-ext';
 import type { IOutput } from '@jupyterlab/nbformat';
@@ -32,11 +32,11 @@ async function executeCode(kernel: Kernel.IKernelConnection, code: string) {
   });
 
   const outputs: IOutput[] = [];
-  future.onIOPub = (msg: KernelMessage.IIOPubMessage) => {
+  future.onIOPub = (msg) => {
     // Only listen for replies to this execution
     if (
-      msg.parent_header.msg_id !== future.msg.header.msg_id ||
-      msg.parent_header.msg_type !== 'execute_request'
+      (msg.parent_header as any).msg_id !== future.msg.header.msg_id ||
+      (msg.parent_header as any).msg_type !== 'execute_request'
     ) {
       console.debug('Ignoring IOPub reply');
       return;
@@ -120,7 +120,7 @@ function setCache(key: CacheKey, value: CacheItem) {}
  * @param frontmatter
  * @param filePath
  */
-async function transformKernelExecution(
+export async function transformKernelExecution(
   sessionManager: SessionManager,
   mdast: GenericParent,
   frontmatter: PageFrontmatter,

--- a/packages/myst-cli/src/transforms/execute.ts
+++ b/packages/myst-cli/src/transforms/execute.ts
@@ -1,12 +1,12 @@
 import { selectAll } from 'unist-util-select';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import { Kernel, KernelMessage, SessionManager } from '@jupyterlab/services';
-import type { IExpressionResult } from 'myst-cli';
+import type { IExpressionResult } from './inlineExpressions.js';
 import type { Code, InlineExpression } from 'myst-spec-ext';
-import assert from 'node:assert';
 import type { IOutput } from '@jupyterlab/nbformat';
-import path from 'node:path';
 import type { GenericParent } from 'myst-common';
+import path from 'node:path';
+import assert from 'node:assert';
 
 /**
  * Interpret an IOPub message as an IOutput object

--- a/packages/myst-cli/src/transforms/execute.ts
+++ b/packages/myst-cli/src/transforms/execute.ts
@@ -28,12 +28,12 @@ export type JupyterServerSettings = Partial<ServerConnection.ISettings> & {
 interface JupyterServerListItem {
   base_url: string;
   hostname: string;
-  password: boolean,
-  pid: number,
-  port: number,
+  password: boolean;
+  pid: number;
+  port: number;
   root_dir: string;
-  secure: boolean,
-  sock: string,
+  secure: boolean;
+  sock: string;
   token: string;
   url: string;
   version: string;
@@ -52,7 +52,7 @@ export function findExistingJupyterServer(): JupyterServerSettings | undefined {
   if (servers.length === 0) {
     return undefined;
   }
-  servers.sort((a, b) => a.pid - b.pid)
+  servers.sort((a, b) => a.pid - b.pid);
   const server = servers.pop()!;
   return {
     baseUrl: server.url,

--- a/packages/myst-cli/src/transforms/inlineExpressions.ts
+++ b/packages/myst-cli/src/transforms/inlineExpressions.ts
@@ -53,7 +53,7 @@ function processLatex(value: string) {
     .trim();
 }
 
-function renderExpression(node: InlineExpression, file: VFile): StaticPhrasingContent[] {
+export function renderExpression(node: InlineExpression, file: VFile): StaticPhrasingContent[] {
   const result = node.result as IExpressionResult;
   if (!result) return [];
   let content: StaticPhrasingContent[] | undefined;

--- a/packages/myst-cli/src/transforms/inlineExpressions.ts
+++ b/packages/myst-cli/src/transforms/inlineExpressions.ts
@@ -38,7 +38,7 @@ export interface IUserExpressionsMetadata {
   [metadataSection]: IUserExpressionMetadata[];
 }
 
-function findExpression(
+export function findExpression(
   expressions: IUserExpressionMetadata[],
   value: string,
 ): IUserExpressionMetadata | undefined {
@@ -54,7 +54,7 @@ function processLatex(value: string) {
 }
 
 export function renderExpression(node: InlineExpression, file: VFile): StaticPhrasingContent[] {
-  const result = node.result as IExpressionResult;
+  const result = node.data as IExpressionResult | undefined;
   if (!result) return [];
   let content: StaticPhrasingContent[] | undefined;
   if (result.status === 'ok') {
@@ -102,7 +102,7 @@ export function transformInlineExpressions(mdast: GenericParent, file: VFile) {
       if (!data) return;
       count += 1;
       inlineExpression.identifier = `eval-${count}`;
-      inlineExpression.result = data.result;
+      inlineExpression.data = data.result as unknown as Record<string, unknown>;
       inlineExpression.children = renderExpression(inlineExpression, file);
     });
   });

--- a/packages/myst-cli/src/transforms/inlineExpressions.ts
+++ b/packages/myst-cli/src/transforms/inlineExpressions.ts
@@ -1,8 +1,15 @@
-import { fileWarn, RuleId } from 'myst-common';
-import type { InlineExpression } from 'myst-spec-ext';
+import { fileWarn, type GenericNode, type GenericParent, liftChildren, RuleId } from 'myst-common';
+import type { Image, InlineExpression } from 'myst-spec-ext';
 import type { StaticPhrasingContent } from 'myst-spec';
-import type { VFile } from 'vfile';
+import { VFile } from 'vfile';
 import { BASE64_HEADER_SPLIT } from './images.js';
+import { castSession, ISession } from '../session/index.js';
+import { selectAll } from 'unist-util-select';
+import { MinifiedOutput, walkOutputs } from 'nbtx';
+import { htmlTransform } from 'myst-transforms';
+import { dirname, relative } from 'node:path';
+import stripAnsi from 'strip-ansi';
+import { remove } from 'unist-util-remove';
 
 export const metadataSection = 'user_expressions';
 
@@ -79,4 +86,11 @@ export function renderExpression(node: InlineExpression, file: VFile): StaticPhr
     });
   }
   return [];
+}
+
+export function renderInlineExpressionsTransform(mdast: GenericParent, vfile: VFile) {
+  const expressions = selectAll('inlineExpression', mdast) as InlineExpression[];
+  expressions.forEach((node) => {
+    node.children = renderExpression(node, vfile);
+  });
 }

--- a/packages/myst-cli/src/transforms/inlineExpressions.ts
+++ b/packages/myst-cli/src/transforms/inlineExpressions.ts
@@ -16,8 +16,8 @@ export interface IBaseExpressionResult {
 
 export interface IExpressionOutput extends IBaseExpressionResult {
   status: 'ok';
-  data: Record<string, string>;
-  metadata: Record<string, string>;
+  data: Record<string, any>;
+  metadata: Record<string, any>;
 }
 
 export interface IExpressionError extends IBaseExpressionResult {

--- a/packages/myst-cli/src/transforms/inlineExpressions.ts
+++ b/packages/myst-cli/src/transforms/inlineExpressions.ts
@@ -1,10 +1,6 @@
-import type { GenericNode, GenericParent } from 'myst-common';
-import { fileWarn, NotebookCell, RuleId } from 'myst-common';
-import { selectAll } from 'unist-util-select';
+import { fileWarn, RuleId } from 'myst-common';
 import type { InlineExpression } from 'myst-spec-ext';
 import type { StaticPhrasingContent } from 'myst-spec';
-import { blockMetadataTransform } from 'myst-transforms';
-import type { Plugin } from 'unified';
 import type { VFile } from 'vfile';
 import { BASE64_HEADER_SPLIT } from './images.js';
 
@@ -84,31 +80,3 @@ export function renderExpression(node: InlineExpression, file: VFile): StaticPhr
   }
   return [];
 }
-
-export function transformInlineExpressions(mdast: GenericParent, file: VFile) {
-  // Ensure block metadata is correctly structured
-  blockMetadataTransform(mdast, file);
-  const blocks = selectAll('block', mdast).filter(
-    (node) => node.data?.type === NotebookCell.content && node.data?.[metadataSection],
-  ) as GenericNode[];
-
-  let count = 0;
-
-  blocks.forEach((node) => {
-    const userExpressions = node.data?.[metadataSection] as IUserExpressionMetadata[];
-    const inlineNodes = selectAll('inlineExpression', node) as InlineExpression[];
-    inlineNodes.forEach((inlineExpression) => {
-      const data = findExpression(userExpressions, inlineExpression.value);
-      if (!data) return;
-      count += 1;
-      inlineExpression.identifier = `eval-${count}`;
-      inlineExpression.data = data.result as unknown as Record<string, unknown>;
-      inlineExpression.children = renderExpression(inlineExpression, file);
-    });
-  });
-}
-
-export const inlineExpressionsPlugin: Plugin<[], GenericParent, GenericParent> =
-  () => (tree, file) => {
-    transformInlineExpressions(tree, file);
-  };

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -37,7 +37,7 @@ export async function transformOutputsToCache(
 ) {
   const outputs = selectAll('output', mdast) as GenericNode[];
   // This happens sooner for notebooks
-  if (!outputs.length || kind !== SourceFileKind.Article) return;
+  if (!outputs.length) return;
   const cache = castSession(session);
   await Promise.all(
     outputs.map(async (output) => {

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -36,7 +36,6 @@ export async function transformOutputsToCache(
   opts?: { minifyMaxCharacters?: number },
 ) {
   const outputs = selectAll('output', mdast) as GenericNode[];
-  // This happens sooner for notebooks
   if (!outputs.length) return;
   const cache = castSession(session);
   await Promise.all(
@@ -48,7 +47,6 @@ export async function transformOutputsToCache(
     }),
   );
 }
-
 export function stringIsMatplotlibOutput(value?: string): boolean {
   if (!value) return false;
   // We can add more when we find them...

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -161,7 +161,7 @@ export type InlineExpression = {
   type: 'inlineExpression';
   value: string;
   identifier?: string;
-  result?: Record<string, any>;
+  data?: Record<string, unknown>;
   children?: StaticPhrasingContent[];
 };
 


### PR DESCRIPTION
This PR is a jumping off point for execution work, and should make it possible to scope discussions to just interested parties.

- [x] Separate existing inline expression result population from rendering
- [x] Implement local on-disk caching (with a nice abstraction)
- [ ] Implement a CLI for execution w/o rendering
- [ ] Implement CLI options to control caching and whether to start existing an Jupyter server

Closes #839, #550