### PR TITLE
🕵️‍♀️ Support cross-references to file allowing labels on lifted headers

### DIFF
--- a/.changeset/green-ravens-pump.md
+++ b/.changeset/green-ravens-pump.md
@@ -1,0 +1,6 @@
+---
+'myst-transforms': patch
+'myst-cli': patch
+---
+
+Support cross-references to file allowing labels on lifted headers

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -30,8 +30,8 @@ export function getPageFrontmatter(
   session: ISession,
   tree: GenericParent,
   vfile: VFile,
-): PageFrontmatter {
-  const { frontmatter: rawPageFrontmatter } = getFrontmatter(vfile, tree, {
+): { frontmatter: PageFrontmatter; identifiers: string[] } {
+  const { frontmatter: rawPageFrontmatter, identifiers } = getFrontmatter(vfile, tree, {
     propagateTargets: true,
   });
   unnestKernelSpec(rawPageFrontmatter);
@@ -48,7 +48,7 @@ export function getPageFrontmatter(
   };
   const pageFrontmatter = validatePageFrontmatter(rawPageFrontmatter, validationOpts);
   logMessagesFromVFile(session, vfile);
-  return pageFrontmatter;
+  return { frontmatter: pageFrontmatter, identifiers };
 }
 
 export function processPageFrontmatter(

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -66,10 +66,10 @@ export async function loadFile(
         const { sha256, useCache } = checkCache(cache, content, file);
         if (useCache) break;
         const mdast = parseMyst(session, content, file);
-        const frontmatter = getPageFrontmatter(session, mdast, vfile);
+        const { frontmatter, identifiers } = getPageFrontmatter(session, mdast, vfile);
         cache.$setMdast(file, {
           sha256,
-          pre: { kind: SourceFileKind.Article, file, location, mdast, frontmatter },
+          pre: { kind: SourceFileKind.Article, file, location, mdast, frontmatter, identifiers },
         });
         break;
       }
@@ -78,10 +78,10 @@ export async function loadFile(
         const { sha256, useCache } = checkCache(cache, content, file);
         if (useCache) break;
         const mdast = await processNotebook(cache, file, content, opts);
-        const frontmatter = getPageFrontmatter(session, mdast, vfile);
+        const { frontmatter, identifiers } = getPageFrontmatter(session, mdast, vfile);
         cache.$setMdast(file, {
           sha256,
-          pre: { kind: SourceFileKind.Notebook, file, location, mdast, frontmatter },
+          pre: { kind: SourceFileKind.Notebook, file, location, mdast, frontmatter, identifiers },
         });
         break;
       }

--- a/packages/myst-cli/src/transforms/types.ts
+++ b/packages/myst-cli/src/transforms/types.ts
@@ -9,6 +9,7 @@ export type PreRendererData = {
   mdast: GenericParent;
   kind: SourceFileKind;
   frontmatter?: PageFrontmatter;
+  identifiers?: string[];
 };
 
 export type RendererData = PreRendererData & {

--- a/packages/myst-transforms/src/enumerate.spec.ts
+++ b/packages/myst-transforms/src/enumerate.spec.ts
@@ -48,7 +48,7 @@ describe('enumeration', () => {
         u('math', { identifier: 'eq:3-4', kind: 'subequation' }),
       ]),
     ]);
-    const state = new ReferenceState({ numbering: { enumerator: 'A.%s' } });
+    const state = new ReferenceState('my-file.md', { numbering: { enumerator: 'A.%s' } });
     enumerateTargetsTransform(tree, { state });
     expect(state.getTarget('eq:1')?.node.enumerator).toBe('A.1');
     expect(state.getTarget('eq:1a')?.node.enumerator).toBe('A.1a');
@@ -67,7 +67,9 @@ describe('enumeration', () => {
       u('heading', { identifier: 'h2', depth: 2 }),
       u('heading', { identifier: 'h3', depth: 1 }),
     ]);
-    const state = new ReferenceState({ numbering: { heading_1: true, heading_2: true } });
+    const state = new ReferenceState('my-file.md', {
+      numbering: { heading_1: true, heading_2: true },
+    });
     enumerateTargetsTransform(tree, { state });
     expect(state.getTarget('h1')?.node.enumerator).toBe('1');
     expect(state.getTarget('h2')?.node.enumerator).toBe('1.1');
@@ -82,7 +84,7 @@ describe('enumeration', () => {
       ]),
       u('container', { identifier: 'fig:2', kind: 'figure' }, []),
     ]);
