### PR TITLE
❎ Exclude files listed in project config from myst build and watch

### DIFF
--- a/.changeset/wet-crabs-taste.md
+++ b/.changeset/wet-crabs-taste.md
@@ -1,0 +1,6 @@
+---
+'myst-config': patch
+'myst-cli': patch
+---
+
+Exclude files listed in project confg from myst build and watch

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -57,6 +57,25 @@ The “root” of a site is the page displayed when someone browses to the index
 All of these can be over-ridden by choosing an explicit `_toc.yml`, when that is present it will be used.
 ```
 
+### Excluding Files
+
+If there are markdown or notebook files within a project folder that you do not want included in your project, you may list these in the `myst.yml` project frontmatter under `exclude`. For example, to ignore a single file `notes.md`, all notebooks in the folder `hpc/`, and all files named `ignore.md`:
+
+```yaml
+project:
+  exclude:
+    - notes.md
+    - hpc/*.ipynb
+    - '**/ignore.md'
+```
+
+Additionally, files excluded in this way will also not be watched during `myst start`. This may be useful if you have a folder with a huge number of files (many thousands?) that causes `myst start` to crash. For example, in the `data/` directory, there may be no markdown and no notebooks but 100,000 small data files:
+
+```yaml
+project:
+  exclude: data/**
+```
+
 (toc-format)=
 
 ## Defining a `_toc.yml` using Jupyter Book’s format

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -69,12 +69,14 @@ project:
     - '**/ignore.md'
 ```
 
-Additionally, files excluded in this way will also not be watched during `myst start`. This may be useful if you have a folder with a huge number of files (many thousands?) that causes `myst start` to crash. For example, in the `data/` directory, there may be no markdown and no notebooks but 100,000 small data files:
+Additionally, files excluded in this way will also not be watched during `myst start`. This may be useful if you have a folder with many thousands of files that causes the `myst start` watch task to crash. For example, in the `data/` directory, there may be no markdown and no notebooks but 100,000 small data files:
 
 ```yaml
 project:
   exclude: data/**
 ```
+
+Note that when these files are excluded, they can still be specifically referenced by other files in your project (e.g. in an {myst:directive}`include directives <include>` or as a download), however, a change in those files will not trigger a build. An alternative in this case is to generate a table of contents (see [](./table-of-contents.md)). By default hidden folders (those starting with `.`, like `.git`), `_build` and `node_modules` are excluded.
 
 (toc-format)=
 

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -140,11 +140,16 @@ export function loadConfig(session: ISession, path: string) {
   return conf;
 }
 
-export function resolveToAbsolute(session: ISession, basePath: string, relativePath: string) {
+export function resolveToAbsolute(
+  session: ISession,
+  basePath: string,
+  relativePath: string,
+  checkExists = true,
+) {
   let message: string;
   try {
     const absPath = resolve(join(basePath, relativePath));
-    if (fs.existsSync(absPath)) {
+    if (!checkExists || fs.existsSync(absPath)) {
       return absPath;
     }
     message = `Does not exist as local path: ${absPath}`;
@@ -155,10 +160,15 @@ export function resolveToAbsolute(session: ISession, basePath: string, relativeP
   return relativePath;
 }
 
-function resolveToRelative(session: ISession, basePath: string, absPath: string) {
+function resolveToRelative(
+  session: ISession,
+  basePath: string,
+  absPath: string,
+  checkExists = true,
+) {
   let message: string;
   try {
-    if (fs.existsSync(absPath)) {
+    if (!checkExists || fs.existsSync(absPath)) {
       // If it is the same path, use a '.'
       return relative(basePath, absPath) || '.';
     }
@@ -174,7 +184,12 @@ function resolveSiteConfigPaths(
   session: ISession,
   path: string,
   siteConfig: SiteConfig,
-  resolutionFn: (session: ISession, basePath: string, path: string) => string,
+  resolutionFn: (
+    session: ISession,
+    basePath: string,
+    path: string,
+    checkExists?: boolean,
+  ) => string,
 ) {
   const resolvedFields: SiteConfig = {};
   if (siteConfig.projects) {
@@ -195,7 +210,12 @@ function resolveProjectConfigPaths(
   session: ISession,
   path: string,
   projectConfig: ProjectConfig,
-  resolutionFn: (session: ISession, basePath: string, path: string) => string,
+  resolutionFn: (
+    session: ISession,
+    basePath: string,
+    path: string,
+    checkExists?: boolean,
+  ) => string,
 ) {
   const resolvedFields: ProjectConfig = {};
   if (projectConfig.bibliography) {
@@ -208,7 +228,7 @@ function resolveProjectConfigPaths(
   }
   if (projectConfig.exclude) {
     resolvedFields.exclude = projectConfig.exclude.map((file) => {
-      return resolutionFn(session, path, file);
+      return resolutionFn(session, path, file, false);
     });
   }
   if (projectConfig.plugins) {

--- a/packages/myst-cli/src/project/load.ts
+++ b/packages/myst-cli/src/project/load.ts
@@ -58,10 +58,11 @@ export async function loadProjectFromDisk(
     writeToc = false;
   } else {
     const project = selectors.selectLocalProject(session.store.getState(), path);
-    if (!index && project?.file) {
+    if (!index && !project?.implicitIndex && project?.file) {
+      // If there is no new index, keep the original unless it was implicit previously
       index = project.file;
     }
-    newProject = projectFromPath(session, path, index);
+    newProject = await projectFromPath(session, path, index);
   }
   if (!newProject) {
     throw new Error(`Could not load project from ${path}`);

--- a/packages/myst-cli/src/project/toc.spec.ts
+++ b/packages/myst-cli/src/project/toc.spec.ts
@@ -15,15 +15,15 @@ const session = new Session();
 describe('site section generation', () => {
   it('empty', async () => {
     memfs.vol.fromJSON({});
-    expect(() => projectFromPath(session, '.')).toThrow();
+    expect(async () => await projectFromPath(session, '.')).toThrow();
   });
   it('invalid index', async () => {
     memfs.vol.fromJSON({ 'readme.md': '' });
-    expect(() => projectFromPath(session, '.', 'index.md')).toThrow();
+    expect(async () => await projectFromPath(session, '.', 'index.md')).toThrow();
   });
   it('readme.md only', async () => {
     memfs.vol.fromJSON({ 'readme.md': '' });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'readme.md',
       path: '.',
       index: 'readme',
@@ -32,7 +32,7 @@ describe('site section generation', () => {
   });
   it('README.md only', async () => {
     memfs.vol.fromJSON({ 'README.md': '' });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'README.md',
       path: '.',
       index: 'readme',
@@ -41,7 +41,7 @@ describe('site section generation', () => {
   });
   it('README.md and index.md', async () => {
     memfs.vol.fromJSON({ 'README.md': '', 'index.md': '' });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'index.md',
       path: '.',
       index: 'index',
@@ -50,7 +50,7 @@ describe('site section generation', () => {
   });
   it('index.md only', async () => {
     memfs.vol.fromJSON({ 'index.md': '' });
-    expect(projectFromPath(session, '.', 'index.md')).toEqual({
+    expect(await projectFromPath(session, '.', 'index.md')).toEqual({
       file: 'index.md',
       path: '.',
       index: 'index',
@@ -59,7 +59,7 @@ describe('site section generation', () => {
   });
   it('folder/subfolder/index.md only', async () => {
     memfs.vol.fromJSON({ 'folder/subfolder/index.md': '' });
-    expect(projectFromPath(session, '.', 'folder/subfolder/index.md')).toEqual({
+    expect(await projectFromPath(session, '.', 'folder/subfolder/index.md')).toEqual({
       file: 'folder/subfolder/index.md',
       path: '.',
       index: 'index',
@@ -68,7 +68,7 @@ describe('site section generation', () => {
   });
   it('flat folder', async () => {
     memfs.vol.fromJSON({ 'readme.md': '', 'page.md': '', 'notebook.ipynb': '' });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'readme.md',
       path: '.',
       index: 'readme',
@@ -88,7 +88,7 @@ describe('site section generation', () => {
   });
   it('single folder', async () => {
     memfs.vol.fromJSON({ 'readme.md': '', 'folder/page.md': '', 'folder/notebook.ipynb': '' });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'readme.md',
       path: '.',
       index: 'readme',
@@ -116,7 +116,7 @@ describe('site section generation', () => {
       'folder1/01_MySecond_folder-ok/folder3/01_notebook.ipynb': '',
       'folder1/01_MySecond_folder-ok/folder3/02_page.md': '',
     });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'readme.md',
       path: '.',
       index: 'readme',
@@ -148,7 +148,7 @@ describe('site section generation', () => {
   });
   it('files before folders', async () => {
     memfs.vol.fromJSON({ 'readme.md': '', 'zfile.md': '', 'afolder/page.md': '' });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'readme.md',
       path: '.',
       index: 'readme',
@@ -178,7 +178,7 @@ describe('site section generation', () => {
       'folder1/folder2/page2.md': '',
       'folder1/folder2/folder3/page3.md': '',
     });
-    expect(projectFromPath(session, 'folder1', 'folder1/folder2/readme.md')).toEqual({
+    expect(await projectFromPath(session, 'folder1', 'folder1/folder2/readme.md')).toEqual({
       file: 'folder1/folder2/readme.md',
       path: 'folder1',
       index: 'readme',
@@ -211,7 +211,7 @@ describe('site section generation', () => {
   });
   it('first md file as index', async () => {
     memfs.vol.fromJSON({ 'folder/page.md': '', 'folder/notebook.ipynb': '' });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'folder/page.md',
       path: '.',
       index: 'page',
@@ -230,7 +230,7 @@ describe('site section generation', () => {
   });
   it('other md picked over default notebook', async () => {
     memfs.vol.fromJSON({ 'page.md': '', 'index.ipynb': '' });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'page.md',
       path: '.',
       index: 'page',
@@ -245,7 +245,7 @@ describe('site section generation', () => {
   });
   it('index notebook picked over other notebook', async () => {
     memfs.vol.fromJSON({ 'aaa.ipynb': '', 'index.ipynb': '' });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'index.ipynb',
       path: '.',
       index: 'index',
@@ -260,7 +260,7 @@ describe('site section generation', () => {
   });
   it('first notebook as index', async () => {
     memfs.vol.fromJSON({ 'folder/page.docx': '', 'folder/notebook.ipynb': '' });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'folder/notebook.ipynb',
       path: '.',
       index: 'notebook',
@@ -275,7 +275,7 @@ describe('site section generation', () => {
       'folder/newproj/page.md': '',
       'folder/newproj/myst.yml': '',
     });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'readme.md',
       path: '.',
       index: 'readme',
@@ -304,7 +304,7 @@ describe('site section generation', () => {
       'chapter2.ipynb': '',
       'chapter10.ipynb': '',
     });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'readme.md',
       path: '.',
       index: 'readme',
@@ -336,7 +336,7 @@ describe('site section generation', () => {
       'folder/newproj/page.md': '',
       'folder/newproj/myst.yml': '',
     });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       file: 'readme.md',
       path: '.',
       index: 'readme',

--- a/packages/myst-cli/src/project/toc.spec.ts
+++ b/packages/myst-cli/src/project/toc.spec.ts
@@ -15,11 +15,11 @@ const session = new Session();
 describe('site section generation', () => {
   it('empty', async () => {
     memfs.vol.fromJSON({});
-    expect(async () => await projectFromPath(session, '.')).toThrow();
+    expect((async () => await projectFromPath(session, '.'))()).rejects.toThrow();
   });
   it('invalid index', async () => {
     memfs.vol.fromJSON({ 'readme.md': '' });
-    expect(async () => await projectFromPath(session, '.', 'index.md')).toThrow();
+    expect((async () => await projectFromPath(session, '.', 'index.md'))()).rejects.toThrow();
   });
   it('readme.md only', async () => {
     memfs.vol.fromJSON({ 'readme.md': '' });
@@ -27,6 +27,7 @@ describe('site section generation', () => {
       file: 'readme.md',
       path: '.',
       index: 'readme',
+      implicitIndex: true,
       pages: [],
     });
   });
@@ -36,6 +37,7 @@ describe('site section generation', () => {
       file: 'README.md',
       path: '.',
       index: 'readme',
+      implicitIndex: true,
       pages: [],
     });
   });
@@ -45,6 +47,7 @@ describe('site section generation', () => {
       file: 'index.md',
       path: '.',
       index: 'index',
+      implicitIndex: true,
       pages: [{ file: 'README.md', level: 1, slug: 'readme' }],
     });
   });
@@ -54,6 +57,7 @@ describe('site section generation', () => {
       file: 'index.md',
       path: '.',
       index: 'index',
+      implicitIndex: false,
       pages: [],
     });
   });
@@ -63,6 +67,7 @@ describe('site section generation', () => {
       file: 'folder/subfolder/index.md',
       path: '.',
       index: 'index',
+      implicitIndex: false,
       pages: [],
     });
   });
@@ -72,6 +77,7 @@ describe('site section generation', () => {
       file: 'readme.md',
       path: '.',
       index: 'readme',
+      implicitIndex: true,
       pages: [
         {
           file: 'notebook.ipynb',
@@ -92,6 +98,7 @@ describe('site section generation', () => {
       file: 'readme.md',
       path: '.',
       index: 'readme',
+      implicitIndex: true,
       pages: [
         {
           title: 'Folder',
@@ -120,6 +127,7 @@ describe('site section generation', () => {
       file: 'readme.md',
       path: '.',
       index: 'readme',
+      implicitIndex: true,
       pages: [
         {
           title: 'Folder1',
@@ -152,6 +160,7 @@ describe('site section generation', () => {
       file: 'readme.md',
       path: '.',
       index: 'readme',
+      implicitIndex: true,
       pages: [
         {
           file: 'zfile.md',
@@ -182,6 +191,7 @@ describe('site section generation', () => {
       file: 'folder1/folder2/readme.md',
       path: 'folder1',
       index: 'readme',
+      implicitIndex: false,
       pages: [
         {
           file: 'folder1/page1.md',
@@ -215,6 +225,7 @@ describe('site section generation', () => {
       file: 'folder/page.md',
       path: '.',
       index: 'page',
+      implicitIndex: true,
       pages: [
         {
           title: 'Folder',
@@ -234,6 +245,7 @@ describe('site section generation', () => {
       file: 'page.md',
       path: '.',
       index: 'page',
+      implicitIndex: true,
       pages: [
         {
           file: 'index.ipynb',
@@ -249,6 +261,7 @@ describe('site section generation', () => {
       file: 'index.ipynb',
       path: '.',
       index: 'index',
+      implicitIndex: true,
       pages: [
         {
           file: 'aaa.ipynb',
@@ -264,6 +277,7 @@ describe('site section generation', () => {
       file: 'folder/notebook.ipynb',
       path: '.',
       index: 'notebook',
+      implicitIndex: true,
       pages: [],
     });
   });
@@ -279,6 +293,7 @@ describe('site section generation', () => {
       file: 'readme.md',
       path: '.',
       index: 'readme',
+      implicitIndex: true,
       pages: [
         {
           title: 'Folder',
@@ -308,6 +323,7 @@ describe('site section generation', () => {
       file: 'readme.md',
       path: '.',
       index: 'readme',
+      implicitIndex: true,
       pages: [
         {
           file: 'chapter1.md',
@@ -340,6 +356,7 @@ describe('site section generation', () => {
       file: 'readme.md',
       path: '.',
       index: 'readme',
+      implicitIndex: true,
       pages: [
         {
           title: 'Folder',
@@ -718,10 +735,11 @@ describe('pagesFromToc', () => {
       'project/c.md': '',
       'project/d.md': '',
     });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       path: '.',
       index: 'readme',
       file: 'readme.md',
+      implicitIndex: true,
       pages: [
         { slug: 'x', file: 'x.md', level: 1 },
         { slug: 'index', file: 'project/index.md', level: 1 },
@@ -748,10 +766,11 @@ describe('pagesFromToc', () => {
       'project/c.md': '',
       'project/d.md': '',
     });
-    expect(projectFromPath(session, '.')).toEqual({
+    expect(await projectFromPath(session, '.')).toEqual({
       path: '.',
       index: 'readme',
       file: 'readme.md',
+      implicitIndex: true,
       pages: [
         { slug: 'x', file: 'x.md', level: 1 },
         { title: 'Project', level: 1 },

--- a/packages/myst-cli/src/project/types.ts
+++ b/packages/myst-cli/src/project/types.ts
@@ -28,6 +28,7 @@ export type LocalProject = {
   file: string;
   /** The slug that the index get's renamed to for the JSON */
   index: string;
