### PR TITLE
🔧  Only parse frontmatter out of first notebook cell

### DIFF
--- a/.changeset/breezy-hairs-poke.md
+++ b/.changeset/breezy-hairs-poke.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'mystmd': patch
+---
+
+Only parse frontmatter out of first notebook cell

--- a/packages/myst-cli/src/process/myst.ts
+++ b/packages/myst-cli/src/process/myst.ts
@@ -11,13 +11,28 @@ import { logMessagesFromVFile } from '../utils/logMessagesFromVFile.js';
 import type { GenericParent } from 'myst-common';
 
 /**
+ * Boiled-down options for parseMyst
+ *
+ * These options are far simpler than the extensive options allowed
+ * if myst-parser and markdown-it are used directly.
+ */
+type Options = {
+  ignoreFrontmatter?: boolean;
+};
+
+/**
  * Parse MyST content using the full suite of built-in directives, roles, and plugins
  *
  * @param session session with logging
  * @param content Markdown content to parse
  * @param file path to file containing content
  */
-export function parseMyst(session: ISession, content: string, file: string): GenericParent {
+export function parseMyst(
+  session: ISession,
+  content: string,
+  file: string,
+  opts?: Options,
+): GenericParent {
   const vfile = new VFile();
   vfile.path = file;
   const parsed = mystParse(content, {
@@ -31,6 +46,9 @@ export function parseMyst(session: ISession, content: string, file: string): Gen
       ...tabDirectives,
       ...(session.plugins?.directives ?? []),
     ],
+    extensions: {
+      frontmatter: !opts?.ignoreFrontmatter,
+    },
     roles: [reactiveRole, ...(session.plugins?.roles ?? [])],
     vfile,
   });

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -93,7 +93,7 @@ export async function processNotebook(
         const cellContent = ensureString(cell.source);
         // If the first cell is a frontmatter block, do not put a block break above it
         const omitBlockDivider = index === 0 && cellContent.startsWith('---\n');
-        const cellMdast = parseMyst(session, cellContent, file);
+        const cellMdast = parseMyst(session, cellContent, file, { ignoreFrontmatter: index > 0 });
         if (cell.attachments) {
           replaceAttachmentsTransform(session, cellMdast, cell.attachments as IAttachments, file);
         }

--- a/packages/mystmd/tests/exports.yml
+++ b/packages/mystmd/tests/exports.yml
@@ -71,3 +71,9 @@ cases:
         content: outputs/multi-page-tex-two.tex
       - path: multi-page-override-tex/_build/out-three.tex
         content: outputs/multi-page-tex-three.tex
+  - title: Notebook exports to tex; frontmatter from first cell only
+    cwd: notebook-with-fm
+    command: myst build --tex --ci
+    outputs:
+      - path: notebook-with-fm/_build/out.tex
+        content: outputs/notebook.tex

--- a/packages/mystmd/tests/notebook-with-fm/input.ipynb
+++ b/packages/mystmd/tests/notebook-with-fm/input.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: Real Title\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('hello world')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: Section One\n",
+    "---\n",
+    "\n",
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna [aliqua](https://example.com)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/packages/mystmd/tests/notebook-with-fm/myst.yml
+++ b/packages/mystmd/tests/notebook-with-fm/myst.yml
@@ -1,0 +1,7 @@
+version: 1
+project:
+  export:
+    format: tex
+    template: ../templates/tex
+    output: _build/out.tex
+    article: input.ipynb

--- a/packages/mystmd/tests/outputs/notebook.tex
+++ b/packages/mystmd/tests/outputs/notebook.tex
@@ -1,0 +1,91 @@
+\documentclass[a4paper,11pt,oneside]{book}
+\usepackage[top=2cm, bottom=2cm, left=2cm, right=2cm]{geometry}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage{hyperref}
+\usepackage{graphicx}
+\usepackage{caption}
+\usepackage{natbib}
+\bibliographystyle{abbrvnat}
+
+% Make list items more compact
+\usepackage{enumitem}
+\setlist[itemize]{noitemsep, topsep=0pt}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%  imports  %%%%%%%%%%%%%%%%%%%
+\usepackage{url}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\usepackage{glossaries}
+\makeglossaries
+
+
+
+% Style quotes
+\usepackage{xcolor}
+% Change links to basic
+\hypersetup{
+  colorlinks,
+  linkcolor={black},
+  citecolor={black},
+  % urlcolor={blue!80!black}
+  urlcolor={black}
+}
+\usepackage{framed}
+\definecolor{quoteshade}{rgb}{0.95,0.95,1}
+\renewenvironment{quote}{%
+  \def\FrameCommand{%
+    \hspace{1pt}%
+    {\color{darkblue}\vrule width 2pt}%
+    {\color{quoteshade}\vrule width 4pt}%
+    \colorbox{quoteshade}%
+  }%
+  \MakeFramed{\advance\hsize-\width\FrameRestore}
+  \noindent\hspace{-8pt}% disable indenting first paragraph
+  \begin{adjustwidth}
+  \vspace{2pt}\vspace{2pt}%
+}
+{%
+  \vspace{2pt}\end{adjustwidth}\endMakeFramed%
+}
+
+\title{\Huge \textbf{Real Title}}
+\author{\textsc{}}
+
+\begin{document}
+\sloppy
+
+\frontmatter
+\maketitle
+
+\tableofcontents
+% \listoffigures
+% \listoftables
+
+\mainmatter
+
+% \include{preface.tex}
+% \include{acknowledgements.tex}
+
+\begin{verbatim}
+print('hello world')
+\end{verbatim}
+
+
+\bigskip
+\centerline{\rule{13cm}{0.4pt}}
+\bigskip
+
+\subsection{title: Section One}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna \href{https://example.com}{aliqua}.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%  acronyms & glossary  %%%%%%%%%%%%%
+\printglossaries
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+
+
+\end{document}


### PR DESCRIPTION
We modified notebook loading to parse each cell individually - this cased a bug where every cell could have a yaml frontmatter block.

This PR turns off that behaviour for all but the first cell.