### PR TITLE
⚙️ Move to `v4` for checkout and node actions

### DIFF
--- a/.changeset/lemon-boxes-divide.md
+++ b/.changeset/lemon-boxes-divide.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Change github action to use v4 for setup-node and checkout

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -14,7 +14,7 @@ runs:
         sudo apt-get install -y libxml2-utils
       shell: bash
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node }}
         cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
           submodules: recursive
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - run: npm install
       - run: npm run lint:format
       - run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
           submodules: recursive

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -124,10 +124,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Install MyST Markdown

--- a/packages/myst-cli/src/build/gh-actions/index.ts
+++ b/packages/myst-cli/src/build/gh-actions/index.ts
@@ -49,10 +49,10 @@ jobs:
       url: \${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Install MyST Markdown


### PR DESCRIPTION
The node16 actions are being deprecated.