### PR TITLE
🎓 Citation improvements

### DIFF
--- a/.changeset/five-countries-wait.md
+++ b/.changeset/five-countries-wait.md
@@ -1,0 +1,5 @@
+---
+'citation-js-utils': patch
+---
+
+Get year from citation issued literal if it is not parsed

--- a/.changeset/good-cameras-hammer.md
+++ b/.changeset/good-cameras-hammer.md
@@ -1,0 +1,6 @@
+---
+'citation-js-utils': patch
+'myst-cli': patch
+---
+
+Pull url from citation data and add to citation node

--- a/.changeset/mean-walls-hear.md
+++ b/.changeset/mean-walls-hear.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Add better warning message for valid dois without bibtex

--- a/.changeset/ninety-pots-smash.md
+++ b/.changeset/ninety-pots-smash.md
@@ -1,0 +1,7 @@
+---
+'myst-spec-ext': patch
+'myst-common': patch
+'myst-cli': patch
+---
+
+Add enumerator to citations and cite nodes

--- a/.changeset/tough-cycles-scream.md
+++ b/.changeset/tough-cycles-scream.md
@@ -1,0 +1,6 @@
+---
+'myst-common': patch
+'myst-cli': patch
+---
+
+Add cli warnings for invalid citation labels

--- a/.changeset/weak-games-poke.md
+++ b/.changeset/weak-games-poke.md
@@ -1,0 +1,5 @@
+---
+'citation-js-utils': patch
+---
+
+Stop removing urls from citation html

--- a/packages/citation-js-utils/src/index.ts
+++ b/packages/citation-js-utils/src/index.ts
@@ -12,7 +12,7 @@ export type CitationJson = {
   type?: 'article-journal' | string;
   id: string;
   author?: { given: string; family: string }[];
-  issued?: { 'date-parts': number[][] };
+  issued?: { 'date-parts'?: number[][]; literal?: string };
   publisher?: string;
   title?: string;
   'citation-key'?: string;
@@ -73,12 +73,20 @@ const defaultString: OutputOptions = {
   style: CitationJSStyles.apa,
 };
 
+export function yearFromCitation(data: CitationJson) {
+  let year: number | string | undefined = data.issued?.['date-parts']?.[0]?.[0];
+  if (year) return year;
+  year = data.issued?.['literal']?.match(/\b[12][0-9]{3}\b/)?.[0];
+  if (year) return year;
+  return 'n.d.';
+}
+
 export function getInlineCitation(data: CitationJson, kind: InlineCite, opts?: InlineOptions) {
   let authors = data.author;
   if (!authors || authors.length === 0) {
     authors = data.editor;
   }
-  const year = data.issued?.['date-parts']?.[0]?.[0];
+  const year = yearFromCitation(data);
   const prefix = opts?.prefix ? `${opts.prefix} ` : '';
   const suffix = opts?.suffix ? `, ${opts.suffix}` : '';
   let yearPart = kind === InlineCite.t ? ` (${year}${suffix})` : `, ${year}${suffix}`;

--- a/packages/citation-js-utils/tests/basic.spec.ts
+++ b/packages/citation-js-utils/tests/basic.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getCitations, CitationJSStyles } from '../src';
+import { getCitations, CitationJSStyles, yearFromCitation } from '../src';
 import {
   bibtex,
   doiInNote,
@@ -31,5 +31,40 @@ describe('Test reference rendering', () => {
   ])('Extract the DOI from the %s', async (_, src) => {
     const citations = await getCitations(src);
     expect(citations['cury2020sparse'].getDOI()).toBe(TEST_DOI_IN_OTHER_FIELD);
+  });
+});
+
+describe('yearFromCitation', () => {
+  it('date-parts year is returned', async () => {
+    const data = { id: 'id', issued: { 'date-parts': [[2020, 1, 1]] } };
+    expect(yearFromCitation(data)).toEqual(2020);
+  });
+  it('date-parts year is prioritized', async () => {
+    const data = { id: 'id', issued: { 'date-parts': [[2020, 1, 1]], literal: '1999' } };
+    expect(yearFromCitation(data)).toEqual(2020);
+  });
+  it('literal is used', async () => {
+    const data = { id: 'id', issued: { literal: '2020' } };
+    expect(yearFromCitation(data)).toEqual('2020');
+  });
+  it('literal is parses from string', async () => {
+    const data = { id: 'id', issued: { literal: 'Accessed 2020 Jan 1' } };
+    expect(yearFromCitation(data)).toEqual('2020');
+  });
+  it('literal is parses from string with comma', async () => {
+    const data = { id: 'id', issued: { literal: 'Accessed 2020, Jan 1' } };
+    expect(yearFromCitation(data)).toEqual('2020');
+  });
+  it('literal is does not parse longer number', async () => {
+    const data = { id: 'id', issued: { literal: 'Accessed 202020' } };
+    expect(yearFromCitation(data)).toEqual('n.d.');
+  });
+  it('literal is does not parse as part of word', async () => {
+    const data = { id: 'id', issued: { literal: 'Accessed a2020' } };
+    expect(yearFromCitation(data)).toEqual('n.d.');
+  });
+  it('no date returns n.d.', async () => {
+    const data = { id: 'id' };
+    expect(yearFromCitation(data)).toEqual('n.d.');
   });
 });