+  implicitIndex?: boolean;
   bibliography: string[];
   pages: (LocalProjectPage | LocalProjectFolder)[];
 };

--- a/packages/myst-config/src/project/project.spec.ts
+++ b/packages/myst-config/src/project/project.spec.ts
@@ -20,6 +20,18 @@ describe('validateProjectConfig', () => {
     };
     expect(validateProjectConfig(projConfig, opts)).toEqual(projConfig);
   });
+  it('single exclude coerces', async () => {
+    expect(
+      validateProjectConfig(
+        {
+          exclude: 'license.md',
+        },
+        opts,
+      ),
+    ).toEqual({
+      exclude: ['license.md'],
+    });
+  });
   it('invalid exclude omitted', async () => {
     expect(validateProjectConfig({ exclude: ['license.md', 5] }, opts)).toEqual({
       exclude: ['license.md'],

--- a/packages/myst-config/src/project/validators.ts
+++ b/packages/myst-config/src/project/validators.ts
@@ -30,7 +30,7 @@ function validateProjectConfigKeys(value: Record<string, any>, opts: ValidationO
   if (defined(value.exclude)) {
     output.exclude = validateList(
       value.exclude,
-      incrementOptions('exclude', opts),
+      { coerce: true, ...incrementOptions('exclude', opts) },
       (file, index: number) => {
         return validateString(file, incrementOptions(`exclude.${index}`, opts));
       },


### PR DESCRIPTION
# Problems:

- Without an explicit `_toc.yml` file, the project build pulls in all md/ipynb files from the project directory
- During `myst start` all files within the directory are watched (potentially an arbitrarily large number of files... enough to break the `watch` function)

# Current state:

- Project config already has an `exclude` field for a list of files to "exclude" - however, nothing respects those excluded files...

# What this pr does:

- Files listed under `exclude` in the project config are treated as `glob` patterns. These come into play in two places:
  1. During project build, any md/ipynb that matches an exclude pattern will not be added to the project
  2. During `myst start`, everything matched by `exclude` is ignored (so you can ignore folders with lots of unrelated files)
- To make this work, there were some changes to the watch function - primarily triggering a project reload on `myst.yml` changes
  - (there was also some refactoring to consolidate to a single watch "processorFn" rather than duplicating logic across the old "fileProcessor" and "siteProcessor")


# Future steps

- Currently you may only build your project with (1) explicit `_toc.yml` or (2) implicit directory contents with explicitly `excluded` files. It would be nice to also be able to have a simpler `include` or something in the project config to define the toc.
- Further, if you exclude a file, it is not built at all; there is no way to build a file as part of the project but not include it in the project's toc (this is useful for notebook-generated figures - we want to keep the source notebook but not really have it as part of the project toc...)