### PR TITLE
🎆 Expose max size for webp conversion

### DIFF
--- a/.changeset/neat-teachers-look.md
+++ b/.changeset/neat-teachers-look.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Expose max size for webp conversion

--- a/.changeset/weak-squids-refuse.md
+++ b/.changeset/weak-squids-refuse.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'mystmd': patch
+---
+
+Expose max size webp conversion to cli

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -29,6 +29,7 @@ export type BuildOpts = {
   checkLinks?: boolean;
   ci?: boolean;
   execute?: boolean;
+  maxSizeWebp?: number;
 };
 
 export function hasAnyExplicitExportFormat(opts: BuildOpts): boolean {

--- a/packages/myst-cli/src/build/site/prepare.ts
+++ b/packages/myst-cli/src/build/site/prepare.ts
@@ -19,6 +19,7 @@ export type Options = {
   extraLinkTransformers?: LinkTransformer[];
   extraTransforms?: TransformFn[];
   defaultTemplate?: string;
+  maxSizeWebp?: number;
 };
 
 export function cleanSiteContent(session: ISession, info = true): void {
@@ -47,6 +48,7 @@ export async function buildSite(session: ISession, opts: Options) {
     extraTransforms,
     defaultTemplate,
     execute,
+    maxSizeWebp,
   } = opts;
   ensureBuildFoldersExist(session);
   await processSite(session, {
@@ -57,5 +59,6 @@ export async function buildSite(session: ISession, opts: Options) {
     extraTransforms,
     defaultTemplate,
     execute,
+    maxSizeWebp,
   });
 }

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -112,13 +112,14 @@ export async function startServer(
   if (!opts.headless) await installSiteTemplate(session, mystTemplate);
   await buildSite(session, opts);
   const server = await startContentServer(session, opts);
-  const { extraLinkTransformers, extraTransforms, defaultTemplate, execute } = opts;
+  const { extraLinkTransformers, extraTransforms, defaultTemplate, execute, maxSizeWebp } = opts;
   if (!opts.buildStatic) {
     watchContent(session, server.reload, {
       extraLinkTransformers,
       extraTransforms,
       defaultTemplate,
       execute,
+      maxSizeWebp,
     });
   }
   if (opts.headless) {

--- a/packages/myst-cli/src/build/site/watch.ts
+++ b/packages/myst-cli/src/build/site/watch.ts
@@ -17,6 +17,7 @@ type TransformOptions = {
   defaultTemplate?: string;
   reloadProject?: boolean;
   execute?: boolean;
+  maxSizeWebp?: number;
 };
 
 function watchConfigAndPublic(session: ISession, serverReload: () => void, opts: TransformOptions) {

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -337,6 +337,7 @@ export async function finalizeMdast(
     optimizeWebp,
     simplifyFigures,
     processThumbnail,
+    maxSizeWebp,
   }: {
     imageWriteFolder: string;
     useExistingImages?: boolean;
@@ -345,6 +346,7 @@ export async function finalizeMdast(
     optimizeWebp?: boolean;
     simplifyFigures?: boolean;
     processThumbnail?: boolean;
+    maxSizeWebp?: number;
   },
 ) {
   const vfile = new VFile(); // Collect errors on this file
@@ -370,17 +372,19 @@ export async function finalizeMdast(
       imageExtensions,
     });
     if (optimizeWebp) {
-      await transformWebp(session, { file, imageWriteFolder });
+      await transformWebp(session, { file, imageWriteFolder, maxSizeWebp });
     }
     if (processThumbnail) {
       // Note, the thumbnail transform must be **after** images, as it may read the images
       await transformThumbnail(session, mdast, file, frontmatter, imageWriteFolder, {
         altOutputFolder: imageAltOutputFolder,
         webp: optimizeWebp,
+        maxSizeWebp,
       });
       await transformBanner(session, file, frontmatter, imageWriteFolder, {
         altOutputFolder: imageAltOutputFolder,
         webp: optimizeWebp,
+        maxSizeWebp,
       });
     }
   }

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -43,6 +43,7 @@ type ProcessOptions = {
   imageWriteFolder?: string;
   imageAltOutputFolder?: string;
   imageExtensions?: ImageExtensions[];
+  maxSizeWebp?: number;
   extraLinkTransformers?: LinkTransformer[];
   extraTransforms?: TransformFn[];
   defaultTemplate?: string;
@@ -271,6 +272,7 @@ export async function processProject(
     writeFiles = true,
     reloadProject,
     execute,
+    maxSizeWebp,
   } = opts || {};
   if (!siteProject.path) {
     const slugSuffix = siteProject.slug ? `: ${siteProject.slug}` : '';
@@ -336,6 +338,7 @@ export async function processProject(
             imageExtensions: usedImageExtensions,
             optimizeWebp: true,
             processThumbnail: true,
+            maxSizeWebp,
           });
         }
         return writeFile(session, {

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -209,6 +209,7 @@ export async function fastProcessFile(
     extraTransforms,
     defaultTemplate,
     execute,
+    maxSizeWebp,
   }: {
     file: string;
     pageSlug: string;
@@ -218,6 +219,7 @@ export async function fastProcessFile(
     extraTransforms?: TransformFn[];
     defaultTemplate?: string;
     execute?: boolean;
+    maxSizeWebp?: number;
   },
 ) {
   const toc = tic();
@@ -248,6 +250,7 @@ export async function fastProcessFile(
       imageExtensions: WEB_IMAGE_EXTENSIONS,
       optimizeWebp: true,
       processThumbnail: true,
+      maxSizeWebp,
     });
   }
   await writeFile(session, { file, pageSlug, projectSlug });

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -507,7 +507,7 @@ export async function transformThumbnail(
   file: string,
   frontmatter: PageFrontmatter,
   writeFolder: string,
-  opts?: { altOutputFolder?: string; webp?: boolean },
+  opts?: { altOutputFolder?: string; webp?: boolean; maxSizeWebp?: number },
 ): Promise<{ url: string; urlOptimized?: string } | undefined> {
   let thumbnail = frontmatter.thumbnail;
   // If the thumbnail is explicitly null, don't add an image
@@ -539,6 +539,7 @@ export async function transformThumbnail(
     const optimized = await imagemagick.convertImageToWebp(
       session,
       path.join(writeFolder, fileMatch),
+      { maxSize: opts.maxSizeWebp },
     );
     if (optimized) {
       const urlOptimized = url.replace(fileMatch, optimized);
@@ -554,7 +555,7 @@ export async function transformBanner(
   file: string,
   frontmatter: { banner?: string | null; bannerOptimized?: string },
   writeFolder: string,
-  opts?: { altOutputFolder?: string; webp?: boolean },
+  opts?: { altOutputFolder?: string; webp?: boolean; maxSizeWebp?: number },
 ): Promise<{ url: string; urlOptimized?: string } | undefined> {
   const banner = frontmatter.banner;
   // If the thumbnail is explicitly null, don't add an image
@@ -575,6 +576,7 @@ export async function transformBanner(
     const optimized = await imagemagick.convertImageToWebp(
       session,
       path.join(writeFolder, fileMatch),
+      { maxSize: opts.maxSizeWebp },
     );
     if (optimized) {
       const urlOptimized = url.replace(fileMatch, optimized);
@@ -587,7 +589,7 @@ export async function transformBanner(
 
 export async function transformWebp(
   session: ISession,
-  opts: { file: string; imageWriteFolder: string },
+  opts: { file: string; imageWriteFolder: string; maxSizeWebp?: number },
 ) {
   const { file, imageWriteFolder } = opts;
   const cache = castSession(session);
@@ -606,6 +608,7 @@ export async function transformWebp(
         const result = await imagemagick.convertImageToWebp(
           session,
           path.join(imageWriteFolder, fileMatch),
+          { maxSize: opts.maxSizeWebp },
         );
         if (result) image.urlOptimized = image.url.replace(fileMatch, result);
       } catch (error) {
@@ -624,6 +627,7 @@ export async function transformWebp(
             const result = await imagemagick.convertImageToWebp(
               session,
               path.join(imageWriteFolder, fileMatch),
+              { maxSize: opts.maxSizeWebp },
             );
             if (result) {
               frontmatter[attrOptimized] = frontmatter[attr]?.replace(fileMatch, result);

--- a/packages/myst-cli/src/utils/imagemagick.ts
+++ b/packages/myst-cli/src/utils/imagemagick.ts
@@ -129,8 +129,11 @@ export async function convert(
 export async function convertImageToWebp(
   session: ISession,
   image: string,
-  quality = 80,
-  overwrite = false,
+  {
+    quality = 80,
+    overwrite = false,
+    maxSize = LARGE_IMAGE,
+  }: { quality?: number; overwrite?: boolean; maxSize?: number },
 ): Promise<string | null> {
   if (!fs.existsSync(image)) {
     // If the image does not exist, it will be caught elsewhere prior to webp conversion
@@ -146,7 +149,7 @@ export async function convertImageToWebp(
 
   const { size } = fs.statSync(image);
   // PDF and TIFF are not image formats that can be used in most web-browsers
-  if (size > LARGE_IMAGE && !(imageExt === '.pdf' || imageExt === '.tiff')) {
+  if (size > maxSize && !(imageExt === '.pdf' || imageExt === '.tiff')) {
     const inMB = (size / (1024 * 1024)).toLocaleString(undefined, {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,

--- a/packages/mystmd/src/build.ts
+++ b/packages/mystmd/src/build.ts
@@ -19,6 +19,7 @@ import {
   makeWatchOption,
   makeCIOption,
   makeExecuteOption,
+  makeMaxSizeWebpOption,
 } from './options.js';
 
 export function makeBuildCLI(program: Command) {
@@ -42,6 +43,7 @@ export function makeBuildCLI(program: Command) {
     .addOption(makeCheckLinksOption())
     .addOption(makeStrictOption())
     .addOption(makeCIOption())
+    .addOption(makeMaxSizeWebpOption())
     .action(clirun(Session, build, program));
   return command;
 }

--- a/packages/mystmd/src/options.ts
+++ b/packages/mystmd/src/options.ts
@@ -148,6 +148,19 @@ export function makeCIOption() {
   ).default(false);
 }
 
+export function makeMaxSizeWebpOption() {
+  return new Option('--max-size-webp <size>', 'Max image size to convert to webp format in MB')
+    .default(1.5 * 1024 * 1024, '1.5')
+    .argParser((value) => {
+      if (value == null) return undefined;
+      const parsedValue = parseFloat(value);
+      if (isNaN(parsedValue)) {
+        throw new InvalidArgumentError('Must be number');
+      }
+      return parsedValue * 1024 * 1024;
+    });
+}
+
 export function promptContinue() {
   return {
     name: 'cont',

--- a/packages/mystmd/src/site.ts
+++ b/packages/mystmd/src/site.ts
@@ -7,6 +7,7 @@ import {
   makePortOption,
   makeServerPortOption,
   makeExecuteOption,
+  makeMaxSizeWebpOption,
 } from './options.js';
 
 export function makeStartCLI(program: Command) {
@@ -17,6 +18,7 @@ export function makeStartCLI(program: Command) {
     .addOption(makeHeadlessOption())
     .addOption(makePortOption())
     .addOption(makeServerPortOption())
+    .addOption(makeMaxSizeWebpOption())
     .action(clirun(Session, startServer, program));
   return command;
 }


### PR DESCRIPTION
By default we do not convert large images to webp so build time may be shorter. However, there are cases where we may want to convert all images, regardless of size (e.g. one-time publish actions). This PR exposes that functionality to pass in `maxSizeWebp` as an option to `buildSite`