### PR TITLE
🏷  Typst: wrap non-identifiers in `label`

### DIFF
--- a/.changeset/tough-pandas-mix.md
+++ b/.changeset/tough-pandas-mix.md
@@ -1,0 +1,5 @@
+---
+"myst-to-typst": patch
+---
+
+Wrap non-identifier citations in `label()`

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -286,7 +286,7 @@ const handlers: Record<string, Handler> = {
     state.renderChildren(node, 0, ' ');
   },
   cite(node, state) {
-    const needsLabel = !/^[a-zA-Z0-9_\-:\.]+$/.test(node.label);
+    const needsLabel = !/^[a-zA-Z0-9_\-:.]+$/.test(node.label);
     const label = needsLabel ? `label("${node.label}")` : `<${node.label}>`;
     state.write(`#cite(${label})`);
     if (node.kind === 'narrative') state.write(`, form: "prose"`);

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -286,8 +286,8 @@ const handlers: Record<string, Handler> = {
     state.renderChildren(node, 0, ' ');
   },
   cite(node, state) {
-    const needsLabel = !(/^[a-zA-Z0-9_\-:\.]+$/.test(node.label));
-    const label = needsLabel ? `label("${ node.label }")` : `<${node.label}>`;
+    const needsLabel = !/^[a-zA-Z0-9_\-:\.]+$/.test(node.label);
+    const label = needsLabel ? `label("${node.label}")` : `<${node.label}>`;
     state.write(`#cite(${label})`);
     if (node.kind === 'narrative') state.write(`, form: "prose"`);
     // node.prefix not supported by typst: see https://github.com/typst/typst/issues/1139

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -286,7 +286,9 @@ const handlers: Record<string, Handler> = {
     state.renderChildren(node, 0, ' ');
   },
   cite(node, state) {
-    state.write(`#cite(<${node.label}>`);
+    const needsLabel = !(/^[a-zA-Z0-9_\-:\.]+$/.test(node.label));
+    const label = needsLabel ? `label("${ node.label }")` : `<${node.label}>`;
+    state.write(`#cite(${label})`);
     if (node.kind === 'narrative') state.write(`, form: "prose"`);
     // node.prefix not supported by typst: see https://github.com/typst/typst/issues/1139
     if (node.suffix) state.write(`, supplement: [${node.suffix}]`);

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -288,7 +288,7 @@ const handlers: Record<string, Handler> = {
   cite(node, state) {
     const needsLabel = !/^[a-zA-Z0-9_\-:.]+$/.test(node.label);
     const label = needsLabel ? `label("${node.label}")` : `<${node.label}>`;
-    state.write(`#cite(${label})`);
+    state.write(`#cite(${label}`);
     if (node.kind === 'narrative') state.write(`, form: "prose"`);
     // node.prefix not supported by typst: see https://github.com/typst/typst/issues/1139
     if (node.suffix) state.write(`, supplement: [${node.suffix}]`);

--- a/packages/myst-to-typst/tests/cite.yml
+++ b/packages/myst-to-typst/tests/cite.yml
@@ -10,6 +10,16 @@ cases:
               label: cockett2015
     typst: |-
       #cite(<cockett2015>)
+  - title: cite single URL
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: cite
+              label: https://doi.org/10.1038/s41586-022-04892-x               
+    typst: |-
+      #cite(label("https://doi.org/10.1038/s41586-022-04892-x"))
   - title: cite multiple
     mdast:
       type: root


### PR DESCRIPTION
This fixes many of the Typst issues that @choldgraf ran into with the CZI report, by wrapping non-identifier labels in `label("<URL>")`

c.f. https://typst.app/docs/reference/model/cite#parameters-key