### PR TITLE
🙈 Ignore hidden directories from watch

### DIFF
--- a/.changeset/tidy-buttons-sparkle.md
+++ b/.changeset/tidy-buttons-sparkle.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Ignore hidden directories from watch

--- a/packages/myst-cli/src/build/site/watch.ts
+++ b/packages/myst-cli/src/build/site/watch.ts
@@ -179,7 +179,7 @@ export function watchContent(session: ISession, serverReload: () => void, opts: 
     chokidar
       .watch([proj.path, ...dependencies], {
         ignoreInitial: true,
-        ignored: ['public', '**/_build/**', '**/.git/**', ...ignored],
+        ignored: ['public', '**/_build/**', '**/node_modules/**', '**/.*/**', ...ignored],
         awaitWriteFinish: { stabilityThreshold: 100, pollInterval: 50 },
       })
       .on('all', watchProcessor(session, proj, serverReload, opts));


### PR DESCRIPTION
Currently all hidden directories are ignored by the project tree, which selects markdown files that are not in hidden folders or node_modules, etc.

However, these are still being watched, and that can lead to large performance hits if there are a lot of files in the hidden directories (e.g. pixi).

cc @roaldarbol

This is the previous output, in the this PR these files don't trigger changes:

![image](https://github.com/executablebooks/mystmd/assets/913249/21643beb-6664-473b-8ce3-67f619967fbf)
