### PR TITLE
:hammer: Add support for legacy glossary syntax

### DIFF
--- a/.changeset/old-geckos-tie.md
+++ b/.changeset/old-geckos-tie.md
@@ -1,0 +1,6 @@
+---
+"myst-transforms": minor
+"myst-cli": patch
+---
+
+Support legacy syntax in glossary directive

--- a/.changeset/two-coins-invite.md
+++ b/.changeset/two-coins-invite.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Add legacy_glossary_syntax to project settings

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -34,6 +34,10 @@ output_matplotlib_strings
     - `"remove-warn"` (default) or `"remove-error"`: remove all matplotlib strings in outputs, and log a warning or error
     - `"warn"` or "error": log a warning or error if matplotlib strings in outputs
 
+(setting:legacy_glossary_syntax)=
+legacy_glossary_syntax
+: Attempt to treat glossary directive in "Sphinx style", indicating that terms definitions are defined through indentation rather than definition lists.
+
 ## LaTeX Rendering Settings
 
 Adding an object of `myst_to_tex` to the settings will allow you to control various default parts of how the LaTeX renderer behaves.

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -177,7 +177,7 @@ export async function transformMdast(
     })
     .use(inlineMathSimplificationPlugin)
     .use(mathPlugin, { macros: frontmatter.math })
-    .use(glossaryPlugin) // This should be before the enumerate plugins
+    .use(glossaryPlugin, {}) // This should be before the enumerate plugins
     .use(abbreviationPlugin, { abbreviations: frontmatter.abbreviations })
     .use(enumerateTargetsPlugin, { state }) // This should be after math/container transforms
     .use(joinGatesPlugin);

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -177,7 +177,7 @@ export async function transformMdast(
     })
     .use(inlineMathSimplificationPlugin)
     .use(mathPlugin, { macros: frontmatter.math })
-    .use(glossaryPlugin, {}) // This should be before the enumerate plugins
+    .use(glossaryPlugin, { upgradeLegacySyntax: frontmatter.settings?.legacy_glossary_syntax }) // This should be before the enumerate plugins
     .use(abbreviationPlugin, { abbreviations: frontmatter.abbreviations })
     .use(enumerateTargetsPlugin, { state }) // This should be after math/container transforms
     .use(joinGatesPlugin);

--- a/packages/myst-frontmatter/src/settings/types.ts
+++ b/packages/myst-frontmatter/src/settings/types.ts
@@ -9,5 +9,6 @@ export type ProjectSettings = {
   output_stderr?: OutputRemovalOptions;
   output_stdout?: OutputRemovalOptions;
   output_matplotlib_strings?: OutputRemovalOptions;
+  legacy_glossary_syntax?: boolean;
   myst_to_tex?: MystToTexSettings;
 };

--- a/packages/myst-frontmatter/src/settings/validators.ts
+++ b/packages/myst-frontmatter/src/settings/validators.ts
@@ -1,5 +1,11 @@
 import type { ValidationOptions } from 'simple-validators';
-import { defined, incrementOptions, validateChoice, validateObjectKeys } from 'simple-validators';
+import {
+  defined,
+  incrementOptions,
+  validateBoolean,
+  validateChoice,
+  validateObjectKeys,
+} from 'simple-validators';
 import type { ProjectSettings } from './types.js';
 import { validateMystToTexSettings } from './validatorsMystToTex.js';
 
@@ -16,6 +22,7 @@ export const PROJECT_SETTINGS = [
   'output_stdout',
   'output_matplotlib_strings',
   'myst_to_tex',
+  'legacy_glossary_syntax',
 ];
 export const PROJECT_SETTINGS_ALIAS = {
   stderr_output: 'output_stderr',
@@ -62,6 +69,13 @@ export function validateProjectAndPageSettings(
       incrementOptions('myst_to_tex', opts),
     );
     if (myst_to_tex) output.myst_to_tex = myst_to_tex;
+  }
+  if (defined(settings.legacy_glossary_syntax)) {
+    const legacy_glossary_syntax = validateBoolean(
+      settings.legacy_glossary_syntax,
+      incrementOptions('legacy_glossary_syntax', opts),
+    );
+    if (legacy_glossary_syntax != null) output.legacy_glossary_syntax = legacy_glossary_syntax;
   }
   if (Object.keys(output).length === 0) return undefined;
   return output;

