### PR TITLE
🔧  Prevent basic transforms from modifying headings by default

### DIFF
--- a/.changeset/brown-numbers-wait.md
+++ b/.changeset/brown-numbers-wait.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Prevent basic transforms from modifying headings by default

--- a/packages/myst-transforms/src/headings.spec.ts
+++ b/packages/myst-transforms/src/headings.spec.ts
@@ -33,7 +33,7 @@ beforeEach(() => {
 describe('headingDepthTransform', () => {
   it('sequential heading depths default to firstDepth = 1', () => {
     const mdast = mdastWithHeadings([1, 2, 3, 1, 2, 1, 2]);
-    headingDepthTransform(mdast, vfile);
+    headingDepthTransform(mdast, vfile, { firstDepth: 1 });
     expect(mdast).toEqual(mdastWithHeadings([1, 2, 3, 1, 2, 1, 2]));
     expect(vfile.messages.length).toBe(0);
   });
@@ -45,13 +45,13 @@ describe('headingDepthTransform', () => {
   });
   it('missing heading depths filled in', () => {
     const mdast = mdastWithHeadings([1, 2, 4, 1, 2, 1, 5]);
-    headingDepthTransform(mdast, vfile);
+    headingDepthTransform(mdast, vfile, { firstDepth: 1 });
     expect(mdast).toEqual(mdastWithHeadings([1, 2, 3, 1, 2, 1, 4]));
     expect(vfile.messages.length).toBe(1);
   });
-  it('lowest depth becomes 2', () => {
+  it('lowest depth becomes 1', () => {
     const mdast = mdastWithHeadings([3, 4]);
-    headingDepthTransform(mdast, vfile);
+    headingDepthTransform(mdast, vfile, { firstDepth: 1 });
     expect(mdast).toEqual(mdastWithHeadings([1, 2]));
     expect(vfile.messages.length).toBe(0);
   });
@@ -71,6 +71,12 @@ describe('headingDepthTransform', () => {
     const mdast = mdastWithHeadings([1, 2, 3, 1, 2, 1, 2]);
     headingDepthTransform(mdast, vfile, { firstDepth: -1 });
     expect(mdast).toEqual(mdastWithHeadings([1, 2, 3, 1, 2, 1, 2]));
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('heading depths unchanged with no firstDepth', () => {
+    const mdast = mdastWithHeadings([4, 5, 6, 4, 5, 4, 5]);
+    headingDepthTransform(mdast, vfile);
+    expect(mdast).toEqual(mdastWithHeadings([4, 5, 6, 4, 5, 4, 5]));
     expect(vfile.messages.length).toBe(0);
   });
 });

--- a/packages/myst-transforms/src/headings.ts
+++ b/packages/myst-transforms/src/headings.ts
@@ -9,25 +9,28 @@ type HeadingDepthOptions = { firstDepth?: number };
 /**
  * Normalize heading depths based on specified first heading depth
  *
- * By default, firstDepth is 1; if, for example, the title should be
- * depth 1 and the first heading of the content should be depth 2,
- * you must specify firstDepth = 2. This transform does not take
- * into account frontmatter title or content_includes_title flag;
- * These must be taken into account when determining first depth.
- * First depth cannot be < 1.
- *
- * The heading levels will be modified so they are all sequential and begin
+ * Heading levels will be modified so they are all sequential and begin
  * at firstDepth. If heading depths are non-sequential, a warning will be
  * raised and they will be normalized to sequential. If max heading depth
  * is greater than 6, a warning is also raised, and all values greater than
  * 6 will be left at 6.
+ *
+ * If firstDepth is undefined, the default, this transform will do nothing.
+ *
+ * If, for example, the title is defined in the frontmatter but should be
+ * depth 1, the first heading of the content should be depth 2 and
+ * you must specify firstDepth = 2. This transform does not take
+ * into account frontmatter title or content_includes_title flag;
+ * These must be considered when specifying firstDepth.
+ * First depth cannot be < 1.
  */
 export async function headingDepthTransform(
   tree: GenericParent,
   vfile: VFile,
   opts?: HeadingDepthOptions,
 ) {
-  const firstDepth = opts?.firstDepth && opts.firstDepth > 0 ? opts.firstDepth : 1;
+  if (opts?.firstDepth == null) return;
+  const firstDepth = opts.firstDepth > 0 ? opts.firstDepth : 1;
   const headings = selectAll('heading', tree) as Heading[];
   if (headings.length === 0) return;
   const currentDepths = [


### PR DESCRIPTION
Recently a new transform was added to `basicTransformations` which normalized heading depth to start at `firstDepth` and count sequentially from there (eliminating skipped depth levels in the source document, etc. - introduced here: https://github.com/executablebooks/mystmd/pull/860 and modified here: https://github.com/executablebooks/mystmd/pull/875/files#diff-8c1296487484c1e135623cfc74ae7da928a293e1b6e5078690cfc7a1fe01df09)

However, there was no way to disable this behaviour; running the basic transforms meant heading depths would get normalized.

Now, this transform _only_ runs if you explicitly provide `firstDepth`. `myst-cli` always provides a value for `firstDepth`, so default, opinionated MyST behaviour is unchanged. But if you use `headingDepthTransform` or `basicTransformations` directly, this functionality may be disabled.