### PR TITLE
feat: add `keystrokes` role

### DIFF
--- a/packages/myst-roles/src/index.ts
+++ b/packages/myst-roles/src/index.ts
@@ -13,6 +13,7 @@ import { smallcapsRole } from './smallcaps.js';
 import { subscriptRole } from './subscript.js';
 import { superscriptRole } from './superscript.js';
 import { underlineRole } from './underline.js';
+import { keystrokesRole } from './keystrokes.js';
 
 export const defaultRoles = [
   abbreviationRole,
@@ -30,6 +31,7 @@ export const defaultRoles = [
   subscriptRole,
   superscriptRole,
   underlineRole,
+  keystrokesRole,
 ];
 export { abbreviationRole } from './abbreviation.js';
 export { chemRole } from './chem.js';
@@ -45,3 +47,4 @@ export { smallcapsRole } from './smallcaps.js';
 export { subscriptRole } from './subscript.js';
 export { superscriptRole } from './superscript.js';
 export { underlineRole } from './underline.js';
+export { keystrokesRole } from './keystrokes.js';


### PR DESCRIPTION
This behaves like `<kbd>`, but allows us to implement something for LaTeX/Typst by using non-HTML