### PR TITLE
🥩 Add raw directive

### DIFF
--- a/.changeset/new-walls-brake.md
+++ b/.changeset/new-walls-brake.md
@@ -1,0 +1,7 @@
+---
+'myst-directives': patch
+'myst-spec-ext': patch
+'myst-cli': patch
+---
+
+Add raw directive

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -72,6 +72,7 @@ import { frontmatterPartsTransform } from '../transforms/parts.js';
 import { parseMyst } from './myst.js';
 import { kernelExecutionTransform, LocalDiskCache } from 'myst-execute';
 import type { IOutput } from '@jupyterlab/nbformat';
+import { rawDirectiveTransform } from '../transforms/raw.js';
 
 const LINKS_SELECTOR = 'link,card,linkBlock';
 
@@ -163,6 +164,7 @@ export async function transformMdast(
   frontmatterPartsTransform(session, file, mdast, frontmatter);
   importMdastFromJson(session, file, mdast);
   await includeFilesTransform(session, file, mdast, vfile);
+  rawDirectiveTransform(mdast, vfile);
   // This needs to come before basic transformations since it may add labels to blocks
   liftCodeMetadataToBlock(session, vfile, mdast);
 

--- a/packages/myst-cli/src/transforms/raw.ts
+++ b/packages/myst-cli/src/transforms/raw.ts
@@ -5,6 +5,7 @@ import { selectAll } from 'unist-util-select';
 import type { Plugin } from 'unified';
 import type { VFile } from 'vfile';
 import { TexParser } from 'tex-to-myst';
+import type { PhrasingContent } from 'myst-spec';
 
 export async function rawDirectiveTransform(tree: GenericParent, vfile: VFile) {
   const rawNodes = selectAll('raw', tree) as Raw[];
@@ -19,7 +20,9 @@ export async function rawDirectiveTransform(tree: GenericParent, vfile: VFile) {
           note: 'Treating content as text',
         });
       }
-      node.children = [{ type: 'paragraph', children: [{ type: 'text', value: node.value }] }];
+      node.children = [
+        { type: 'paragraph', children: [{ type: 'text', value: node.value }] as PhrasingContent[] },
+      ];
     }
   });
 }

--- a/packages/myst-cli/src/transforms/raw.ts
+++ b/packages/myst-cli/src/transforms/raw.ts
@@ -1,0 +1,30 @@
+import type { GenericNode, GenericParent } from 'myst-common';
+import { fileWarn, RuleId } from 'myst-common';
+import type { Raw } from 'myst-spec-ext';
+import { selectAll } from 'unist-util-select';
+import type { Plugin } from 'unified';
+import type { VFile } from 'vfile';
+import { TexParser } from 'tex-to-myst';
+
+export async function rawDirectiveTransform(tree: GenericParent, vfile: VFile) {
+  const rawNodes = selectAll('raw', tree) as Raw[];
+  rawNodes.forEach((node) => {
+    if (['latex', 'tex'].includes(node.lang as string)) {
+      const state = new TexParser(node.value, vfile);
+      (node as GenericNode).children = state.ast.children;
+    } else {
+      if (node.lang && node.lang !== 'text') {
+        fileWarn(vfile, `unknown format for raw content: ${node.lang}`, {
+          ruleId: RuleId.directiveArgumentCorrect,
+          note: 'Treating content as text',
+        });
+      }
+      node.children = [{ type: 'paragraph', children: [{ type: 'text', value: node.value }] }];
+    }
+  });
+}
+
+export const rawDirectivePlugin: Plugin<[], GenericParent, GenericParent> =
+  () => async (tree, file) => {
+    await rawDirectiveTransform(tree as GenericParent, file);
+  };

--- a/packages/myst-directives/src/index.ts
+++ b/packages/myst-directives/src/index.ts
@@ -15,6 +15,7 @@ import { mdastDirective } from './mdast.js';
 import { mermaidDirective } from './mermaid.js';
 import { mystdemoDirective } from './mystdemo.js';
 import { outputDirective } from './output.js';
+import { rawDirective } from './raw.js';
 
 export const defaultDirectives = [
   admonitionDirective,
@@ -36,6 +37,7 @@ export const defaultDirectives = [
   mermaidDirective,
   mystdemoDirective,
   outputDirective,
+  rawDirective,
 ];
 
 export { admonitionDirective } from './admonition.js';
@@ -54,3 +56,4 @@ export { mdastDirective } from './mdast.js';
 export { mermaidDirective } from './mermaid.js';
 export { mystdemoDirective } from './mystdemo.js';
 export { outputDirective } from './output.js';
+export { rawDirective } from './raw.js';

--- a/packages/myst-directives/src/raw.ts
+++ b/packages/myst-directives/src/raw.ts
@@ -1,0 +1,24 @@
+import type { DirectiveSpec } from 'myst-common';
+import type { Raw } from 'myst-spec-ext';
+
+export const rawDirective: DirectiveSpec = {
+  name: 'raw',
+  doc: 'Allows you to include the source or parsed version of a separate file into your document tree.',
+  arg: {
+    type: String,
+    doc: 'Format of directive content - for now, only "latex" is valid',
+  },
+  body: {
+    type: String,
+    doc: 'Raw content to be parsed',
+  },
+  run(data): Raw[] {
+    return [
+      {
+        type: 'raw',
+        lang: (data.arg as string) ?? '',
+        value: (data.body as string) ?? '',
+      },
+    ];
+  },
+};

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -217,6 +217,13 @@ export type Include = {
   caption?: (FlowContent | ListContent | PhrasingContent)[];
 };
 
+export type Raw = {
+  type: 'raw';
+  lang?: string;
+  value: string;
+  children?: (FlowContent | ListContent | PhrasingContent)[];
+};
+
 export type Container = Omit<SpecContainer, 'kind'> & {
   kind?: 'figure' | 'table' | 'quote' | 'code' | string;
   source?: Dependency;


### PR DESCRIPTION
The `raw` directive lets you include raw latex in a myst file. The latex will be parsed using `tex-to-myst`:
````markdown
```{raw} latex
\section{Hello World!}
\textbf{Hello World!} Here's some latex!
\begin{equation}
\gamma^2+\theta^2=\omega^2
\end{equation}
Pretty cool!
```
````

You can also use the `raw` directive to add unparsed text:
````markdown
```{raw}
*Keep these astrisks!*
```
```` 