### PR TITLE
🎨 Update CSS classes applied to math nodes to match `remark-math`

### DIFF
--- a/.changeset/beige-jobs-decide.md
+++ b/.changeset/beige-jobs-decide.md
@@ -1,0 +1,5 @@
+---
+'myst-to-html': patch
+---
+
+Move to `math-display` and `math-inline` for class names to match remark.

--- a/.changeset/chatty-birds-admire.md
+++ b/.changeset/chatty-birds-admire.md
@@ -1,0 +1,14 @@
+---
+'myst-transforms': patch
+'myst-ext-proof': patch
+'myst-spec-ext': patch
+'jats-to-myst': patch
+'myst-to-docx': patch
+'myst-to-html': patch
+'myst-to-jats': patch
+'myst-common': patch
+'myst-parser': patch
+'myst-cli': patch
+---
+
+Update myst-spec

--- a/package-lock.json
+++ b/package-lock.json
@@ -8738,9 +8738,9 @@
       "link": true
     },
     "node_modules/myst-spec": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/myst-spec/-/myst-spec-0.0.4.tgz",
-      "integrity": "sha512-1j7184Wmg5lhgSXt6AXtG82E0PFJ7ULFPplfshQDzb4nIOLKruYFD0CYWheRPMM/eVqNbNZUzc/LLrhyubsK0Q=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/myst-spec/-/myst-spec-0.0.5.tgz",
+      "integrity": "sha512-L/4TV1l5ZbWUOgSnXqiYrx192SV4I+HqjX7TBQ4k02/heeNFckpkUIyLulraap5heTyLcJs8UYBxu+Kv5JiiRw=="
     },
     "node_modules/myst-spec-ext": {
       "resolved": "packages/myst-spec-ext",
@@ -13377,7 +13377,7 @@
         "jats-xml": "^1.0.8",
         "myst-common": "^1.1.20",
         "myst-frontmatter": "^1.1.20",
-        "myst-spec": "^0.0.4",
+        "myst-spec": "^0.0.5",
         "myst-spec-ext": "^1.1.20",
         "myst-transforms": "^1.1.18",
         "unified": "^10.0.0",
@@ -13519,7 +13519,7 @@
         "myst-ext-tabs": "^1.0.5",
         "myst-frontmatter": "^1.1.21",
         "myst-parser": "^1.0.21",
-        "myst-spec": "^0.0.4",
+        "myst-spec": "^0.0.5",
         "myst-spec-ext": "^1.1.21",
         "myst-templates": "^1.0.15",
         "myst-to-docx": "^1.0.8",
@@ -13755,7 +13755,7 @@
       "dependencies": {
         "mdast": "^3.0.0",
         "myst-frontmatter": "^1.1.21",
-        "myst-spec": "^0.0.4",
+        "myst-spec": "^0.0.5",
         "nanoid": "^4.0.0",
         "unified": "^10.1.2",
         "unist-util-remove": "^3.1.0",
@@ -13826,7 +13826,7 @@
       "license": "MIT",
       "dependencies": {
         "myst-common": "^1.1.20",
-        "myst-spec": "^0.0.4"
+        "myst-spec": "^0.0.5"
       },
       "devDependencies": {
         "myst-parser": "^1.0.20"
@@ -13886,7 +13886,7 @@
         "myst-common": "^1.1.21",
         "myst-directives": "^1.0.21",
         "myst-roles": "^1.0.21",
-        "myst-spec": "^0.0.4",
+        "myst-spec": "^0.0.5",
         "unified": "^10.1.1",
         "unist-builder": "^3.0.0",
         "unist-util-remove": "^3.1.0",
@@ -13950,7 +13950,7 @@
       "version": "1.1.21",
       "license": "MIT",
       "dependencies": {
-        "myst-spec": "^0.0.4"
+        "myst-spec": "^0.0.5"
       }
     },
     "packages/myst-templates": {
@@ -13993,7 +13993,7 @@
         "docx": "^7.3.0",
         "myst-common": "^1.1.20",
         "myst-frontmatter": "^1.1.20",
-        "myst-spec": "^0.0.4",
+        "myst-spec": "^0.0.5",
         "myst-spec-ext": "^1.1.20",
         "unist-util-select": "^4.0.3"
       }
@@ -14046,7 +14046,7 @@
         "katex": "^0.15.2",
         "myst-common": "^1.1.20",
         "myst-frontmatter": "^1.1.20",
-        "myst-spec": "^0.0.4",
+        "myst-spec": "^0.0.5",
         "myst-spec-ext": "^1.1.20",
         "myst-transforms": "^1.1.18",
         "nbtx": "^0.2.3",
@@ -14161,7 +14161,7 @@
         "katex": "^0.15.2",
         "mdast-util-find-and-replace": "^2.1.0",
         "myst-common": "^1.1.21",
-        "myst-spec": "^0.0.4",
+        "myst-spec": "^0.0.5",
         "myst-spec-ext": "^1.1.21",
         "myst-to-html": "1.0.21",
         "rehype-parse": "^8.0.4",

--- a/packages/jats-to-myst/package.json
+++ b/packages/jats-to-myst/package.json
@@ -40,7 +40,7 @@
     "jats-xml": "^1.0.8",
     "myst-common": "^1.1.20",
     "myst-frontmatter": "^1.1.20",
-    "myst-spec": "^0.0.4",
+    "myst-spec": "^0.0.5",
     "myst-spec-ext": "^1.1.20",
     "myst-transforms": "^1.1.18",
     "unified": "^10.0.0",

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -77,7 +77,7 @@
     "myst-ext-tabs": "^1.0.5",
     "myst-frontmatter": "^1.1.21",
     "myst-parser": "^1.0.21",
-    "myst-spec": "^0.0.4",
+    "myst-spec": "^0.0.5",
     "myst-spec-ext": "^1.1.21",
     "myst-templates": "^1.0.15",
     "myst-to-docx": "^1.0.8",

--- a/packages/myst-common/package.json
+++ b/packages/myst-common/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "mdast": "^3.0.0",
     "myst-frontmatter": "^1.1.21",
-    "myst-spec": "^0.0.4",
+    "myst-spec": "^0.0.5",
     "nanoid": "^4.0.0",
     "unified": "^10.1.2",
     "unist-util-remove": "^3.1.0",

--- a/packages/myst-ext-proof/package.json
+++ b/packages/myst-ext-proof/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/executablebooks/mystmd/issues"
   },
   "dependencies": {
-    "myst-spec": "^0.0.4",
+    "myst-spec": "^0.0.5",
     "myst-common": "^1.1.20"
   },
   "devDependencies": {

--- a/packages/myst-parser/package.json
+++ b/packages/myst-parser/package.json
@@ -54,7 +54,7 @@
     "myst-common": "^1.1.21",
     "myst-directives": "^1.0.21",
     "myst-roles": "^1.0.21",
-    "myst-spec": "^0.0.4",
+    "myst-spec": "^0.0.5",
     "unified": "^10.1.1",
     "unist-builder": "^3.0.0",
     "unist-util-remove": "^3.1.0",

--- a/packages/myst-spec-ext/package.json
+++ b/packages/myst-spec-ext/package.json
@@ -32,6 +32,6 @@
     "url": "https://github.com/executablebooks/mystmd/issues"
   },
   "dependencies": {
-    "myst-spec": "^0.0.4"
+    "myst-spec": "^0.0.5"
   }
 }

