### PR TITLE
🏴‍☠️ Cache DOIs and intersphinx results to file

### DIFF
--- a/.changeset/rare-trainers-listen.md
+++ b/.changeset/rare-trainers-listen.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Cache successful linkcheck results to file

--- a/.changeset/twelve-walls-talk.md
+++ b/.changeset/twelve-walls-talk.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'mystmd': patch
+---
+
+Add cache folder for intersphinx and doi fetches

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -18,7 +18,7 @@ This is a link in markdown: [Cockett, 2022](https://doi.org/10.5281/zenodo.64760
 
 It is also possible to to drop the link text, that is:\
 `<doi:10.5281/zenodo.6476040>` or `[](doi:10.5281/zenodo.6476040)`,\
-which will insert the citation text in the correct format (e.g. adding an italic "_et al._", etc.).
+which will insert the citation text in the correct format (e.g. adding an italic "_et al._", etc.). The citation data for these DOIs will be downloaded from `https://doi.org` once and cached to a local file in the `_build` directory. This cache may be cleared with `myst clean --cache`.
 
 Providing your DOIs as full links has the advantage that on other rendering platforms (e.g. GitHub), your citation will still be shown as a link. If you have many citations, however, this will slow down the build process as the citation information is fetched dynamically.
 

--- a/docs/external-references.md
+++ b/docs/external-references.md
@@ -48,8 +48,8 @@ references:
   jupyterbook: https://jupyterbook.org/en/stable/
 ```
 
-When you specify these in your project configuration, MyST will load and cache the remote `objects.inv` file,
-and provide access to all of the references in that project.
+When you specify these in your project configuration, MyST will load the remote `objects.inv` file,
+and provide access to all of the references in that project. This `inv` file will be cached to disk locally in the `_build` folder, eliminating duplicate web requests on subsequent builds. If the target documentation updates and you must reload the remote references, you may delete the cache with `myst clean --cache`.
 
 ````{important}
 # Intersphinx Examples

--- a/docs/quickstart-myst-websites.md
+++ b/docs/quickstart-myst-websites.md
@@ -148,9 +148,9 @@ Running `myst init` added:
 The `_build` folder also contains your templates (including the site template you installed) and any exports you make (when we build a PDF the exported document will show up in the `_build/exports` folder). You can clean up the built files at any time using `myst clean`[^clean-all].
 
 [^clean-all]:
-    By default the `myst clean` command doesn't remove installed templates, however, the function can with a:\
+    By default the `myst clean` command doesn't remove installed templates or cached web responses; however, the function can with a:\
     `myst clean --all`, or\
-    `myst clean --templates`.
+    `myst clean --templates --cache`.
 
     Before deleting any folders `myst` will confirm what is going to happen, or you can bypass this confirmation with the `-y` option. For example:
 

--- a/packages/myst-cli/docs/reference.md
+++ b/packages/myst-cli/docs/reference.md
@@ -85,6 +85,8 @@ And to fail the build if there are bad links:
 myst build --strict
 ```
 
+If a link successfully resolves during `--check-links`, the status will be cached to disk and the link will not be rechecked. If you need to recheck for broken links, you may clear this cache with `myst clean --cache`.
+
 ## MyST Start
 
 `myst start` starts a local web server for your MyST site.
@@ -119,7 +121,7 @@ You may also specify specific file types or source files. For example, to clean 
 myst clean --pdf index.md
 ```
 
-You may also specify `--templates`, `--site`, `--temp`, and `--exports` options to only delete the corresponding folders in the `_build` directory:
+You may also specify `--templates`, `--logs`, `--cache`, `--site`, `--temp`, and `--exports` options to only delete the corresponding folders in the `_build` directory:
 
 ```
 myst clean --templates

--- a/packages/myst-cli/src/build/clean.ts
+++ b/packages/myst-cli/src/build/clean.ts
@@ -165,7 +165,7 @@ export async function clean(session: ISession, files: string[], opts: CleanOptio
     buildFolders.push(session.buildPath());
   }
   buildFolders = [...new Set(buildFolders)].sort();
-  if (temp || logs || exports || templates || execute || html) {
+  if (temp || logs || cache || exports || templates || execute || html) {
     buildFolders.forEach((folder) => {
       if (temp) pathsToDelete.push(path.join(folder, 'temp'));
       if (logs) pathsToDelete.push(path.join(folder, 'logs'));

--- a/packages/myst-cli/src/build/clean.ts
+++ b/packages/myst-cli/src/build/clean.ts
@@ -27,6 +27,7 @@ export type CleanOptions = {
   html?: boolean;
   temp?: boolean;
   logs?: boolean;
+  cache?: boolean;
   exports?: boolean;
   execute?: boolean;
   templates?: boolean;
@@ -45,6 +46,7 @@ const ALL_OPTS: CleanOptions = {
   html: true,
   temp: true,
   logs: true,
+  cache: true,
   exports: true,
   execute: true,
   templates: true,
@@ -76,6 +78,7 @@ function coerceOpts(opts: CleanOptions) {
     html,
     temp,
     logs,
+    cache,
     exports,
     execute,
     templates,
@@ -93,6 +96,7 @@ function coerceOpts(opts: CleanOptions) {
     !html &&
     !temp &&
     !logs &&
+    !cache &&
     !exports &&
     !execute &&
     !templates
@@ -135,7 +139,7 @@ function deduplicatePaths(paths: string[]) {
 
 export async function clean(session: ISession, files: string[], opts: CleanOptions) {
   opts = coerceOpts(opts);
-  const { site, html, temp, logs, exports, execute, templates, yes } = opts;
+  const { site, html, temp, logs, cache, exports, execute, templates, yes } = opts;
   let pathsToDelete: string[] = [];
   const exportOptionsList = await collectAllBuildExportOptions(session, files, opts);
   if (exports) {
@@ -148,7 +152,7 @@ export async function clean(session: ISession, files: string[], opts: CleanOptio
     });
   }
   let buildFolders: string[] = [];
-  if (temp || logs || exports || execute || templates || html) {
+  if (temp || logs || cache || exports || execute || templates || html) {
     const projectPaths = [
       ...getProjectPaths(session),
       ...exportOptionsList.map((exp) => exp.$project),
@@ -165,6 +169,7 @@ export async function clean(session: ISession, files: string[], opts: CleanOptio
     buildFolders.forEach((folder) => {
       if (temp) pathsToDelete.push(path.join(folder, 'temp'));
       if (logs) pathsToDelete.push(path.join(folder, 'logs'));
+      if (cache) pathsToDelete.push(path.join(folder, 'cache'));
       if (exports) pathsToDelete.push(path.join(folder, 'exports'));
       if (templates) pathsToDelete.push(path.join(folder, 'templates'));
       if (html) pathsToDelete.push(path.join(folder, 'html'));

--- a/packages/myst-cli/src/process/intersphinx.ts
+++ b/packages/myst-cli/src/process/intersphinx.ts
@@ -35,32 +35,44 @@ export async function loadIntersphinx(
   const vfile = new VFile();
   vfile.path = configFile;
   const cache = castSession(session);
-  const references = Object.entries(projectConfig.references)
-    .filter(([key, object]) => {
-      if (isUrl(object.url)) return true;
-      fileError(vfile, `${key} references is not a valid url: "${object.url}"`, {
-        ruleId: RuleId.intersphinxReferencesResolve,
-      });
-      return false;
-    })
-    .map(([key, object]) => {
-      if (!cache.$externalReferences[key] || opts.force) {
-        let inventory = new Inventory({ id: key, path: object.url });
-        const cachePath = inventoryCacheFile(session, key, inventory.path);
-        if (fs.existsSync(cachePath) && !opts.force) {
-          session.log.debug(`Loading cached inventory file for ${inventory.path}: ${cachePath}`);
-          inventory = new Inventory({ id: key, path: cachePath });
+  const references = await Promise.all(
+    Object.entries(projectConfig.references)
+      .filter(([key, object]) => {
+        if (isUrl(object.url)) return true;
+        fileError(vfile, `${key} references is not a valid url: "${object.url}"`, {
+          ruleId: RuleId.intersphinxReferencesResolve,
+        });
+        return false;
+      })
+      .map(async ([key, object]) => {
+        if (!cache.$externalReferences[key] || opts.force) {
+          const inventory = new Inventory({ id: key, path: object.url });
+          const cachePath = inventoryCacheFile(session, key, inventory.path);
+          if (fs.existsSync(cachePath) && !opts.force) {
+            const localInventory = new Inventory({ id: key, path: cachePath });
+            session.log.debug(`Loading cached inventory file for ${inventory.path}: ${cachePath}`);
+            const toc = tic();
+            await localInventory.load();
+            inventory.project = localInventory.project;
+            inventory.version = localInventory.version;
+            inventory.data = localInventory.data;
+            inventory._loaded = true;
+            session.log.info(
+              toc(`🏫 Read ${inventory.numEntries} references links for "${inventory.id}" in %s.`),
+            );
+          }
+          cache.$externalReferences[key] = inventory;
         }
-        cache.$externalReferences[key] = inventory;
-      }
-      return cache.$externalReferences[key];
-    })
-    .filter((exists) => !!exists);
+        return cache.$externalReferences[key];
+      })
+      .filter((exists) => !!exists),
+  );
   await Promise.all(
     references.map(async (loader) => {
       if (loader._loaded) return;
       const toc = tic();
       try {
+        session.log.debug(`Loading inventory file ${loader.path}`);
         await loader.load();
       } catch (error) {
         session.log.debug(`\n\n${(error as Error)?.stack}\n\n`);
@@ -69,10 +81,10 @@ export async function loadIntersphinx(
         });
         return null;
       }
-      if (isUrl(loader.path)) {
-        const cachePath = inventoryCacheFile(session, loader.id, loader.path);
-        loader.write(cachePath);
+      const cachePath = inventoryCacheFile(session, loader.id, loader.path);
+      if (!fs.existsSync(cachePath) && isUrl(loader.path)) {
         session.log.debug(`Saving remote inventory file to cache ${loader.path}: ${cachePath}`);
+        loader.write(cachePath);
       }
       session.log.info(
         toc(`🏫 Read ${loader.numEntries} references links for "${loader.id}" in %s.`),

--- a/packages/myst-cli/src/process/intersphinx.ts
+++ b/packages/myst-cli/src/process/intersphinx.ts
@@ -1,11 +1,21 @@
+import fs from 'node:fs';
+import { join } from 'node:path';
 import { Inventory } from 'intersphinx';
-import { tic, isUrl } from 'myst-cli-utils';
+import { tic, isUrl, computeHash } from 'myst-cli-utils';
 import { RuleId, fileError } from 'myst-common';
 import { VFile } from 'vfile';
 import { castSession } from '../session/cache.js';
 import type { ISession } from '../session/types.js';
 import { selectors } from '../store/index.js';
 import { logMessagesFromVFile } from '../utils/logging.js';
+
+function inventoryCacheFile(session: ISession, id?: string, path?: string) {
+  const hashcontent = `${id}${path}`;
+  const filename = `intersphinx-${computeHash(hashcontent)}.inv`;
+  const cacheFolder = join(session.buildPath(), 'cache');
+  if (!fs.existsSync(cacheFolder)) fs.mkdirSync(cacheFolder, { recursive: true });
+  return join(cacheFolder, filename);
+}
 
 /**
  * Load an array of intersphinx inventories defined in the project frontmatter
@@ -35,7 +45,13 @@ export async function loadIntersphinx(
     })
     .map(([key, object]) => {
       if (!cache.$externalReferences[key] || opts.force) {
-        cache.$externalReferences[key] = new Inventory({ id: key, path: object.url });
+        let inventory = new Inventory({ id: key, path: object.url });
+        const cachePath = inventoryCacheFile(session, key, inventory.path);
+        if (fs.existsSync(cachePath) && !opts.force) {
+          session.log.debug(`Loading cached inventory file for ${inventory.path}: ${cachePath}`);
+          inventory = new Inventory({ id: key, path: cachePath });
+        }
+        cache.$externalReferences[key] = inventory;
       }
       return cache.$externalReferences[key];
     })
@@ -52,6 +68,11 @@ export async function loadIntersphinx(
           ruleId: RuleId.intersphinxReferencesResolve,
         });
         return null;
+      }
+      if (isUrl(loader.path)) {
+        const cachePath = inventoryCacheFile(session, loader.id, loader.path);
+        loader.write(cachePath);
+        session.log.debug(`Saving remote inventory file to cache ${loader.path}: ${cachePath}`);
       }
       session.log.info(
         toc(`🏫 Read ${loader.numEntries} references links for "${loader.id}" in %s.`),

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -202,7 +202,7 @@ export async function transformMdast(
 
   // Initialize citation renderers for this (non-bib) file
   cache.$citationRenderers[file] = await transformLinkedDOIs(
-    log,
+    session,
     vfile,
     mdast,
     cache.$doiRenderers,

--- a/packages/mystmd/src/clean.ts
+++ b/packages/mystmd/src/clean.ts
@@ -15,6 +15,7 @@ import {
   makeExecuteOption,
   makeYesOption,
   makeLogsOption,
+  makeCacheOption,
 } from './options.js';
 
 export function makeTempOption() {
@@ -54,6 +55,7 @@ export function makeCleanCLI(program: Command) {
     .addOption(makeExecuteOption('Clean execute cache'))
     .addOption(makeTempOption())
     .addOption(makeLogsOption('Clean CLI logs'))
+    .addOption(makeCacheOption('Clean web request cache'))
     .addOption(makeExportsOption())
     .addOption(makeTemplatesOption())
     .addOption(

--- a/packages/mystmd/src/options.ts
+++ b/packages/mystmd/src/options.ts
@@ -46,6 +46,10 @@ export function makeLogsOption(description: string) {
   return new Option('--logs', description).default(false);
 }
 
+export function makeCacheOption(description: string) {
+  return new Option('--cache', description).default(false);
+}
+
 export function makeExecuteOption(description: string) {
   return new Option('--execute', description).default(false);
 }


### PR DESCRIPTION
This adds a new `cache` directory to the `_build` folder, where web request results may be stored across sessions.

For now, this is storing:
- doi.org bibtex responses for each successful doi request
- intersphinx inventory files
- successful link check statuses