### PR TITLE
🪆 Support `\input` in latex

### DIFF
--- a/.changeset/long-ducks-shave.md
+++ b/.changeset/long-ducks-shave.md
@@ -1,0 +1,5 @@
+---
+"myst-transforms": patch
+---
+
+Export more include directive content for finer-grain use

--- a/.changeset/new-poems-whisper.md
+++ b/.changeset/new-poems-whisper.md
@@ -1,0 +1,7 @@
+---
+"myst-transforms": patch
+"tex-to-myst": patch
+"myst-cli": patch
+---
+
+Add tex-include to allow for input of sub-tex files

--- a/.changeset/red-schools-love.md
+++ b/.changeset/red-schools-love.md
@@ -1,0 +1,5 @@
+---
+"tex-to-myst": patch
+---
+
+Recognize input / include statements

--- a/.changeset/serious-hairs-visit.md
+++ b/.changeset/serious-hairs-visit.md
@@ -1,0 +1,5 @@
+---
+"myst-transforms": patch
+---
+
+Allow include directive to be recursive

--- a/packages/myst-cli/src/build/site/watch.ts
+++ b/packages/myst-cli/src/build/site/watch.ts
@@ -7,6 +7,7 @@ import { changeFile, fastProcessFile, processSite } from '../../process/site.js'
 import type { TransformFn } from '../../process/mdast.js';
 import { selectors, watch } from '../../store/index.js';
 import { KNOWN_FAST_BUILDS } from '../../utils/resolveExtension.js';
+import chalk from 'chalk';
 
 // TODO: allow this to work from other paths
 
