### PR TITLE
📤 Conform jats/meca export function interface to other export functions

### DIFF
--- a/.changeset/wild-comics-tease.md
+++ b/.changeset/wild-comics-tease.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Conform jats/meca export function interface to other export functions

--- a/packages/myst-cli/src/build/index.ts
+++ b/packages/myst-cli/src/build/index.ts
@@ -9,4 +9,5 @@ export * from './types.js';
 export * from './utils/index.js';
 export * from './html/index.js';
 export * from './meca/index.js';
+export * from './jats/index.js';
 export * from './typst.js';

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -13,7 +13,7 @@ import { castSession } from '../../session/cache.js';
 import type { ISession } from '../../session/types.js';
 import { logMessagesFromVFile } from '../../utils/logging.js';
 import { KNOWN_IMAGE_EXTENSIONS } from '../../utils/resolveExtension.js';
-import type { ExportWithOutput, ExportOptions, ExportFnOptions } from '../types.js';
+import type { ExportWithOutput, ExportOptions, ExportFnOptions, ExportResults } from '../types.js';
 import { cleanOutput } from '../utils/cleanOutput.js';
 import { collectBasicExportOptions } from '../utils/collectExportOptions.js';
 import { getFileContent } from '../utils/getFileContent.js';
@@ -109,15 +109,18 @@ export async function localArticleToJats(
   ).map((exportOptions) => {
     return { ...exportOptions, ...templateOptions };
   });
+  const results: ExportResults = { tempFolders: [] };
   await resolveAndLogErrors(
     session,
     exportOptionsList.map(async (exportOptions) => {
-      await runJatsExport(session, file, exportOptions, {
+      const exportResults = await runJatsExport(session, file, exportOptions, {
         projectPath,
         clean: opts.clean,
         extraLinkTransformers,
       });
+      results.tempFolders.push(...exportResults.tempFolders);
     }),
     opts.throwOnFailure,
   );
+  return results;
 }

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -21,7 +21,7 @@ import { castSession } from '../../session/cache.js';
 import { selectors } from '../../store/index.js';
 import { createTempFolder } from '../../utils/createTempFolder.js';
 import { logMessagesFromVFile } from '../../utils/logging.js';
-import type { ExportWithOutput, ExportOptions, ExportFnOptions } from '../types.js';
+import type { ExportWithOutput, ExportOptions, ExportFnOptions, ExportResults } from '../types.js';
 import { cleanOutput } from '../utils/cleanOutput.js';
 import { collectBasicExportOptions, collectExportOptions } from '../utils/collectExportOptions.js';
 import { resolveAndLogErrors } from '../utils/resolveAndLogErrors.js';
@@ -372,15 +372,18 @@ export async function localProjectToMeca(
   ).map((exportOptions) => {
     return { ...exportOptions, ...templateOptions };
   });
+  const results: ExportResults = { tempFolders: [] };
   await resolveAndLogErrors(
     session,
     exportOptionsList.map(async (exportOptions) => {
-      await runMecaExport(session, file, exportOptions, {
+      const exportResults = await runMecaExport(session, file, exportOptions, {
         projectPath,
         clean: opts.clean,
         extraLinkTransformers,
       });
+      results.tempFolders.push(...exportResults.tempFolders);
     }),
     opts.throwOnFailure,
   );
+  return results;
 }


### PR DESCRIPTION
This is just some minor cleanup so jats/meca functions have the same type interface as other export functions... We also weren't exporting jats export before.