### PR TITLE
🪵 Log missing citations in the correct place

### DIFF
--- a/.changeset/gentle-hounds-boil.md
+++ b/.changeset/gentle-hounds-boil.md
@@ -1,0 +1,6 @@
+---
+'myst-common': patch
+'myst-cli': patch
+---
+
+Log missing citations in the correct place

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -296,7 +296,7 @@ export async function postProcessMdast(
   const { mdast, dependencies } = mdastPost;
   const fileState = cache.$internalReferences[file];
   const state = pageReferenceStates
-    ? new MultiPageReferenceResolver(pageReferenceStates, file)
+    ? new MultiPageReferenceResolver(pageReferenceStates, file, vfile)
     : fileState;
   // NOTE: This is doing things in place, we should potentially make this a different state?
   const transformers = [

--- a/packages/myst-cli/src/transforms/citations.ts
+++ b/packages/myst-cli/src/transforms/citations.ts
@@ -37,9 +37,6 @@ function addCitationChildren(
 ): boolean {
   const render = renderer[cite.label as string];
   if (!render) {
-    addWarningForFile(session, file, `Citation not found for label: ${cite.label}`, 'error', {
-      ruleId: RuleId.citationLabelExists,
-    });
     cite.error = 'not found';
     return false;
   }

--- a/packages/myst-common/src/ruleids.ts
+++ b/packages/myst-common/src/ruleids.ts
@@ -81,7 +81,6 @@ export enum RuleId {
   citationIsUnique = 'citation-is-unique',
   bibFileExists = 'bib-file-exists',
   citationRenders = 'citation-renders',
-  citationLabelExists = 'citation-label-exists',
   // Code rules
   codeMetadataLifted = 'code-metadata-lifted',
   codeMetatagsValid = 'code-metatags-valid',


### PR DESCRIPTION
This PR #937 restored warnings for inline citations that could not be resolved - However, these warnings were added too early (before resolving these citation labels as normal cross-references) and, it turns out, there already was a warning in the correct place. It just didn't work because the `vfile` wasn't getting passed around correctly.

This PR removes the recently added warning and fixes the existing warning.