### PR TITLE
🔃 Do not recursively call include transform

### DIFF
--- a/.changeset/lucky-clocks-repair.md
+++ b/.changeset/lucky-clocks-repair.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Do not recursively call include transform

--- a/packages/myst-transforms/src/include.ts
+++ b/packages/myst-transforms/src/include.ts
@@ -82,7 +82,7 @@ export async function includeDirectiveTransform(tree: GenericParent, vfile: VFil
       }
       node.children = children as any;
       // Recurse!
-      await includeDirectiveTransform(node as GenericParent, vfile, opts);
+      // await includeDirectiveTransform(node as GenericParent, vfile, opts);
     }),
   );
 }


### PR DESCRIPTION
This recursive call was causing infinite recursion problems. It should be fixed for real, but for now, this disables the recursion.