### PR TITLE
👈 Cross reference the subEnumerator directly.

### DIFF
--- a/.changeset/real-jeans-shout.md
+++ b/.changeset/real-jeans-shout.md
@@ -1,0 +1,5 @@
+---
+"myst-transforms": patch
+---
+
+Allow for {subEnumerator} to be a reference target template.

--- a/.changeset/rich-frogs-try.md
+++ b/.changeset/rich-frogs-try.md
@@ -1,0 +1,5 @@
+---
+"tex-to-myst": patch
+---
+
+Add subref, subfigure, and landscape functions for tex

--- a/.changeset/tender-crabs-push.md
+++ b/.changeset/tender-crabs-push.md
@@ -1,0 +1,5 @@
+---
+"myst-spec-ext": patch
+---
+
+Allow the figure container to have an extensible kind

--- a/docs/figures.md
+++ b/docs/figures.md
@@ -90,6 +90,8 @@ Some pictures of fruit and beaches!
 See [](#my-figure-fruit) for the fruit, and [](#my-figure) to reference both subfigures.
 ```
 
+By default, when referring to subfigures, the `{number}` that is used includes the parent enumerator (that is: `1a` rather than just `a`). To specifically use the sub-enumerator only, you can use the syntax `{subEnumerator}` in your text link which will be replaced with the sub-enumerator (that is: `a` rather than `1a`).
+
 ## Supported Image Formats
 
 MyST supports many images formats including `.png`, `.jpg`, `.gif`, `.tiff`, `.svg`, `.pdf`, and `.eps`.

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -217,7 +217,7 @@ export type Include = {
 };
 
 export type Container = Omit<SpecContainer, 'kind'> & {
-  kind?: 'figure' | 'table' | 'quote' | 'code';
+  kind?: 'figure' | 'table' | 'quote' | 'code' | string;
   source?: Dependency;
   subcontainer?: boolean;
   noSubcontainers?: boolean;

--- a/packages/tex-to-myst/src/figures.ts
+++ b/packages/tex-to-myst/src/figures.ts
@@ -33,7 +33,11 @@ const FIGURE_HANDLERS: Record<string, Handler> = {
     state.closeNode();
   },
   env_subfigure(node, state) {
+    state.closeParagraph();
+    state.openNode('container', { kind: 'figure' });
     state.renderChildren(node);
+    state.closeParagraph();
+    state.closeNode();
   },
   env_centering(node, state) {
     centering(node, state);

--- a/packages/tex-to-myst/src/misc.ts
+++ b/packages/tex-to-myst/src/misc.ts
@@ -54,6 +54,13 @@ export const MISC_HANDLERS: Record<string, Handler> = {
   macro_and(node, state) {
     state.data.andCallback?.();
   },
+  env_landscape(node, state) {
+    state.closeParagraph();
+    state.openBlock({ landscape: true });
+    state.renderChildren(node);
+    state.closeParagraph();
+    state.closeBlock();
+  },
   macro_noindent: pass,
   macro_acknowledgments: pass,
   macro_def: pass,

--- a/packages/tex-to-myst/src/refs.ts
+++ b/packages/tex-to-myst/src/refs.ts
@@ -30,6 +30,11 @@ export const REF_HANDLERS: Record<string, Handler> = {
     const label = texToText(getArguments(node, 'group'));
     state.pushNode(u('crossReference', { label }, [u('text', '%s')]));
   },
+  macro_subref(node, state) {
+    state.openParagraph();
+    const label = texToText(getArguments(node, 'group'));
+    state.pushNode(u('crossReference', { label }, [u('text', '{subEnumerator}')]));
+  },
   macro_nameref(node, state) {
     state.openParagraph();
     const label = texToText(getArguments(node, 'group'));

--- a/packages/tex-to-myst/src/tex.ts
+++ b/packages/tex-to-myst/src/tex.ts
@@ -63,6 +63,7 @@ const macros: Record<string, number> = {
   primarypubs: 2,
   eqref: 1,
   nameref: 1,
+  subref: 1,
   textsubscript: 1,
   textsuperscript: 1,
   adjustwidth: 2,

--- a/packages/tex-to-myst/tests/figures.yml
+++ b/packages/tex-to-myst/tests/figures.yml
@@ -101,10 +101,15 @@ cases:
   - title: subfigure
     tex: |-
       \begin{figure}
+        \begin{subfigure}{0.49\textwidth}
+          \includegraphics[width=\textwidth]{figures/one.jpg}
+          \caption{This is Fig 1a}
+        \end{subfigure}
         \begin{subfigure}[b]{0.49\textwidth}
           \centering
-          \includegraphics[width=\textwidth]{figures/one.jpg}
+          \includegraphics[width=\textwidth]{figures/two.jpg}
         \end{subfigure}
+        \caption{This is the full figure caption.}
       \end{figure}
     tree:
       type: root
@@ -112,9 +117,29 @@ cases:
         - type: container
           kind: figure
           children:
-            - type: image
-              url: figures/one.jpg
-          align: center
+            - type: container
+              kind: figure
+              children:
+                - type: image
+                  url: figures/one.jpg
+                - type: caption
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: This is Fig 1a
+            - type: container
+              kind: figure
+              align: center
+              children:
+                - type: image
+                  url: figures/two.jpg
+            - type: caption
+              children:
+                - type: paragraph
+                  children:
+                    - type: text
+                      value: This is the full figure caption.
   - title: minipage
     tex: |-
       \begin{figure}


### PR DESCRIPTION
Also adds support in latex for `subref`, `landscape` and improves `subfigure` support for multiple captions defined in latex.