### PR TITLE
🧟‍♂️ Restore basic session on myst-cli-utils

### DIFF
--- a/.changeset/slow-pumpkins-protect.md
+++ b/.changeset/slow-pumpkins-protect.md
@@ -1,0 +1,5 @@
+---
+'myst-cli-utils': patch
+---
+
+Restore basic session on myst-cli-utils

--- a/packages/myst-cli-utils/src/index.ts
+++ b/packages/myst-cli-utils/src/index.ts
@@ -10,6 +10,7 @@ export {
 export { exec, makeExecutable } from './exec.js';
 export { clirun, tic } from './utils.js';
 export { isUrl } from './isUrl.js';
+export { Session, getSession } from './session.js';
 export {
   computeHash,
   copyFileMaintainPath,

--- a/packages/myst-cli-utils/src/session.ts
+++ b/packages/myst-cli-utils/src/session.ts
@@ -1,0 +1,17 @@
+import type { RequestInfo, RequestInit, Response } from 'node-fetch';
+import { chalkLogger, LogLevel } from './logger.js';
+import type { Logger, ISession } from './types.js';
+
+export class Session implements ISession {
+  log: Logger;
+  constructor(opts?: { logger?: Logger }) {
+    this.log = opts?.logger ?? chalkLogger(LogLevel.debug, process.cwd());
+  }
+  fetch(url: URL | RequestInfo, init?: RequestInit | undefined): Promise<Response> {
+    throw new Error('fetch not implemented on session');
+  }
+}
+
+export function getSession(logger: Logger) {
+  return new Session({ logger });
+}


### PR DESCRIPTION
When adding `fetch` to `ISession`, I removed the basic `Session` implementation from `myst-cli-utils`, so that library did not need to import/implement `fetch`: https://github.com/executablebooks/mystmd/commit/36decbb45e705d4f5af9f3967d676df2e64d342f#diff-abc58fa98ab1efb675ec0fe9411bd055f6ef828067556d9f747e371e1bffd5b2

This PR just brings back that `Session` and resolves the `fetch` issue by leaving it unimplemented.