### PR TITLE
🎣 Extract DOI from note for citations

### DIFF
--- a/.changeset/orange-radios-rhyme.md
+++ b/.changeset/orange-radios-rhyme.md
@@ -1,0 +1,5 @@
+---
+"citation-js-utils": patch
+---
+
+Extract DOI from note for citations

--- a/packages/citation-js-utils/src/index.ts
+++ b/packages/citation-js-utils/src/index.ts
@@ -5,6 +5,8 @@ import sanitizeHtml from 'sanitize-html';
 import '@citation-js/plugin-bibtex';
 import '@citation-js/plugin-csl';
 
+const DOI_IN_TEXT = /(10.\d{4,9}\/[-._;()/:A-Z0-9]*[A-Z0-9])/i;
+
 // This is duplicated in citation-js types, which are not exported
 export type CitationJson = {
   type?: 'article-journal' | string;
@@ -143,6 +145,10 @@ export async function getCitations(bibtex: string): Promise<CitationRenderer> {
 
   return Object.fromEntries(
     p.data.map((c: any): [string, CitationRenderer[0]] => {
+      const matchDoi = c.note?.match(DOI_IN_TEXT);
+      if (!c.DOI && matchDoi) {
+        c.DOI = matchDoi[0];
+      }
       return [
         c.id,
         {

--- a/packages/citation-js-utils/tests/basic.spec.ts
+++ b/packages/citation-js-utils/tests/basic.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { getCitations, CitationJSStyles } from '../src';
-import { bibtex, TEST_APA_HTML, TEST_VANCOUVER_HTML } from './fixtures';
+import {
+  bibtex,
+  doiInNote,
+  TEST_APA_HTML,
+  TEST_DOI_IN_NOTE,
+  TEST_VANCOUVER_HTML,
+} from './fixtures';
 
 const key = 'Cockett2015SimPEG';
 
@@ -17,5 +23,9 @@ describe('Test reference rendering', () => {
     const citations = await getCitations(bibtex);
     const cite = citations[key];
     expect(cite.render(CitationJSStyles.vancouver)).toEqual(TEST_VANCOUVER_HTML);
+  });
+  it('Extract the DOI from the note', async () => {
+    const citations = await getCitations(doiInNote);
+    expect(citations['cury2020sparse'].getDOI()).toBe(TEST_DOI_IN_NOTE);
   });
 });

--- a/packages/citation-js-utils/tests/fixtures.ts
+++ b/packages/citation-js-utils/tests/fixtures.ts
@@ -11,6 +11,19 @@ export const bibtex = `@article{Cockett2015SimPEG,
   url = {http://dx.doi.org/10.1016/j.cageo.2015.09.015},
 }`;
 
+export const doiInNote = `@article{cury2020sparse,
+  title={A sparse EEG-informed fMRI model for hybrid EEG-fMRI neurofeedback prediction},
+  author={Cury, Claire and Maurel, Pierre and Gribonval, R{\\'e}mi and Barillot, Christian},
+  journal={Frontiers in neuroscience},
+	note = {See the DOI in \\url{https://doi.org/10.3389/fnins.2019.01451}, for example.},
+  volume={13},
+  pages={1451},
+  year={2020},
+  publisher={Frontiers}
+}`;
+
+export const TEST_DOI_IN_NOTE = '10.3389/fnins.2019.01451';
+
 export const TEST_DATA_JSON =
   '{"type":"article","label":"Cockett2015SimPEG","properties":{"author":"Cockett, Rowan and Kang, Seogi and Heagy, Lindsey J. and Pidlisecky, Adam and Oldenburg, Douglas W.","journal":"Computers & Geosciences","year":"2015","month":"12","pages":"142--154","title":"SimPEG: An open source framework for simulation and gradient based parameter estimation in geophysical applications","volume":"85","doi": "10.1016/j.cageo.2015.09.015","issn": "0098-3004","url": "http://dx.doi.org/10.1016/j.cageo.2015.09.015"}}';
 export const TEST_DATA_RIS =


### PR DESCRIPTION
This allows for pulling out DOIs from the `note` element in a bibtex citation, this is quite common in some areas that use IEEE citation styles which by default doesn't show the DOI, so people move it to the note.

We still want to get the DOI out when rendering with MyST.