--- a/packages/citation-js-utils/tests/basic.spec.ts
+++ b/packages/citation-js-utils/tests/basic.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getCitations, CitationJSStyles, yearFromCitation } from '../src';
+import { getCitations, CitationJSStyles, yearFromCitation, firstNonDoiUrl } from '../src';
 import {
   bibtex,
   doiInNote,
@@ -66,5 +66,29 @@ describe('yearFromCitation', () => {
   it('no date returns n.d.', async () => {
     const data = { id: 'id' };
     expect(yearFromCitation(data)).toEqual('n.d.');
+  });
+});
+
+describe('firstNonDoiUrl', () => {
+  it('no url returns undefined', async () => {
+    expect(firstNonDoiUrl('my citation', 'abc123')).toEqual(undefined);
+  });
+  it('one url returns url', async () => {
+    expect(firstNonDoiUrl('my citation https://example.com', 'abc123')).toEqual(
+      'https://example.com',
+    );
+  });
+  it('two urls returns first url', async () => {
+    expect(
+      firstNonDoiUrl('my citation https://example.com/a and https://example.com/b', 'abc123'),
+    ).toEqual('https://example.com/a');
+  });
+  it('doi urls is skipped', async () => {
+    expect(firstNonDoiUrl('my citation https://example.com/abc123', 'abc123')).toEqual(undefined);
+  });
+  it('url after doi url is returned', async () => {
+    expect(
+      firstNonDoiUrl('my citation https://example.com/abc123 and https://example.com/b', 'abc123'),
+    ).toEqual('https://example.com/b');
   });
 });

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -232,7 +232,7 @@ export async function transformMdast(
   transformRenderInlineExpressions(mdast, vfile);
   await transformOutputsToCache(session, mdast, kind, { minifyMaxCharacters });
   transformFilterOutputStreams(mdast, vfile, frontmatter.settings);
-  transformCitations(mdast, fileCitationRenderer, references);
+  transformCitations(session, file, mdast, fileCitationRenderer, references);
   await unified()
     .use(codePlugin, { lang: frontmatter?.kernelspec?.language })
     .use(footnotesPlugin) // Needs to happen near the end

--- a/packages/myst-cli/src/transforms/citations.spec.ts
+++ b/packages/myst-cli/src/transforms/citations.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { Session } from '../session';
+import { transformCitations } from './citations';
+import type { CitationRenderer } from 'citation-js-utils';
+import type { References } from 'myst-common';
+
+const RENDERER: CitationRenderer = {
+  author1: {
+    render: () => '<rendered 1/>',
+    inline: () => {
+      return [{ type: 'text', value: 'inline 1' }];
+    },
+    getDOI: () => 'abc123',
+    getURL: () => 'https://example.com',
+    cite: { id: 'my-cite-1' },
+  },
+  author2: {
+    render: () => '<rendered 2/>',
+    inline: () => {
+      return [{ type: 'text', value: 'inline 2' }];
+    },
+    getDOI: () => undefined,
+    getURL: () => undefined,
+    cite: { id: 'my-cite-2' },
+  },
+};
+
+describe('transformCitations', () => {
+  it('citation transforms', async () => {
+    const mdast: any = {
+      type: 'root',
+      children: [
+        {
+          type: 'cite',
+          label: 'author1',
+        },
+      ],
+    };
+    const references: References = {};
+    transformCitations(new Session(), '', mdast, RENDERER, references);
+    expect(mdast.children[0].children).toEqual([{ type: 'text', value: 'inline 1' }]);
+    expect(mdast.children[0].enumerator).toEqual('1');
+    expect(references.cite?.order).toEqual(['author1']);
+    expect(references.cite?.data?.author1).toEqual({
+      label: 'author1',
+      doi: 'abc123',
+      url: 'https://example.com',
+      enumerator: '1',
+      html: '<rendered 1/>',
+    });
+  });
+  it('multiple citations transform', async () => {
+    const mdast: any = {
+      type: 'root',
+      children: [
+        {
+          type: 'cite',
+          label: 'author2',
+        },
+        {
+          type: 'cite',
+          label: 'author1',
+        },
+        {
+          type: 'cite',
+          label: 'author2',
+        },
+      ],
+    };
+    const references: References = {};
+    transformCitations(new Session(), '', mdast, RENDERER, references);
+    expect(mdast.children[0].children).toEqual([{ type: 'text', value: 'inline 2' }]);
+    expect(mdast.children[0].enumerator).toEqual('1');
+    expect(mdast.children[1].children).toEqual([{ type: 'text', value: 'inline 1' }]);
+    expect(mdast.children[1].enumerator).toEqual('2');
+    expect(mdast.children[2].children).toEqual([{ type: 'text', value: 'inline 2' }]);
+    expect(mdast.children[2].enumerator).toEqual('1');
+    expect(references.cite?.order).toEqual(['author2', 'author1']);
+    expect(references.cite?.data?.author1).toEqual({
+      label: 'author1',
+      doi: 'abc123',
+      url: 'https://example.com',
+      enumerator: '2',
+      html: '<rendered 1/>',
+    });
+    expect(references.cite?.data?.author2).toEqual({
+      label: 'author2',
+      enumerator: '1',
+      html: '<rendered 2/>',
+    });
+  });
+});

--- a/packages/myst-cli/src/transforms/citations.ts
+++ b/packages/myst-cli/src/transforms/citations.ts
@@ -23,7 +23,7 @@ function pushCite(
       enumerator: `${references.cite.order.length}`,
       doi: citeRenderer[label]?.getDOI(),
       html: citeRenderer[label]?.render(),
-      //url:
+      url: citeRenderer[label]?.getURL(),
     };
   }
   return references.cite.data[label].enumerator;

--- a/packages/myst-cli/src/transforms/citations.ts
+++ b/packages/myst-cli/src/transforms/citations.ts
@@ -12,19 +12,21 @@ function pushCite(
   references: Pick<References, 'cite'>,
   citeRenderer: CitationRenderer,
   label: string,
-) {
+): string {
   if (!references.cite) {
     references.cite = { order: [], data: {} };
   }
-  if (!references.cite?.data[label]) {
+  if (!references.cite.data[label]) {
     references.cite.order.push(label);
+    references.cite.data[label] = {
+      label,
+      enumerator: `${references.cite.order.length}`,
+      doi: citeRenderer[label]?.getDOI(),
+      html: citeRenderer[label]?.render(),
+      //url:
+    };
   }
-  references.cite.data[label] = {
-    // TODO: this number isn't right? Should be the last time it was seen, not the current size.
-    number: references.cite.order.length,
-    doi: citeRenderer[label]?.getDOI(),
-    html: citeRenderer[label]?.render(),
-  };
+  return references.cite.data[label].enumerator;
 }
 
 function addCitationChildren(
@@ -82,6 +84,6 @@ export function transformCitations(
     const citeLabel = cite.label as string;
     // push cites in order of appearance in the document
     const success = addCitationChildren(session, file, cite, renderer);
-    if (success) pushCite(references, renderer, citeLabel);
+    if (success) cite.enumerator = pushCite(references, renderer, citeLabel);
   });
 }

--- a/packages/myst-common/src/ruleids.ts
+++ b/packages/myst-common/src/ruleids.ts
@@ -80,6 +80,8 @@ export enum RuleId {
   // Citation rules
   citationIsUnique = 'citation-is-unique',
   bibFileExists = 'bib-file-exists',
+  citationRenders = 'citation-renders',
+  citationLabelExists = 'citation-label-exists',
   // Code rules
   codeMetadataLifted = 'code-metadata-lifted',
   codeMetatagsValid = 'code-metatags-valid',

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -20,7 +20,10 @@ export type GenericParent<T extends Record<string, any> = Record<string, any>> =
 
 export type Citations = {
   order: string[];
-  data: Record<string, { html: string; number: number; doi: string | undefined }>;
+  data: Record<
+    string,
+    { label: string; html: string; enumerator: string; doi?: string; url?: string }
+  >;
 };
 
 export enum NotebookCell {

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -141,6 +141,7 @@ export type Cite = {
   prefix?: string;
   suffix?: string;
   partial?: 'author' | 'year';
+  enumerator?: string;
 };
 
 export type CiteGroup = {


### PR DESCRIPTION
- Some dois do not have bibtex available from doi.org - we now give more useful warnings in this case
- Year is parsed from dates if they are defined as a string in bibtex (e.g. "August 1, 2012") instead of structured `year`/`day` values.
- Fix bug where all non-doi urls were deleted from citation html
- CLI warns on unknown citation labels, eg `@unknown`
- cite nodes now have enumerator value so we can switch to citing like `[1]`
- URLs are pulled from citation data to be available to the renderer