### PR TITLE
🧮 Allow enumeration to start at a specified number

### DIFF
--- a/.changeset/nasty-mugs-happen.md
+++ b/.changeset/nasty-mugs-happen.md
@@ -1,0 +1,6 @@
+---
+'myst-frontmatter': patch
+'myst-transforms': patch
+---
+
+Allow enumeration to start at a different number

--- a/packages/myst-frontmatter/src/numbering/numbering.yml
+++ b/packages/myst-frontmatter/src/numbering/numbering.yml
@@ -19,7 +19,7 @@ cases:
   - title: invalid extras keys are removed
     raw:
       numbering:
-        list: 1
+        list: 'invalid'
     normalized: {}
     errors: 1
   - title: full object returns self
@@ -62,3 +62,20 @@ cases:
         heading_4: true
         heading_5: true
         heading_6: true
+  - title: Allow numbers to start at
+    raw:
+      numbering:
+        figure: 2
+        list: 1
+    normalized:
+      numbering:
+        figure: 2
+        list: 1
+  - title: Numbers can't be negative or fractional
+    raw:
+      numbering:
+        figure: 1.5 # Must not be a fraction
+        list: -1 # Must be positive
+        something: 0 # This should just be true
+    normalized: {}
+    errors: 3

--- a/packages/myst-frontmatter/src/numbering/validators.ts
+++ b/packages/myst-frontmatter/src/numbering/validators.ts
@@ -3,6 +3,7 @@ import {
   defined,
   incrementOptions,
   validateBoolean,
+  validateNumber,
   validateObjectKeys,
   validateString,
 } from 'simple-validators';
@@ -56,8 +57,17 @@ export function validateNumbering(input: any, opts: ValidationOptions): Numberin
     .filter((key) => !NUMBERING_OPTIONS.includes(key)) // For all the unknown options
     .forEach((key) => {
       if (defined(value[key])) {
-        const bool = validateBoolean(value[key], incrementOptions(key, opts));
-        if (defined(bool)) output[key] = bool;
+        if (typeof value[key] === 'number') {
+          const number = validateNumber(value[key], {
+            ...incrementOptions(key, opts),
+            integer: true,
+            min: 1,
+          });
+          if (defined(number)) output[key] = number;
+        } else {
+          const bool = validateBoolean(value[key], incrementOptions(key, opts));
+          if (defined(bool)) output[key] = bool;
+        }
       }
     });
   if (Object.keys(output).length === 0) return undefined;


### PR DESCRIPTION
This allows you to additionally start numbering at `3` or any other number, rather than starting every numbering on the page at 1. This is a stepping stone towards sharing book-wide numbering.