### PR TITLE
🐍 Remove .py from linkify domains

### DIFF
--- a/.changeset/breezy-plants-act.md
+++ b/.changeset/breezy-plants-act.md
@@ -1,0 +1,5 @@
+---
+'myst-parser': patch
+---
+
+Remove .py from linkify domains

--- a/package-lock.json
+++ b/package-lock.json
@@ -11787,6 +11787,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tlds": {
+      "version": "1.250.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.250.0.tgz",
+      "integrity": "sha512-rWsBfFCWKrjM/o2Q1TTUeYQv6tHSd/umUutDjVs6taTuEgRDIreVYIBgWRWW4ot7jp6n0UVUuxhTLWBtUmPu/w==",
+      "bin": {
+        "tlds": "bin.js"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -14308,6 +14316,7 @@
         "myst-directives": "^1.0.22",
         "myst-roles": "^1.0.22",
         "myst-spec": "^0.0.5",
+        "tlds": "^1.250.0",
         "unified": "^10.1.1",
         "unist-builder": "^3.0.0",
         "unist-util-remove": "^3.1.0",

--- a/packages/myst-parser/package.json
+++ b/packages/myst-parser/package.json
@@ -55,6 +55,7 @@
     "myst-directives": "^1.0.22",
     "myst-roles": "^1.0.22",
     "myst-spec": "^0.0.5",
+    "tlds": "^1.250.0",
     "unified": "^10.1.1",
     "unist-builder": "^3.0.0",
     "unist-util-remove": "^3.1.0",

--- a/packages/myst-parser/src/config.ts
+++ b/packages/myst-parser/src/config.ts
@@ -69,4 +69,4 @@ export const MARKDOWN_IT_CONFIG = {
 };
 
 // List of valid TLDs to exclude from linkify
-export const EXCLUDE_TLDS = ['py'];
+export const EXCLUDE_TLDS = ['py', 'md'];

--- a/packages/myst-parser/src/config.ts
+++ b/packages/myst-parser/src/config.ts
@@ -67,3 +67,6 @@ export const MARKDOWN_IT_CONFIG = {
     },
   },
 };
+
+// List of valid TLDs to exclude from linkify
+export const EXCLUDE_TLDS = ['py'];

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -3,7 +3,8 @@ import { defaultDirectives } from 'myst-directives';
 import { defaultRoles } from 'myst-roles';
 import type { Plugin } from 'unified';
 import { VFile } from 'vfile';
-import { MARKDOWN_IT_CONFIG } from './config.js';
+import tlds from 'tlds';
+import { EXCLUDE_TLDS, MARKDOWN_IT_CONFIG } from './config.js';
 import { tokensToMyst } from './tokensToMyst.js';
 import {
   mathPlugin,
@@ -70,6 +71,9 @@ export function createTokenizer(opts?: Options) {
     } as any,
     markdownit,
   );
+  if (markdownit.linkify) {
+    tokenizer.linkify.tlds(tlds.filter((tld) => !EXCLUDE_TLDS.includes(tld)));
+  }
   if (extensions.smartquotes) tokenizer.enable('smartquotes');
   if (extensions.tables) tokenizer.enable('table');
   if (extensions.colonFences) tokenizer.use(colonFencePlugin);

--- a/packages/myst-parser/tests/linkify.spec.ts
+++ b/packages/myst-parser/tests/linkify.spec.ts
@@ -104,4 +104,18 @@ describe('linkify', () => {
       ],
     });
   });
+  it('dont linkify .py', () => {
+    const content = 'Link in paragraph: example.py';
+    const expected = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', value: 'Link in paragraph: example.py' }],
+        },
+      ],
+    };
+    expect(stripPositions(mystParse(content))).toEqual(expected);
+    expect(stripPositions(mystParse(content, { markdownit: { linkify: true } }))).toEqual(expected);
+  });
 });


### PR DESCRIPTION
There are a ton of domains that `linkify` catches, including `py`... That means someone writing about their python `my_script.py` file gets linkified.

For now, I've addressed this by hard-coding excluded domains in myst parser. We may want to make this configurable at the MyST config level...?

I think hardcoding what is excluded is ok, since users can always explicitly make things a link. If something they want linkified is not working (because of our exclude list), they can just make it an explicit link. Potentially we even lock down the domain list way more... there are currently 1450 valid domains 😳 https://github.com/stephenmathieson/node-tlds/blob/master/index.json (1449 with `py` excluded).