### PR TITLE
:paintbrush: add `sidebar` directive

### DIFF
--- a/.changeset/brave-comics-confess.md
+++ b/.changeset/brave-comics-confess.md
@@ -1,0 +1,5 @@
+---
+"myst-directives": minor
+---
+
+Add sidebar directive

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -48,6 +48,9 @@ description: Code and code-blocks can be used to show programming languages.
 :::{myst:directive} margin
 :::
 
+:::{myst:directive} sidebar
+:::
+
 :::{myst:directive} math
 :::
 

--- a/packages/myst-directives/src/index.ts
+++ b/packages/myst-directives/src/index.ts
@@ -9,6 +9,7 @@ import { imageDirective } from './image.js';
 import { includeDirective } from './include.js';
 import { tableDirective, listTableDirective } from './table.js';
 import { marginDirective } from './margin.js';
+import { sidebarDirective } from './sidebar.js';
 import { glossaryDirective } from './glossary.js';
 import { mathDirective } from './math.js';
 import { mdastDirective } from './mdast.js';
@@ -33,6 +34,7 @@ export const defaultDirectives = [
   tableDirective,
   listTableDirective,
   marginDirective,
+  sidebarDirective,
   glossaryDirective,
   mathDirective,
   mdastDirective,
@@ -53,6 +55,7 @@ export { imageDirective } from './image.js';
 export { includeDirective } from './include.js';
 export { listTableDirective, tableDirective } from './table.js';
 export { marginDirective } from './margin.js';
+export { sidebarDirective } from './sidebar.js';
 export { mathDirective } from './math.js';
 export { mdastDirective } from './mdast.js';
 export { mermaidDirective } from './mermaid.js';

--- a/packages/myst-directives/src/sidebar.ts
+++ b/packages/myst-directives/src/sidebar.ts
@@ -1,0 +1,17 @@
+import type { DirectiveSpec, DirectiveData, GenericNode } from 'myst-common';
+
+export const sidebarDirective: DirectiveSpec = {
+  name: 'sidebar',
+  body: {
+    type: 'myst',
+    required: true,
+  },
+  run(data: DirectiveData): GenericNode[] {
+    return [
+      {
+        type: 'sidebar',
+        children: data.body as GenericNode[],
+      },
+    ];
+  },
+};


### PR DESCRIPTION
We already have a `margin` directive, this PR adds support for `sidebar`. I don't know whether we want to advertise this directive for core MyST (it might be better to stick to a reduced set of directives to allow us more control), but JB will certainly need it.

c.f. https://github.com/executablebooks/myst-theme/pull/341