### PR TITLE
🔢 Expand numbering items to include template and start

### DIFF
--- a/.changeset/mighty-yaks-nail.md
+++ b/.changeset/mighty-yaks-nail.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Consume expanded numbering frontmatter

--- a/.changeset/nice-papayas-count.md
+++ b/.changeset/nice-papayas-count.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Expand numbering items to include template and start

--- a/docs/cross-references.md
+++ b/docs/cross-references.md
@@ -128,7 +128,7 @@ These will show up, for example, as `Section 1` and `Section 2.1`. To turn on al
 ## Header Numbering
 
 By default section numbering for headers is turned off with numbering for figure and table numbering enabled.
-To turn on `numbering` for headers, you can can change the frontmatter in the document or project.
+To turn on `numbering` for headers, you can can change the frontmatter in the document or project. See [](#numbering) for more details on the numbering object.
 
 ```{myst}
 
@@ -266,3 +266,64 @@ doc
 
 download
 : The `` {download}`./my-file.zip` `` syntax creates a download to a document, which is equivalent to `[](./my-file.zip)`.
+
+(numbering)=
+
+## Numbering
+
+Frontmatter may specify `numbering` to customize how various components of the page are numbered. By default, numbering is enabled for figures, equations, tables, and code blocks; it is disabled for headings and other content types contained on the page.
+
+To enable numbering of all content, you may simply use:
+
+```yaml
+numbering: true
+```
+
+Similarly, to disable all numbering:
+
+```yaml
+numbering: false
+```
+
+The `numbering` object allows you to be much more granular with enabling and disabling specific components:
+
+```yaml
+numbering:
+  code: false
+  headings: true
+```
+
+For components with numbering enabled you may specify `start` to begin counting at a number other than 1 and `template` to redefine how the component will render when referenced in the text. For this example, the figures on the page will start with `Figure 5` and when referenced in the text they will appear as "fig (5)"
+
+```yaml
+numbering:
+  figure:
+    start: 5
+    template: fig (%s)
+```
+
+Numbering may be used for `figure` as above, as well as `subfigure`, `equation`, `subequation`, `table`, `code`, `headings` (for all heading depths), and `heading_1` through `heading_6` (for modifying each depth separately).
+
+You may also add numbering for custom content kinds:
+
+```markdown
+---
+numbering:
+  box:
+    enabled: true
+---
+
+:::{figure} image.png
+:label: my-box
+:kind: box
+
+This figure will be numbered as "Box 1"
+:::
+```
+
+Finally, under the `numbering` object, you may specify `enumerator`. For now, this applies to all numberings on the page. Instead of enumerating as simply 1, 2, 3... they will follow the template set in `enumerator`. For example, in Appendix 1, you may want to use the following `numbering` so content is enumerated as A1.1, A1.2, A1.3...
+
+```yaml
+numbering:
+  enumerator: A1.%s
+```

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -133,6 +133,9 @@ The following table lists the available frontmatter fields, a brief description 
 * - `abbreviations`
   - a dictionary of abbreviations in the project (see [](#abbreviations))
   - page can override project
+* - `numbering`
+  - object for customizing content numbering (see [](#numbering))
+  - page can override project
 * - `parts`
   - a dictionary of arbitrary content parts, not part of the main article, for example `abstract`, `data_availability`
   - page only

--- a/package-lock.json
+++ b/package-lock.json
@@ -14591,6 +14591,7 @@
         "katex": "^0.15.2",
         "mdast-util-find-and-replace": "^2.1.0",
         "myst-common": "^1.1.28",
+        "myst-frontmatter": "^1.1.27",
         "myst-spec": "^0.0.5",
         "myst-spec-ext": "^1.1.28",
         "myst-to-html": "1.0.23",

--- a/packages/myst-frontmatter/src/numbering/numbering.spec.ts
+++ b/packages/myst-frontmatter/src/numbering/numbering.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { fillNumbering } from './validators';
+
+describe('fillNumbering', () => {
+  it('empty numberings return empty', async () => {
+    expect(fillNumbering({}, {})).toEqual({});
+  });
+  it('base numberings return base', async () => {
+    expect(
+      fillNumbering(
+        {
+          all: { enabled: true },
+          enumerator: { template: '' },
+          heading_6: { enabled: false },
+        },
+        {},
+      ),
+    ).toEqual({
+      all: { enabled: true },
+      enumerator: { template: '' },
+      heading_6: { enabled: false },
+    });
+  });
+  it('filler numberings return filler', async () => {
+    expect(
+      fillNumbering(
+        {},
+        {
+          all: { enabled: true },
+          enumerator: { template: '' },
+          heading_6: { enabled: false },
+        },
+      ),
+    ).toEqual({
+      all: { enabled: true },
+      enumerator: { template: '' },
+      heading_6: { enabled: false },
+    });
+  });
+  it('basic keys fill', async () => {
+    expect(
+      fillNumbering(
+        {
+          heading_1: { enabled: true, start: 2 },
+          list: { enabled: true },
+        },
+        {
+          enumerator: { template: '' },
+          figure: { enabled: true, template: 'Fig. %s' },
+          another: { enabled: true },
+        },
+      ),
+    ).toEqual({
+      enumerator: { template: '' },
+      heading_1: { enabled: true, start: 2 },
+      list: { enabled: true },
+      figure: { enabled: true, template: 'Fig. %s' },
+      another: { enabled: true },
+    });
+  });
+  it('sub-keys fill', async () => {
+    expect(
+      fillNumbering(
+        {
+          heading_1: { enabled: true, start: 2 },
+        },
+        {
+          heading_1: { template: 'Fig. %s' },
+        },
+      ),
+    ).toEqual({
+      heading_1: { enabled: true, start: 2, template: 'Fig. %s' },
+    });
+  });
+  it('all overrides previous enabled values', async () => {
+    expect(
+      fillNumbering(
+        {
+          all: { enabled: false },
+          heading_1: { enabled: true, start: 2 },
+          list: { enabled: false },
+          heading_3: { enabled: true },
+        },
+        {
+          heading_2: { enabled: true, template: 'Fig. %s' },
+          heading_3: { enabled: true },
+        },
+      ),
+    ).toEqual({
+      all: { enabled: false },
+      heading_1: { enabled: true, start: 2 },
+      list: { enabled: false },
+      heading_2: { enabled: false, template: 'Fig. %s' },
+      heading_3: { enabled: true },
+    });
+    expect(
+      fillNumbering(
+        {
+          all: { enabled: true },
+          heading_1: { enabled: true, start: 2 },
+          list: { enabled: false },
+          heading_3: { enabled: false },
+        },
+        {
+          heading_2: { enabled: false, template: 'Fig. %s' },
+          heading_3: { enabled: true },
+        },
+      ),
+    ).toEqual({
+      all: { enabled: true },
+      heading_1: { enabled: true, start: 2 },
+      list: { enabled: false },
+      heading_2: { enabled: true, template: 'Fig. %s' },
+      heading_3: { enabled: false },
+    });
+  });
+});

--- a/packages/myst-frontmatter/src/numbering/numbering.yml
+++ b/packages/myst-frontmatter/src/numbering/numbering.yml
@@ -15,17 +15,20 @@ cases:
         list: true
     normalized:
       numbering:
-        list: true
+        list:
+          enabled: true
   - title: invalid extras keys are removed
     raw:
       numbering:
-        list: 'invalid'
+        list:
+          invalid: true
     normalized: {}
-    errors: 1
+    warnings: 1
   - title: full object returns self
     raw:
       numbering:
         enumerator: ''
+        all: true
         figure: true
         equation: true
         table: true
@@ -38,17 +41,30 @@ cases:
         heading_6: true
     normalized:
       numbering:
-        enumerator: ''
-        figure: true
-        equation: true
-        table: true
-        code: true
-        heading_1: true
-        heading_2: true
-        heading_3: true
-        heading_4: true
-        heading_5: true
-        heading_6: true
+        enumerator:
+          template: ''
+        all:
+          enabled: true
+        figure:
+          enabled: true
+        equation:
+          enabled: true
+        table:
+          enabled: true
+        code:
+          enabled: true
+        heading_1:
+          enabled: true
+        heading_2:
+          enabled: true
+        heading_3:
+          enabled: true
+        heading_4:
+          enabled: true
+        heading_5:
+          enabled: true
+        heading_6:
+          enabled: true
   - title: headings unpack
     raw:
       numbering:
@@ -56,12 +72,18 @@ cases:
         h3: false # alias for heading_3
     normalized:
       numbering:
-        heading_1: true
-        heading_2: true
-        heading_3: false
-        heading_4: true
-        heading_5: true
-        heading_6: true
+        heading_1:
+          enabled: true
+        heading_2:
+          enabled: true
+        heading_3:
+          enabled: false
+        heading_4:
+          enabled: true
+        heading_5:
+          enabled: true
+        heading_6:
+          enabled: true
   - title: Allow numbers to start at
     raw:
       numbering:
@@ -69,8 +91,12 @@ cases:
         list: 1
     normalized:
       numbering:
-        figure: 2
-        list: 1
+        figure:
+          enabled: true
+          start: 2
+        list:
+          enabled: true
+          start: 1
   - title: Numbers can't be negative or fractional
     raw:
       numbering:
@@ -79,3 +105,84 @@ cases:
         something: 0 # This should just be true
     normalized: {}
     errors: 3
+  - title: String becomes template
+    raw:
+      numbering:
+        list: L%s
+    normalized:
+      numbering:
+        list:
+          enabled: true
+          template: L%s
+  - title: Specific heading overrides headings
+    raw:
+      numbering:
+        headings: Heading %s
+        heading_3: false
+        heading_4: H%s
+        heading_6: 4
+        list: true
+    normalized:
+      numbering:
+        heading_1:
+          enabled: true
+          template: Heading %s
+        heading_2:
+          enabled: true
+          template: Heading %s
+        heading_3:
+          enabled: false
+          template: Heading %s
+        heading_4:
+          enabled: true
+          template: H%s
+        heading_5:
+          enabled: true
+          template: Heading %s
+        heading_6:
+          enabled: true
+          start: 4
+          template: Heading %s
+        list:
+          enabled: true
+  - title: Boolean coerces
+    raw:
+      numbering: true
+    normalized:
+      numbering:
+        all:
+          enabled: true
+  - title: Extra fields on enumerator warn
+    raw:
+      numbering:
+        enumerator:
+          enabled: false
+          template: ''
+          start: 2
+    normalized:
+      numbering:
+        enumerator:
+          template: ''
+    warnings: 2
+  - title: Enumerator enabled removed without warning
+    raw:
+      numbering:
+        enumerator:
+          enabled: true
+          template: ''
+    normalized:
+      numbering:
+        enumerator:
+          template: ''
+  - title: Extra fields on all warn
+    raw:
+      numbering:
+        all:
+          enabled: false
+          template: ''
+          start: 2
+    normalized:
+      numbering:
+        all:
+          enabled: false
+    warnings: 2

--- a/packages/myst-frontmatter/src/numbering/types.ts
+++ b/packages/myst-frontmatter/src/numbering/types.ts
@@ -1,13 +1,22 @@
-export type Numbering = {
-  enumerator?: string;
-  figure?: boolean;
-  equation?: boolean;
-  table?: boolean;
-  code?: boolean;
-  heading_1?: boolean;
-  heading_2?: boolean;
-  heading_3?: boolean;
-  heading_4?: boolean;
-  heading_5?: boolean;
-  heading_6?: boolean;
+export type NumberingItem = {
+  enabled?: boolean;
+  start?: number;
+  template?: string;
 };
+
+export type Numbering = {
+  enumerator?: NumberingItem; // start ignored
+  all?: NumberingItem; // start and template ignored
+  figure?: NumberingItem;
+  subfigure?: NumberingItem;
+  equation?: NumberingItem;
+  subequation?: NumberingItem;
+  table?: NumberingItem;
+  code?: NumberingItem;
+  heading_1?: NumberingItem;
+  heading_2?: NumberingItem;
+  heading_3?: NumberingItem;
+  heading_4?: NumberingItem;
+  heading_5?: NumberingItem;
+  heading_6?: NumberingItem;
+} & Record<string, NumberingItem>;

--- a/packages/myst-frontmatter/src/numbering/validators.ts
+++ b/packages/myst-frontmatter/src/numbering/validators.ts
@@ -1,18 +1,30 @@
 import type { ValidationOptions } from 'simple-validators';
 import {
   defined,
+  fillMissingKeys,
   incrementOptions,
   validateBoolean,
   validateNumber,
   validateObjectKeys,
   validateString,
+  validationWarning,
 } from 'simple-validators';
-import type { Numbering } from './types.js';
+import type { Numbering, NumberingItem } from './types.js';
 
-export const NUMBERING_OPTIONS = ['enumerator', 'headings'];
+export const NUMBERING_OPTIONS = ['enumerator', 'all', 'headings'];
 
 const HEADING_KEYS = ['heading_1', 'heading_2', 'heading_3', 'heading_4', 'heading_5', 'heading_6'];
-export const NUMBERING_KEYS = ['figure', 'equation', 'table', 'code', ...HEADING_KEYS];
+export const NUMBERING_KEYS = [
+  'figure',
+  'subfigure',
+  'equation',
+  'subequation',
+  'table',
+  'code',
+  ...HEADING_KEYS,
+];
+
+const NUMBERING_ITEM_KEYS = ['enabled', 'start', 'template'];
 
 export const NUMBERING_ALIAS = {
   sections: 'headings',
@@ -30,26 +42,110 @@ export const NUMBERING_ALIAS = {
   heading6: 'heading_6',
 };
 
+function isBoolean(input: any) {
+  if (typeof input === 'string') {
+    return ['true', 'false'].includes(input.toLowerCase());
+  }
+  return typeof input === 'boolean';
+}
+
+/**
+ * Validate value for each numbering entry
+ *
+ * Value may be:
+ * - boolean, to simply enable/disable numbering
+ * - number, to indicate the starting number
+ * - string, to define the cross-reference template
+ *   (e.g. 'Fig. %s' to get "Fig. 1" instead of "Figure 1" in your document)
+ * - An object with any of enabled/start/template - specifying the above types
+ *   will coerce to this object
+ */
+export function validateNumberingItem(
+  input: any,
+  opts: ValidationOptions,
+): NumberingItem | undefined {
+  if (isBoolean(input)) {
+    input = { enabled: input };
+  } else if (typeof input === 'number') {
+    input = { start: input };
+  } else if (typeof input === 'string') {
+    input = { template: input };
+  }
+  const value = validateObjectKeys(input, { optional: NUMBERING_ITEM_KEYS }, opts);
+  if (value === undefined) return undefined;
+  const output: NumberingItem = {};
+  if (defined(value.enabled)) {
+    const enabled = validateBoolean(value.enabled, incrementOptions('enabled', opts));
+    if (defined(enabled)) output.enabled = enabled;
+  }
+  if (defined(value.start)) {
+    const start = validateNumber(value.start, {
+      ...incrementOptions('start', opts),
+      integer: true,
+      min: 1,
+    });
+    if (start) {
+      output.start = start;
+      output.enabled = output.enabled ?? true;
+    }
+  }
+  if (defined(value.template)) {
+    const template = validateString(value.template, incrementOptions('template', opts));
+    if (defined(template)) {
+      output.template = template;
+      output.enabled = output.enabled ?? true;
+    }
+  }
+  if (Object.keys(output).length === 0) return undefined;
+  return output;
+}
+
 /**
  * Validate Numbering object
  */
 export function validateNumbering(input: any, opts: ValidationOptions): Numbering | undefined {
+  if (isBoolean(input)) {
+    input = { all: input };
+  }
   const value = validateObjectKeys(
     input,
     { optional: [...NUMBERING_KEYS, ...NUMBERING_OPTIONS], alias: NUMBERING_ALIAS },
     { ...opts, suppressWarnings: true, keepExtraKeys: true },
   );
   if (value === undefined) return undefined;
-  const output: Record<string, any> = {};
+  const output: Numbering = {};
+  let headings: NumberingItem | undefined;
   if (defined(value.enumerator)) {
-    output.enumerator = validateString(value.enumerator, incrementOptions('enumerator', opts));
+    const enumeratorOpts = incrementOptions('enumerator', opts);
+    output.enumerator = validateNumberingItem(value.enumerator, enumeratorOpts);
+    if (output.enumerator?.enabled != null) {
+      if (output.enumerator.enabled !== true) {
+        validationWarning("value for 'enabled' is ignored", enumeratorOpts);
+      }
+      delete output.enumerator.enabled;
+    }
+    if (output.enumerator?.start != null) {
+      validationWarning("value for 'start' is ignored", enumeratorOpts);
+      delete output.enumerator.start;
+    }
+  }
+  if (defined(value.all)) {
+    const allOpts = incrementOptions('all', opts);
+    output.all = validateNumberingItem(value.all, allOpts);
+    if (output.all?.template != null) {
+      validationWarning("value for 'template' is ignored", allOpts);
+      delete output.all.template;
+    }
+    if (output.all?.start != null) {
+      validationWarning("value for 'start' is ignored", allOpts);
+      delete output.all.start;
+    }
   }
   if (defined(value.headings)) {
-    const headings = validateBoolean(value.headings, incrementOptions('headings', opts));
+    headings = validateNumberingItem(value.headings, incrementOptions('headings', opts));
     HEADING_KEYS.forEach((headingKey) => {
       if (headings && !defined(value[headingKey])) {
-        // This will be validated next!
-        value[headingKey] = true;
+        value[headingKey] = headings;
       }
     });
   }
@@ -57,19 +153,30 @@ export function validateNumbering(input: any, opts: ValidationOptions): Numberin
     .filter((key) => !NUMBERING_OPTIONS.includes(key)) // For all the unknown options
     .forEach((key) => {
       if (defined(value[key])) {
-        if (typeof value[key] === 'number') {
-          const number = validateNumber(value[key], {
-            ...incrementOptions(key, opts),
-            integer: true,
-            min: 1,
-          });
-          if (defined(number)) output[key] = number;
+        const item = validateNumberingItem(value[key], incrementOptions(key, opts));
+        if (!defined(item)) return;
+        if (headings && HEADING_KEYS.includes(key)) {
+          output[key] = { ...headings, ...item };
         } else {
-          const bool = validateBoolean(value[key], incrementOptions(key, opts));
-          if (defined(bool)) output[key] = bool;
+          output[key] = item;
         }
       }
     });
   if (Object.keys(output).length === 0) return undefined;
+  return output;
+}
+
+export function fillNumbering(base?: Numbering, filler?: Numbering) {
+  const output: Numbering = { ...filler, ...base };
+  Object.entries(filler ?? {})
+    .filter(([key]) => !NUMBERING_OPTIONS.includes(key))
+    .forEach(([key, val]) => {
+      output[key] = fillMissingKeys(
+        base?.[key] ?? {},
+        // Enabling/disabling all in base overrides filler
+        { ...val, enabled: base?.all?.enabled ?? val.enabled },
+        NUMBERING_ITEM_KEYS,
+      );
+    });
   return output;
 }

--- a/packages/myst-frontmatter/src/project/project.yml
+++ b/packages/myst-frontmatter/src/project/project.yml
@@ -113,7 +113,9 @@ cases:
     raw:
       numbering: 'false'
     normalized:
-      numbering: false
+      numbering:
+        all:
+          enabled: false
   - title: invalid doi errors
     raw:
       doi: ''

--- a/packages/myst-frontmatter/src/project/types.ts
+++ b/packages/myst-frontmatter/src/project/types.ts
@@ -53,7 +53,7 @@ export type ProjectAndPageFrontmatter = SiteFrontmatter & {
   bibliography?: string[];
   biblio?: Biblio;
   oxa?: string;
-  numbering?: boolean | Numbering;
+  numbering?: Numbering;
   /** Math macros to be passed to KaTeX or LaTeX */
   math?: Record<string, string>;
   /** Abbreviations used throughout the project */

--- a/packages/myst-frontmatter/src/project/validators.ts
+++ b/packages/myst-frontmatter/src/project/validators.ts
@@ -17,7 +17,7 @@ import { validateLicenses } from '../licenses/validators.js';
 import { validateNumbering } from '../numbering/validators.js';
 import { FRONTMATTER_ALIASES, validateSiteFrontmatterKeys } from '../site/validators.js';
 import { validateThebe } from '../thebe/validators.js';
-import { validateBooleanOrObject, validateDoi } from '../utils/validators.js';
+import { validateDoi } from '../utils/validators.js';
 import { PROJECT_FRONTMATTER_KEYS } from './types.js';
 import type { ProjectAndPageFrontmatter, ProjectFrontmatter } from './types.js';
 import { validateProjectAndPageSettings } from '../settings/validators.js';
@@ -77,11 +77,7 @@ export function validateProjectAndPageFrontmatterKeys(
     output.oxa = validateString(value.oxa, incrementOptions('oxa', opts));
   }
   if (defined(value.numbering)) {
-    output.numbering = validateBooleanOrObject(
-      value.numbering,
-      incrementOptions('numbering', opts),
-      validateNumbering,
-    );
+    output.numbering = validateNumbering(value.numbering, incrementOptions('numbering', opts));
   }
   if (defined(value.math)) {
     const mathOpts = incrementOptions('math', opts);

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.spec.ts
@@ -117,12 +117,29 @@ describe('fillPageFrontmatter', () => {
   it('page and project numbering are combined', async () => {
     expect(
       fillPageFrontmatter(
-        { numbering: { enumerator: '#', heading_5: true, heading_6: true } },
-        { numbering: { enumerator: '$', heading_1: true, heading_6: false } },
+        {
+          numbering: {
+            enumerator: { template: '#' },
+            heading_5: { enabled: true },
+            heading_6: { enabled: true },
+          },
+        },
+        {
+          numbering: {
+            enumerator: { template: '$' },
+            heading_1: { enabled: true },
+            heading_6: { enabled: false },
+          },
+        },
         opts,
       ),
     ).toEqual({
-      numbering: { enumerator: '#', heading_1: true, heading_5: true, heading_6: true },
+      numbering: {
+        enumerator: { template: '#' },
+        heading_1: { enabled: true },
+        heading_5: { enabled: true },
+        heading_6: { enabled: true },
+      },
     });
   });
   it('extra project affiliations are not included', async () => {

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
@@ -2,7 +2,7 @@ import type { ValidationOptions } from 'simple-validators';
 import { fillMissingKeys, incrementOptions, validationWarning } from 'simple-validators';
 import type { Affiliation } from '../affiliations/types.js';
 import type { Contributor } from '../contributors/types.js';
-import { NUMBERING_KEYS } from '../numbering/validators.js';
+import { fillNumbering } from '../numbering/validators.js';
 import { USE_PROJECT_FALLBACK } from '../page/validators.js';
 import type { PageFrontmatter } from '../page/types.js';
 import type { ProjectFrontmatter } from '../project/types.js';
@@ -22,18 +22,7 @@ export function fillPageFrontmatter(
 ) {
   const frontmatter = fillMissingKeys(pageFrontmatter, projectFrontmatter, USE_PROJECT_FALLBACK);
 
-  // If numbering is an object, combine page and project settings.
-  // Otherwise, the value filled above is correct.
-  if (
-    typeof pageFrontmatter.numbering === 'object' &&
-    typeof projectFrontmatter.numbering === 'object'
-  ) {
-    frontmatter.numbering = fillMissingKeys(
-      pageFrontmatter.numbering,
-      projectFrontmatter.numbering,
-      NUMBERING_KEYS,
-    );
-  }
+  frontmatter.numbering = fillNumbering(pageFrontmatter.numbering, projectFrontmatter.numbering);
 
   // Combine all math macros defined on page and project
   if (projectFrontmatter.math || pageFrontmatter.math) {

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
@@ -22,7 +22,9 @@ export function fillPageFrontmatter(
 ) {
   const frontmatter = fillMissingKeys(pageFrontmatter, projectFrontmatter, USE_PROJECT_FALLBACK);
 
-  frontmatter.numbering = fillNumbering(pageFrontmatter.numbering, projectFrontmatter.numbering);
+  if (pageFrontmatter.numbering || projectFrontmatter.numbering) {
+    frontmatter.numbering = fillNumbering(pageFrontmatter.numbering, projectFrontmatter.numbering);
+  }
 
   // Combine all math macros defined on page and project
   if (projectFrontmatter.math || pageFrontmatter.math) {

--- a/packages/myst-transforms/package.json
+++ b/packages/myst-transforms/package.json
@@ -27,6 +27,7 @@
     "hast-util-to-mdast": "^8.3.1",
     "mdast-util-find-and-replace": "^2.1.0",
     "myst-common": "^1.1.28",
+    "myst-frontmatter": "^1.1.27",
     "myst-spec": "^0.0.5",
     "myst-spec-ext": "^1.1.28",
     "myst-to-html": "1.0.23",

--- a/packages/myst-transforms/src/enumerate.spec.ts
+++ b/packages/myst-transforms/src/enumerate.spec.ts
@@ -48,7 +48,9 @@ describe('enumeration', () => {
         u('math', { identifier: 'eq:3-4', kind: 'subequation' }),
       ]),
     ]);
-    const state = new ReferenceState('my-file.md', { numbering: { enumerator: 'A.%s' } });
+    const state = new ReferenceState('my-file.md', {
+      numbering: { enumerator: { template: 'A.%s' } },
+    });
     enumerateTargetsTransform(tree, { state });
     expect(state.getTarget('eq:1')?.node.enumerator).toBe('A.1');
     expect(state.getTarget('eq:1a')?.node.enumerator).toBe('A.1a');
@@ -68,7 +70,7 @@ describe('enumeration', () => {
       u('heading', { identifier: 'h3', depth: 1 }),
     ]);
     const state = new ReferenceState('my-file.md', {
-      numbering: { heading_1: true, heading_2: true },
+      numbering: { heading_1: { enabled: true }, heading_2: { enabled: true } },
     });
     enumerateTargetsTransform(tree, { state });
     expect(state.getTarget('h1')?.node.enumerator).toBe('1');
@@ -84,7 +86,9 @@ describe('enumeration', () => {
       ]),
       u('container', { identifier: 'fig:2', kind: 'figure' }, []),
     ]);
-    const state = new ReferenceState('my-file.md', { numbering: { enumerator: 'A.%s' } });
+    const state = new ReferenceState('my-file.md', {
+      numbering: { enumerator: { template: 'A.%s' } },
+    });
     enumerateTargetsTransform(tree, { state });
     expect(state.getTarget('fig:1')?.node.enumerator).toBe('A.1');
     expect(state.getTarget('fig:1a')?.node.enumerator).toBe('a');

--- a/packages/myst-transforms/src/enumerate.ts
+++ b/packages/myst-transforms/src/enumerate.ts
@@ -444,10 +444,6 @@ export class ReferenceState implements IReferenceStateResolver {
         target.node,
         copyNode(target.node as Heading).children as PhrasingContent[],
       );
-    } else if (target.kind === TargetKind.equation) {
-      // Equations are always numbered
-      const template = getReferenceTemplate(target, this.numbering, true, false);
-      fillReferenceEnumerators(this.vfile, node, template, target.node);
     } else {
       // By default look into the caption or admonition title if it exists
       const caption =

--- a/packages/myst-transforms/src/enumerate.ts
+++ b/packages/myst-transforms/src/enumerate.ts
@@ -288,7 +288,6 @@ export function initializeTargetCounts(
       targetCounts[key] = { main: val.start - 1, sub: 0 };
     }
   });
-  console.log(targetCounts);
   return targetCounts;
 }
 

--- a/packages/myst-transforms/src/index.ts
+++ b/packages/myst-transforms/src/index.ts
@@ -60,7 +60,7 @@ export { containerChildrenPlugin, containerChildrenTransform } from './container
 export { headingDepthPlugin, headingDepthTransform } from './headings.js';
 
 // Enumeration
-export type { IReferenceStateResolver, NumberingOptions, ReferenceKind } from './enumerate.js';
+export type { IReferenceStateResolver, ReferenceKind } from './enumerate.js';
 export {
   enumerateTargetsTransform,
   enumerateTargetsPlugin,

--- a/packages/myst-transforms/tests/enumerators.yml
+++ b/packages/myst-transforms/tests/enumerators.yml
@@ -668,3 +668,83 @@ cases:
                       children:
                         - type: text
                           value: Something! A legend!?
+  - title: heading numbering with start
+    opts:
+      numbering:
+        heading_1:
+          enabled: true
+          start: 5
+    before:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: one
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: two
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: three
+    after:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: one
+          enumerator: '5'
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: two
+          enumerator: '6'
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: three
+          enumerator: '7'
+  - title: heading numbering with enumerator
+    opts:
+      numbering:
+        enumerator:
+          template: A%s
+        heading_1:
+          enabled: true
+    before:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: one
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: two
+    after:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: one
+          enumerator: 'A1'
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: two
+          enumerator: 'A2'

--- a/packages/myst-transforms/tests/enumerators.yml
+++ b/packages/myst-transforms/tests/enumerators.yml
@@ -2,7 +2,8 @@ cases:
   - title: heading numbering
     opts:
       numbering:
-        heading_1: true
+        heading_1:
+          enabled: true
     before:
       type: root
       children:
@@ -45,7 +46,8 @@ cases:
   - title: heading numbering - unnumbered
     opts:
       numbering:
-        heading_1: true
+        heading_1:
+          enabled: true
     before:
       type: root
       children:
@@ -89,12 +91,18 @@ cases:
   - title: heading numbering - levels
     opts:
       numbering:
-        heading_1: true
-        heading_2: true
-        heading_3: true
-        heading_4: true
-        heading_5: true
-        heading_6: true
+        heading_1:
+          enabled: true
+        heading_2:
+          enabled: true
+        heading_3:
+          enabled: true
+        heading_4:
+          enabled: true
+        heading_5:
+          enabled: true
+        heading_6:
+          enabled: true
     before:
       type: root
       children:
@@ -182,12 +190,18 @@ cases:
   - title: heading numbering - disabled
     opts:
       numbering:
-        heading_1: false
-        heading_2: false
-        heading_3: false
-        heading_4: false
-        heading_5: false
-        heading_6: false
+        heading_1:
+          enabled: false
+        heading_2:
+          enabled: false
+        heading_3:
+          enabled: false
+        heading_4:
+          enabled: false
+        heading_5:
+          enabled: false
+        heading_6:
+          enabled: false
     before:
       type: root
       children:
@@ -250,7 +264,8 @@ cases:
   - title: math numbering - inside directive
     opts:
       numbering:
-        equation: true
+        equation:
+          enabled: true
     before:
       type: root
       children:
@@ -286,7 +301,8 @@ cases:
   - title: math numbering - disabled
     opts:
       numbering:
-        equation: false
+        equation:
+          enabled: false
     before:
       type: root
       children:
@@ -592,8 +608,10 @@ cases:
   - title: container numbering - disabled
     opts:
       numbering:
-        figure: false
-        table: false
+        figure:
+          enabled: false
+        table:
+          enabled: false
     before:
       type: root
       children:


### PR DESCRIPTION
This updates numbering frontmatter so each field is an object with `enabled`, `template`, and `start`. `start` sets the first number for the corresponding kind and `template` sets the text when the item is referenced inline.
```yaml
numbering:
  figure:
    start: 3
    template: Fig. %s
```

This is backwards compatible with the previous numbering schema for enabling/disabling numbering, e.g. 
```yaml
numbering: true
```
and
```yaml
numbering:
  headings: true
  figure: false
```
are still valid.

More details in the docs updates in this PR!