### PR TITLE
MAINT: update python release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
-
+  workflow_dispatch:
+    inputs:
+      forcePublishPyPI:
+        description: |
+          Force publish to PyPI, even if the NPM release has already occurred.i
+        type: boolean
+        required: false
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -53,7 +59,7 @@ jobs:
   release-py:  
     name: Release Python
     runs-on: ubuntu-latest
-    if: ${{ needs.build-npm.outputs.published }}
+    if: ${{ needs.build-npm.outputs.published || inputs.forcePublishPyPI }}
     needs:
       - release-npm
       - build-py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,11 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  release:
-    name: Release
+  release-npm:
+    name: Release NPM
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -32,12 +34,39 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Publish to PyPI
-        if: steps.changesets.outputs.published == 'true'
+  build-py:
+    name: Build Python
+    runs-on: ubuntu-latest
+    needs:
+      - release-npm
+    steps:
+      - name: Build Python package
         run: |
-          pip install twine build
-          cd packages/mystmd-py
-          bash scripts/pypi-deploy.sh
-        env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          pip install build
+          python -m build
+        working-directory: ./packages/mystmd-py
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: ./packages/mystmd-py/dist/
+  release-py:  
+    name: Release Python
+    runs-on: ubuntu-latest
+    if: ${{ needs.build-npm.outputs.published }}
+    needs:
+      - release-npm
+      - build-py
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mystmd
+    permissions:
+      id-token: write
+    steps:    
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/       
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/packages/mystmd/package.json
+++ b/packages/mystmd/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/executablebooks/mystmd.git"
+    "url": "https://github.com/executablebooks/mystmd.git"
   },
   "bugs": {
     "url": "https://github.com/executablebooks/mystmd/issues"


### PR DESCRIPTION
This PR:
- Updates the `mystmd` package metadata to provide a valid Git URL (only https scheme) for PyPI
- Updates the release workflow to use the new trusted publisher