### PR TITLE
🫓 Flatten inlineCode (that may have children)

### DIFF
--- a/.changeset/fuzzy-mayflies-punch.md
+++ b/.changeset/fuzzy-mayflies-punch.md
@@ -1,0 +1,5 @@
+---
+"myst-common": patch
+---
+
+Add inline code rule for errors

--- a/.changeset/great-goats-search.md
+++ b/.changeset/great-goats-search.md
@@ -1,0 +1,5 @@
+---
+"myst-transforms": patch
+---
+
+Flatten inline code by default

--- a/packages/myst-common/src/ruleids.ts
+++ b/packages/myst-common/src/ruleids.ts
@@ -85,6 +85,7 @@ export enum RuleId {
   codeMetatagsValid = 'code-metatags-valid',
   codeLangDefined = 'code-lang-defined',
   codeMetadataLoads = 'code-metadata-loads',
+  inlineCodeMalformed = 'inline-code-malformed',
   inlineExpressionRenders = 'inline-expression-renders',
   // Static file rules
   staticFileCopied = 'static-file-copied',

--- a/packages/myst-transforms/src/basic.ts
+++ b/packages/myst-transforms/src/basic.ts
@@ -10,7 +10,7 @@ import { htmlIdsTransform } from './htmlIds.js';
 import { imageAltTextTransform } from './images.js';
 import { mathLabelTransform, mathNestingTransform, subequationTransform } from './math.js';
 import { blockquoteTransform } from './blockquote.js';
-import { codeBlockToDirectiveTransform } from './code.js';
+import { codeBlockToDirectiveTransform, inlineCodeFlattenTransform } from './code.js';
 import { removeUnicodeTransform } from './removeUnicode.js';
 import { containerChildrenTransform } from './containers.js';
 import { headingDepthTransform } from './headings.js';
@@ -41,6 +41,7 @@ export function basicTransformations(tree: GenericParent, file: VFile, opts: Rec
   blockquoteTransform(tree);
   removeUnicodeTransform(tree);
   headingDepthTransform(tree, file, opts);
+  inlineCodeFlattenTransform(tree, file);
 }
 
 export const basicTransformationsPlugin: Plugin<

--- a/packages/myst-transforms/src/index.ts
+++ b/packages/myst-transforms/src/index.ts
@@ -33,7 +33,12 @@ export {
   blockMetadataPlugin,
   blockMetadataTransform,
 } from './blocks.js';
-export { codePlugin, codeTransform } from './code.js';
+export {
+  codePlugin,
+  codeTransform,
+  inlineCodeFlattenPlugin,
+  inlineCodeFlattenTransform,
+} from './code.js';
 export { blockquotePlugin, blockquoteTransform } from './blockquote.js';
 export { imageAltTextPlugin, imageAltTextTransform } from './images.js';
 export {


### PR DESCRIPTION
When tex is being parsed, it is possible for inline code `\texttt{}` to have children. If all of those children are text, then the children are transformed into be a single node with `.value`.