### PR TITLE
MAINT: use _package.json to avoid NPM errors during local dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           pip install build
           # Copy over needed files
           cp ../mystmd/dist/myst.cjs src/mystmd_py/
-          cp ../mystmd/package.json .
+          cp ../mystmd/package.json _package.json
           python -m build
         working-directory: packages/mystmd-py
       - name: Store the distribution packages

--- a/packages/mystmd-py/.gitignore
+++ b/packages/mystmd-py/.gitignore
@@ -1,5 +1,5 @@
 *.egg-info
 dist
 src/mystmd_py/myst.cjs
-package.json
 **/__pycache__/
+_package.json

--- a/packages/mystmd-py/pyproject.toml
+++ b/packages/mystmd-py/pyproject.toml
@@ -32,13 +32,15 @@ myst = "mystmd_py.main:main"
 
 [tool.hatch.version]
 source = "nodejs"
+path = "_package.json"		
 
 [tool.hatch.metadata.hooks.nodejs]
 fields = ["description", "authors", "urls", "keywords", "license"]
+path = "_package.json"
 
 [tool.hatch.build.targets.sdist]
 artifacts = [
-    "/package.json",
+    "/_package.json",
     "/src/mystmd_py/myst.cjs"
 ]
 

--- a/packages/mystmd-py/scripts/pypi-deploy.sh
+++ b/packages/mystmd-py/scripts/pypi-deploy.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-cp ../mystmd/dist/myst.cjs mystmd_py
-cp ../mystmd/package.json .
-rm -rf dist
-python -m build
-python -m twine upload dist/*

--- a/packages/mystmd/package.json
+++ b/packages/mystmd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mystmd",
-  "version": "1.1.40",
+  "version": "1.1.41",
   "description": "Command line tools for MyST Markdown",
   "author": "Rowan Cockett <rowan@curvenote.com>",
   "license": "MIT",

--- a/packages/mystmd/package.json
+++ b/packages/mystmd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mystmd",
-  "version": "1.1.41",
+  "version": "1.1.40",
   "description": "Command line tools for MyST Markdown",
   "author": "Rowan Cockett <rowan@curvenote.com>",
   "license": "MIT",


### PR DESCRIPTION
This PR changes the build plugin to look for `_package.json` rather than the canonical name. This ensures that the build artifact (`_package.json`) is not found by NPM during local development (as it complains).