### PR TITLE
fix: don't require MyST template when headless

### DIFF
--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -108,8 +108,10 @@ export async function startServer(
   // Ensure we are on the latest version of the configs
   session.reload();
   warnOnHostEnvironmentVariable(session, opts);
-  const mystTemplate = await getMystTemplate(session, opts);
-  if (!opts.headless) await installSiteTemplate(session, mystTemplate);
+  if (!opts.headless) {
+    const mystTemplate = await getMystTemplate(session, opts);
+    await installSiteTemplate(session, mystTemplate);
+  }
   await buildSite(session, opts);
   const server = await startContentServer(session, opts);
   const { extraLinkTransformers, extraTransforms, defaultTemplate } = opts;


### PR DESCRIPTION
`myst start --headless` shouldn't need to download the theme. 