### PR TITLE
fix: throw error if `typst` is not available

### DIFF
--- a/packages/myst-cli/src/build/typst.ts
+++ b/packages/myst-cli/src/build/typst.ts
@@ -57,6 +57,7 @@ export function isTypstAvailable() {
 
 export async function runTypstExecutable(session: ISession, typstFile: string) {
   if (!isTypstAvailable()) {
+    throw new Error(`typst CLI must be installed to build PDFs from typst`);
     session.log.debug('typst CLI must be installed to build PDFs from typst');
     return;
   }


### PR DESCRIPTION
Closes #962 

I'm not sure if we have an internal policy for error handling. It seems fine to throw an error, but I'd welcome any feedback if we prefer log-and-return.