### PR TITLE
🔗 Use `READTHEDOCS_CANONICAL_URL` as baseurl if defined

### DIFF
--- a/.changeset/wet-buttons-heal.md
+++ b/.changeset/wet-buttons-heal.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Use READTHEDOCS_CANONICAL_URL as baseurl if defined


### PR DESCRIPTION
There must be a better way around this with relative paths [^1], but until then, this is a simple quick-fix for RTD deployments. The user would still need #984 to have a seamless experience.

Closes #983

[^1]: https://github.com/executablebooks/mystmd/issues/188#issuecomment-2003171341