@@ -90,7 +91,9 @@ async function fileProcessor(
     });
   }
   if (dependencies.length) {
-    session.log.info(`🔄 Updating dependent pages`);
+    session.log.info(
+      `🔄 Updating dependent pages for ${file} ${chalk.dim(`[${dependencies.join(', ')}]`)}`,
+    );
     await Promise.all([
       dependencies.map((dep) => {
         const depSlug = selectors.selectPageSlug(session.store.getState(), projectPath, dep);

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -12,7 +12,7 @@ import { frontmatterValidationOpts, getPageFrontmatter } from '../frontmatter.js
 import type { ISession, ISessionWithCache } from '../session/types.js';
 import { castSession } from '../session/cache.js';
 import { warnings, watch } from '../store/reducers.js';
-import type { RendererData } from '../transforms/types.js';
+import type { PreRendererData, RendererData } from '../transforms/types.js';
 import { logMessagesFromVFile } from '../utils/logging.js';
 import { addWarningForFile } from '../utils/addWarningForFile.js';
 import { loadCitations } from './citations.js';
@@ -52,7 +52,7 @@ export async function loadFile(
   projectPath?: string,
   extension?: '.md' | '.ipynb' | '.bib',
   opts?: { preFrontmatter?: Record<string, any> },
-) {
+): Promise<PreRendererData | undefined> {
   await session.loadPlugins();
   const toc = tic();
   session.store.dispatch(warnings.actions.clearWarnings({ file }));
@@ -165,6 +165,7 @@ export async function loadFile(
     success = false;
   }
   if (success) session.log.debug(toc(`loadFile: loaded ${file} in %s.`));
+  return cache.$getMdast(file)?.pre;
 }
 
 /**

--- a/packages/myst-cli/src/transforms/include.ts
+++ b/packages/myst-cli/src/transforms/include.ts
@@ -8,14 +8,9 @@ import { parseMyst } from '../process/myst.js';
 import type { ISession } from '../session/types.js';
 import { watch } from '../store/reducers.js';
 
-export async function includeFilesTransform(
-  session: ISession,
-  baseFile: string,
-  tree: GenericParent,
-  vfile: VFile,
-) {
-  const dir = path.dirname(baseFile);
-  const loadFile = (filename: string) => {
+export const makeFileLoader =
+  (session: ISession, vfile: VFile, baseFile: string) => (filename: string) => {
+    const dir = path.dirname(baseFile);
     const fullFile = path.join(dir, filename);
     if (!fs.existsSync(fullFile)) {
       fileError(vfile, `Include Directive: Could not find "${fullFile}" in "${baseFile}"`, {
@@ -31,11 +26,19 @@ export async function includeFilesTransform(
     );
     return fs.readFileSync(fullFile).toString();
   };
+
+export async function includeFilesTransform(
+  session: ISession,
+  baseFile: string,
+  tree: GenericParent,
+  vfile: VFile,
+) {
   const parseContent = (filename: string, content: string) => {
     if (filename.toLowerCase().endsWith('.html')) {
       return [{ type: 'html', value: content }];
     }
     return parseMyst(session, content, filename).children;
   };
+  const loadFile = makeFileLoader(session, vfile, baseFile);
   await includeDirectiveTransform(tree, vfile, { loadFile, parseContent });
 }

--- a/packages/myst-transforms/src/include.ts
+++ b/packages/myst-transforms/src/include.ts
@@ -21,6 +21,8 @@ export async function includeDirectiveTransform(tree: GenericParent, file: VFile
   const includeNodes = selectAll('include', tree) as Include[];
   await Promise.all(
     includeNodes.map(async (node) => {
+      // If the transform has already run, don't run it again!
+      if (node.children && node.children.length > 0) return;
       const rawContent = await opts.loadFile(node.file);
       if (rawContent == null) return;
       const { content, startingLineNumber } = filterIncludedContent(file, node.filter, rawContent);

--- a/packages/myst-transforms/src/include.ts
+++ b/packages/myst-transforms/src/include.ts
@@ -19,6 +19,7 @@ export type Options = {
  */
 export async function includeDirectiveTransform(tree: GenericParent, file: VFile, opts: Options) {
   const includeNodes = selectAll('include', tree) as Include[];
+  if (includeNodes.length === 0) return;
   await Promise.all(
     includeNodes.map(async (node) => {
       // If the transform has already run, don't run it again!
@@ -80,6 +81,8 @@ export async function includeDirectiveTransform(tree: GenericParent, file: VFile
         children = await opts.parseContent(node.file, content);
       }
       node.children = children as any;
+      // Recurse!
+      await includeDirectiveTransform(node as GenericParent, file, opts);
     }),
   );
 }

--- a/packages/myst-transforms/src/include.ts
+++ b/packages/myst-transforms/src/include.ts
@@ -17,7 +17,7 @@ export type Options = {
  * RST documentation:
  *  - https://docutils.sourceforge.io/docs/ref/rst/directives.html#including-an-external-document-fragment
  */
-export async function includeDirectiveTransform(tree: GenericParent, file: VFile, opts: Options) {
+export async function includeDirectiveTransform(tree: GenericParent, vfile: VFile, opts: Options) {
   const includeNodes = selectAll('include', tree) as Include[];
   if (includeNodes.length === 0) return;
   await Promise.all(
@@ -26,7 +26,7 @@ export async function includeDirectiveTransform(tree: GenericParent, file: VFile
       if (node.children && node.children.length > 0) return;
       const rawContent = await opts.loadFile(node.file);
       if (rawContent == null) return;
-      const { content, startingLineNumber } = filterIncludedContent(file, node.filter, rawContent);
+      const { content, startingLineNumber } = filterIncludedContent(vfile, node.filter, rawContent);
       let children: GenericNode[];
       if (node.literal) {
         const code: Code = {
@@ -82,7 +82,7 @@ export async function includeDirectiveTransform(tree: GenericParent, file: VFile
       }
       node.children = children as any;
       // Recurse!
-      await includeDirectiveTransform(node as GenericParent, file, opts);
+      await includeDirectiveTransform(node as GenericParent, vfile, opts);
     }),
   );
 }

--- a/packages/tex-to-myst/src/misc.ts
+++ b/packages/tex-to-myst/src/misc.ts
@@ -61,6 +61,11 @@ export const MISC_HANDLERS: Record<string, Handler> = {
     state.closeParagraph();
     state.closeBlock();
   },
+  macro_input(node, state) {
+    const [content] = getArguments(node, 'group');
+    const file = texToText(content);
+    state.addLeaf('include', { file: file.endsWith('.tex') ? file : `${file}.tex` });
+  },
   macro_noindent: pass,
   macro_acknowledgments: pass,
   macro_def: pass,

--- a/packages/tex-to-myst/tests/cases.spec.ts
+++ b/packages/tex-to-myst/tests/cases.spec.ts
@@ -47,6 +47,7 @@ const files = [
   'verbatim.yml',
   'algorithm.yml',
   'macros.yml',
+  'input.yml',
 ];
 
 const only = ''; // Can set this to a test title

--- a/packages/tex-to-myst/tests/input.yml
+++ b/packages/tex-to-myst/tests/input.yml
@@ -1,0 +1,9 @@
+title: Input
+cases:
+  - title: input
+    tex: \input{figures/main}
+    tree:
+      type: root
+      children:
+        - type: include
+          file: figures/main.tex


### PR DESCRIPTION
This supports the input macro for latex, and improves the include transform to be able to be recursive.