--- a/packages/myst-transforms/src/glossary.spec.ts
+++ b/packages/myst-transforms/src/glossary.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import { glossaryTransform } from './glossary';
+import { VFile } from 'vfile';
+
+let vfile: VFile;
+
+beforeEach(() => {
+  vfile = new VFile();
+});
+
+describe('Test glossary upgrade', () => {
+  test('tree with legacy glossary can upgrade', async () => {
+    const mdast = {
+      type: 'root',
+      children: [
+        {
+          type: 'glossary',
+          children: [
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'text',
+                  value: 'term\ndefinition',
+                },
+              ],
+            },
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'inlineMath',
+                  value: 'x = y + 2',
+                },
+              ],
+            },
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'text',
+                  value: 'other-term\nother-definition',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    glossaryTransform(mdast, vfile, { upgradeLegacySyntax: true });
+    expect(mdast).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'glossary',
+          children: [
+            {
+              type: 'definitionList',
+              children: [
+                {
+                  type: 'definitionTerm',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'term',
+                    },
+                  ],
+                  label: 'term',
+                  identifier: 'term-term',
+                  html_id: 'term-term',
+                },
+                {
+                  type: 'definitionDescription',
+                  children: [
+                    {
+                      type: 'paragraph',
+                      children: [
+                        {
+                          type: 'text',
+                          value: 'definition',
+                        },
+                      ],
+                    },
+                    {
+                      type: 'paragraph',
+                      children: [
+                        {
+                          type: 'inlineMath',
+                          value: 'x = y + 2',
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: 'definitionTerm',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'other-term',
+                    },
+                  ],
+                  label: 'other-term',
+                  identifier: 'term-other-term',
+                  html_id: 'term-other-term',
+                },
+                {
+                  type: 'definitionDescription',
+                  children: [
+                    {
+                      type: 'paragraph',
+                      children: [
+                        {
+                          type: 'text',
+                          value: 'other-definition',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/myst-transforms/src/glossary.ts
+++ b/packages/myst-transforms/src/glossary.ts
@@ -1,13 +1,86 @@
 import type { Plugin } from 'unified';
 import type { Node } from 'myst-spec';
 import type { VFile } from 'vfile';
-import { selectAll } from 'unist-util-select';
+import { selectAll, select } from 'unist-util-select';
 import type { GenericParent } from 'myst-common';
-import { normalizeLabel, toText, fileError, RuleId } from 'myst-common';
+import { normalizeLabel, toText, fileError, fileWarn, RuleId } from 'myst-common';
+import type { DefinitionTerm, DefinitionDescription, DefinitionList } from 'myst-spec-ext';
 
-export function glossaryTransform<T extends Node | GenericParent>(mdast: T, file: VFile) {
+export type Options = {
+  upgradeLegacySyntax?: boolean;
+};
+
+/**
+ * Lift out definitionTerms from top-level `TERM\nDEFINITION` text nodes
+ */
+function maybeLiftLegacyDefinitionTerm(node: GenericParent): GenericParent | undefined {
+  if (node.type !== 'paragraph') {
+    return undefined;
+  }
+  const firstChild = node.children[0];
+  if (firstChild?.type !== 'text') {
+    return undefined;
+  }
+  const value = firstChild.value as string;
+  const index = value.indexOf('\n');
+  if (index === -1) {
+    return undefined;
+  }
+  const term = value.slice(0, index);
+  const remainder = value.slice(index + 1, value.length);
+  firstChild.value = remainder;
+  return {
+    type: 'definitionTerm',
+    children: [{ type: 'text', value: term }],
+  };
+}
+
+export function glossaryTransform<T extends Node | GenericParent>(
+  mdast: T,
+  file: VFile,
+  opts: Options,
+) {
   const glossaries = selectAll('glossary', mdast) as GenericParent[];
   glossaries.forEach((glossary) => {
+    // Do we have a ReST-like glossary? If so, pull it out.
+    if (opts.upgradeLegacySyntax && !select('definitionList', glossary)) {
+      fileWarn(
+        file,
+        `Unexpected node as a child of a glossary, expected only \`definitionList\` children
+  Treating glossary as a legacy-format glossary and attempting to upgrade.`,
+        {
+          node: glossary,
+          ruleId: RuleId.glossaryUsesDefinitionList,
+        },
+      );
+
+      const definitionList = {
+        type: 'definitionList',
+        children: [],
+      } as DefinitionList;
+
+      let termChildren: DefinitionDescription['children'] = [];
+
+      // Build up definitionList as alternating term-definition
+      for (const child of glossary.children) {
+        let definitionTerm: GenericParent | undefined;
+        if ((definitionTerm = maybeLiftLegacyDefinitionTerm(child as unknown as GenericParent))) {
+          // Assign new children for this term
+          termChildren = [];
+          // Push the term
+          definitionList.children.push(definitionTerm as DefinitionTerm);
+          // Push the yet-unfilled description
+          definitionList.children.push({
+            type: 'definitionDescription',
+            children: termChildren,
+          });
+        }
+        // Populate the current definition's children
+        termChildren.push(child);
+      }
+      // Overwrite the glossary!
+      glossary.children = [definitionList];
+    }
     glossary.children.forEach((list) => {
       if (list.type !== 'definitionList') {
         fileError(
@@ -32,6 +105,7 @@ export function glossaryTransform<T extends Node | GenericParent>(mdast: T, file
   });
 }
 
-export const glossaryPlugin: Plugin<[], GenericParent, GenericParent> = () => (tree, file) => {
-  glossaryTransform(tree, file);
-};
+export const glossaryPlugin: Plugin<[Options], GenericParent, GenericParent> =
+  (opts) => (tree, file) => {
+    glossaryTransform(tree, file, opts);
+  };

--- a/packages/myst-transforms/src/glossary.ts
+++ b/packages/myst-transforms/src/glossary.ts
@@ -43,19 +43,19 @@ function maybeLiftLegacyDefinitionTerm(node: GenericParent): GenericParent | und
 export function glossaryTransform<T extends Node | GenericParent>(
   mdast: T,
   file: VFile,
-  opts: Options,
+  opts?: Options,
 ) {
   const glossaries = selectAll('glossary', mdast) as GenericParent[];
   glossaries.forEach((glossary) => {
     // Do we have a ReST-like glossary? If so, pull it out.
-    if (opts.upgradeLegacySyntax && !select('definitionList', glossary)) {
+    if (opts?.upgradeLegacySyntax && !select('definitionList', glossary)) {
       fileWarn(
         file,
-        `Unexpected node as a child of a glossary, expected only \`definitionList\` children
-  Treating glossary as a legacy-format glossary and attempting to upgrade.`,
+        'Unexpected node as a child of a glossary, expected only `definitionList` children.',
         {
           node: glossary,
           ruleId: RuleId.glossaryUsesDefinitionList,
+          note: 'Treating glossary as a legacy-format glossary and attempting to upgrade.',
         },
       );
 
@@ -110,7 +110,7 @@ export function glossaryTransform<T extends Node | GenericParent>(
   });
 }
 
-export const glossaryPlugin: Plugin<[Options], GenericParent, GenericParent> =
+export const glossaryPlugin: Plugin<[Options?], GenericParent, GenericParent> =
   (opts) => (tree, file) => {
     glossaryTransform(tree, file, opts);
   };

--- a/packages/myst-transforms/src/glossary.ts
+++ b/packages/myst-transforms/src/glossary.ts
@@ -14,21 +14,26 @@ export type Options = {
  * Lift out definitionTerms from top-level `TERM\nDEFINITION` text nodes
  */
 function maybeLiftLegacyDefinitionTerm(node: GenericParent): GenericParent | undefined {
+  // Only operate on paragraphs
   if (node.type !== 'paragraph') {
     return undefined;
   }
+  // Require that the first child is a Text node
   const firstChild = node.children[0];
   if (firstChild?.type !== 'text') {
     return undefined;
   }
+  // Require that we have a newline in the value, and locate it
   const value = firstChild.value as string;
   const index = value.indexOf('\n');
   if (index === -1) {
     return undefined;
   }
+  // Split the value into a term and a remainder
   const term = value.slice(0, index);
   const remainder = value.slice(index + 1, value.length);
   firstChild.value = remainder;
+  // Return the lifted term
   return {
     type: 'definitionTerm',
     children: [{ type: 'text', value: term }],


### PR DESCRIPTION
Fixes #618 through an AST-level transformation. 

The Sphinx `{glossary}` node has the following ReST definition-list-based syntax
````
```{glossary}
term
  definition
  
  additional context

next-term
  next-definition
```
````

Whereas we require a Markdown definition list:
````
```{glossary}
term
:  definition
  
   additional context

next-term
:  next-definition
```
````

Whilst we have MyST Spec to define the nature of MyST, we have places where the spec is ill-defined. Glossaries are not yet mentioned in the set of AST directives, nor are definition lists. This PR allows users of the glossary transform to opt-in and upgrade them to deflists. I wonder whether this should be a separate transform that JupyterBook uses, rather than an option?

It's not foolproof to handle this at the AST level. My rationale is that this is a "backwards compatibility" feature, and so we expect that the input is already valid ReST.