### PR TITLE
Add macro to convert `\cref{}` into Myst reference

### DIFF
--- a/packages/tex-to-myst/src/refs.ts
+++ b/packages/tex-to-myst/src/refs.ts
@@ -51,4 +51,9 @@ export const REF_HANDLERS: Record<string, Handler> = {
     const label = texToText(getArguments(node, 'group'));
     state.pushNode(u('crossReference', { label }));
   },
+  macro_cref(node, state){
+    state.openParagraph();
+    const label = texToText(getArguments(node, 'group'));
+    state.pushNode(u('crossReference', { label }, [u('text', '%s')]))
+  }
 };

--- a/packages/tex-to-myst/tests/refs.yml
+++ b/packages/tex-to-myst/tests/refs.yml
@@ -105,3 +105,48 @@ cases:
               children:
                 - type: text
                   value: '%s'
+  - title: cref
+    tex: >
+      \section{Greetings}
+      \label{sec:greetings}
+
+      Hello!
+
+      \section{Referencing}
+
+      I greeted in section~\cref{sec:greetings}.
+    tree:
+      type: root
+      children:
+        - type: block
+          children:
+            - type: heading
+              depth: 2
+              identifier: sec:greetings
+              label: sec:greetings
+              children:
+                - type: text
+                  value: Greetings
+            - type: paragraph
+              children:
+                - type: text
+                  value: Hello!
+        - type: block
+          children:
+            - type: heading
+              depth: 2
+              children:
+                - type: text
+                  value: Referencing
+            - type: paragraph
+              children:
+                - type: text
+                  value: 'I greeted in section '
+                - type: crossReference
+                  identifier: sec:greetings
+                  label: sec:greetings
+                  children:
+                    - type: text
+                      value: '%s'
+                - type: text
+                  value: '.'


### PR DESCRIPTION
Closes #872.

This PR adds:

- a new macro to convert a tex reference made with `\cref{}` into a Myst reference.
- a test for the new macro.