### PR TITLE
🎣 Extract DOI from URL for citations

### DIFF
--- a/.changeset/lemon-tomatoes-share.md
+++ b/.changeset/lemon-tomatoes-share.md
@@ -1,0 +1,5 @@
+---
+"citation-js-utils": patch
+---
+
+Extract DOI from the URL in bibtex

--- a/packages/citation-js-utils/src/index.ts
+++ b/packages/citation-js-utils/src/index.ts
@@ -145,7 +145,7 @@ export async function getCitations(bibtex: string): Promise<CitationRenderer> {
 
   return Object.fromEntries(
     p.data.map((c: any): [string, CitationRenderer[0]] => {
-      const matchDoi = c.note?.match(DOI_IN_TEXT);
+      const matchDoi = c.URL?.match(DOI_IN_TEXT) ?? c.note?.match(DOI_IN_TEXT);
       if (!c.DOI && matchDoi) {
         c.DOI = matchDoi[0];
       }

--- a/packages/citation-js-utils/tests/basic.spec.ts
+++ b/packages/citation-js-utils/tests/basic.spec.ts
@@ -3,8 +3,9 @@ import { getCitations, CitationJSStyles } from '../src';
 import {
   bibtex,
   doiInNote,
+  doiInURL,
   TEST_APA_HTML,
-  TEST_DOI_IN_NOTE,
+  TEST_DOI_IN_OTHER_FIELD,
   TEST_VANCOUVER_HTML,
 } from './fixtures';
 
@@ -24,8 +25,11 @@ describe('Test reference rendering', () => {
     const cite = citations[key];
     expect(cite.render(CitationJSStyles.vancouver)).toEqual(TEST_VANCOUVER_HTML);
   });
-  it('Extract the DOI from the note', async () => {
-    const citations = await getCitations(doiInNote);
-    expect(citations['cury2020sparse'].getDOI()).toBe(TEST_DOI_IN_NOTE);
+  it.each([
+    ['url', doiInURL],
+    ['note', doiInNote],
+  ])('Extract the DOI from the %s', async (_, src) => {
+    const citations = await getCitations(src);
+    expect(citations['cury2020sparse'].getDOI()).toBe(TEST_DOI_IN_OTHER_FIELD);
   });
 });

--- a/packages/citation-js-utils/tests/fixtures.ts
+++ b/packages/citation-js-utils/tests/fixtures.ts
@@ -22,7 +22,18 @@ export const doiInNote = `@article{cury2020sparse,
   publisher={Frontiers}
 }`;
 
-export const TEST_DOI_IN_NOTE = '10.3389/fnins.2019.01451';
+export const doiInURL = `@article{cury2020sparse,
+  title={A sparse EEG-informed fMRI model for hybrid EEG-fMRI neurofeedback prediction},
+  author={Cury, Claire and Maurel, Pierre and Gribonval, R{\\'e}mi and Barillot, Christian},
+  journal={Frontiers in neuroscience},
+	url = {https://doi.org/10.3389/fnins.2019.01451},
+  volume={13},
+  pages={1451},
+  year={2020},
+  publisher={Frontiers}
+}`;
+
+export const TEST_DOI_IN_OTHER_FIELD = '10.3389/fnins.2019.01451';
 
 export const TEST_DATA_JSON =
   '{"type":"article","label":"Cockett2015SimPEG","properties":{"author":"Cockett, Rowan and Kang, Seogi and Heagy, Lindsey J. and Pidlisecky, Adam and Oldenburg, Douglas W.","journal":"Computers & Geosciences","year":"2015","month":"12","pages":"142--154","title":"SimPEG: An open source framework for simulation and gradient based parameter estimation in geophysical applications","volume":"85","doi": "10.1016/j.cageo.2015.09.015","issn": "0098-3004","url": "http://dx.doi.org/10.1016/j.cageo.2015.09.015"}}';


### PR DESCRIPTION
This pulls in the DOI from the URL if it isn't already defined.