--- a/packages/myst-to-docx/package.json
+++ b/packages/myst-to-docx/package.json
@@ -38,7 +38,7 @@
     "docx": "^7.3.0",
     "myst-common": "^1.1.20",
     "myst-frontmatter": "^1.1.20",
-    "myst-spec": "^0.0.4",
+    "myst-spec": "^0.0.5",
     "myst-spec-ext": "^1.1.20",
     "unist-util-select": "^4.0.3"
   }

--- a/packages/myst-to-html/src/schema.ts
+++ b/packages/myst-to-html/src/schema.ts
@@ -56,7 +56,7 @@ const captionNumber: Handler = (h, node) => {
 };
 
 const math: Handler = (h, node) => {
-  const attrs = { id: node.identifier || undefined, class: 'math block' };
+  const attrs = { id: node.identifier || undefined, class: 'math-display' };
   if (node.value.indexOf('\n') !== -1) {
     const mathHast = h(node, 'div', attrs, [u('text', node.value)]);
     return h(node, 'pre', [mathHast]);
@@ -65,7 +65,7 @@ const math: Handler = (h, node) => {
 };
 
 const inlineMath: Handler = (h, node) => {
-  return h(node, 'span', { class: 'math inline' }, [
+  return h(node, 'span', { class: 'math-inline' }, [
     u('text', node.value.replace(/\r?\n|\r/g, ' ')),
   ]);
 };

--- a/packages/myst-to-html/tests/html.spec.ts
+++ b/packages/myst-to-html/tests/html.spec.ts
@@ -15,4 +15,12 @@ describe('mystToHtml', () => {
     const html = mystToHtml(u('root', [u('html', '<p>hello world</>')]) as any);
     expect(html).toBe('');
   });
+  it('Applies `math-inline` to `inlineMath` nodes', () => {
+    const html = mystToHtml(u('root', [u('paragraph', [u('inlineMath', 'y = a x + b')])]));
+    expect(html).toBe('<p><span class="math-inline">y = a x + b</span></p>');
+  });
+  it('Applies `math-display` to `math` nodes', () => {
+    const html = mystToHtml(u('root', [u('math', 'y = a x + b')]));
+    expect(html).toBe('<div class="math-display">y = a x + b</div>');
+  });
 });

--- a/packages/myst-to-jats/package.json
+++ b/packages/myst-to-jats/package.json
@@ -43,7 +43,7 @@
     "katex": "^0.15.2",
     "myst-common": "^1.1.20",
     "myst-frontmatter": "^1.1.20",
-    "myst-spec": "^0.0.4",
+    "myst-spec": "^0.0.5",
     "myst-spec-ext": "^1.1.20",
     "myst-transforms": "^1.1.18",
     "nbtx": "^0.2.3",

--- a/packages/myst-transforms/package.json
+++ b/packages/myst-transforms/package.json
@@ -27,7 +27,7 @@
     "hast-util-to-mdast": "^8.3.1",
     "mdast-util-find-and-replace": "^2.1.0",
     "myst-common": "^1.1.21",
-    "myst-spec": "^0.0.4",
+    "myst-spec": "^0.0.5",
     "myst-spec-ext": "^1.1.21",
     "myst-to-html": "1.0.21",
     "rehype-parse": "^8.0.4",


### PR DESCRIPTION
change `math block` to `math-display` and `math inline` to `math-inline`

ref #859 