-    const state = new ReferenceState({ numbering: { enumerator: 'A.%s' } });
+    const state = new ReferenceState('my-file.md', { numbering: { enumerator: 'A.%s' } });
     enumerateTargetsTransform(tree, { state });
     expect(state.getTarget('fig:1')?.node.enumerator).toBe('A.1');
     expect(state.getTarget('fig:1a')?.node.enumerator).toBe('a');

--- a/packages/myst-transforms/src/frontmatter.spec.ts
+++ b/packages/myst-transforms/src/frontmatter.spec.ts
@@ -608,4 +608,28 @@ describe('getFrontmatter', () => {
     expect(frontmatter).toEqual({ title: 'Heading Title', content_includes_title: false });
     expect(file.messages.length).toBe(1);
   });
+  it('first h1 label carries to page', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'heading',
+          depth: 1,
+          label: 'h1',
+          children: [
+            {
+              type: 'text',
+              value: 'Heading Title',
+            },
+          ],
+        },
+        {
+          type: 'text',
+          value: 'hello',
+        },
+      ],
+    };
+    const { identifiers } = getFrontmatter(new VFile(), copy(input), {});
+    expect(identifiers).toEqual(['h1']);
+  });
 });

--- a/packages/myst-transforms/src/glossary.ts
+++ b/packages/myst-transforms/src/glossary.ts
@@ -4,17 +4,8 @@ import type { VFile } from 'vfile';
 import { selectAll } from 'unist-util-select';
 import type { GenericParent } from 'myst-common';
 import { normalizeLabel, toText, fileError, RuleId } from 'myst-common';
-import type { IReferenceState } from './enumerate.js';
 
-export type Options = {
-  state: IReferenceState;
-};
-
-export function glossaryTransform<T extends Node | GenericParent>(
-  mdast: T,
-  file: VFile,
-  opts: Options,
-) {
+export function glossaryTransform<T extends Node | GenericParent>(mdast: T, file: VFile) {
   const glossaries = selectAll('glossary', mdast) as GenericParent[];
   glossaries.forEach((glossary) => {
     glossary.children.forEach((list) => {
@@ -41,7 +32,6 @@ export function glossaryTransform<T extends Node | GenericParent>(
   });
 }
 
-export const glossaryPlugin: Plugin<[Options], GenericParent, GenericParent> =
-  (opts) => (tree, file) => {
-    glossaryTransform(tree, file, opts);
-  };
+export const glossaryPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree, file) => {
+  glossaryTransform(tree, file);
+};

--- a/packages/myst-transforms/src/index.ts
+++ b/packages/myst-transforms/src/index.ts
@@ -55,14 +55,14 @@ export { containerChildrenPlugin, containerChildrenTransform } from './container
 export { headingDepthPlugin, headingDepthTransform } from './headings.js';
 
 // Enumeration
-export type { IReferenceState, NumberingOptions, ReferenceKind } from './enumerate.js';
+export type { IReferenceStateResolver, NumberingOptions, ReferenceKind } from './enumerate.js';
 export {
   enumerateTargetsTransform,
   enumerateTargetsPlugin,
   resolveReferencesTransform,
   resolveReferencesPlugin,
   ReferenceState,
-  MultiPageReferenceState,
+  MultiPageReferenceResolver,
 } from './enumerate.js';
 
 // Composite plugins

--- a/packages/myst-transforms/tests/enumerators.spec.ts
+++ b/packages/myst-transforms/tests/enumerators.spec.ts
@@ -23,7 +23,7 @@ describe('enumerateTargets', () => {
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
     '%s',
     (_, { before, after, opts }) => {
-      const state = new ReferenceState(opts);
+      const state = new ReferenceState('my-file.md', opts);
       const transformed = enumerateTargetsTransform(before, { state });
       expect(yaml.dump(transformed)).toEqual(yaml.dump(after));
     },


### PR DESCRIPTION
By default, if no title is provided, MyST will lift the first H1 header out of the page and make it the title. However, if that header is labeled, the label is lost, e.g.

```markdown
(introduction)=
# Introduction To My Research

...
```

Anywhere that references `[](#introduction)` will be broken.

This PR fixes that, so now references to the label will become links to the page. To get here, it took a few steps:
1. processed pages now have `identifiers`
2. `ReferenceStateResolvers` can now get `fileTargets` in addition to "normal" node targets
3. Cross-references to these new file targets resolve into an internal `Link` node.

I also refactored the ReferenceState code a little bit... Previously there was a single page `ReferenceState` and a `MultiPageReferenceState`. Both had functionality to add targets and resolve targets; however, we should never actually add targets to a multi-page state - they are only on a single page. So now, there is a `ReferenceState` similar to before and a `MultiPageReferenceResolver` which only does the resolving part...