### PR TITLE
✨ Add `csv-table` directive

### DIFF
--- a/.changeset/silent-dancers-burn.md
+++ b/.changeset/silent-dancers-burn.md
@@ -1,0 +1,5 @@
+---
+"myst-directives": minor
+---
+
+Add the csv-table directive

--- a/.changeset/tame-apricots-doubt.md
+++ b/.changeset/tame-apricots-doubt.md
@@ -1,0 +1,5 @@
+---
+"myst-transforms": patch
+---
+
+Support span and div in html parser

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -18,6 +18,9 @@ description: A full list of the directives included in MyST Markdown by default.
 :::{myst:directive} code-cell
 :::
 
+:::{myst:directive} csv-table
+:::
+
 :::{myst:directive} dropdown
 :::
 

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -44,6 +44,7 @@ project:
     JSON: JavaScript Object Notation
     TLA: Three Letter Acronym
     OA: Open Access
+    CSV: comma-separated values
   plugins:
     - directives.mjs
     - unsplash.mjs

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -1,4 +1,6 @@
-# Tables
+---
+title: Tables
+---
 
 ## Github Flavoured
 
@@ -40,8 +42,10 @@ You can use the {myst:directive}`table` directive to add a caption to a markdown
 You may have inline markdown in the table caption, however, if it includes backticks, you must use a [colon fence](#example-fence).
 ```
 
-
 ## List Tables
+
+The {myst:directive}`list-table` directive is used to create a table from data in a uniform two-level bullet list.
+"Uniform" means that each sublist (second-level list) must contain the same number of list items.
 
 ````{myst}
 ```{list-table} This table title
@@ -59,16 +63,41 @@ You may have inline markdown in the table caption, however, if it includes backt
 
 ## CSV Tables
 
-````{myst}
-```{csv-table} This table title
-:header-rows: 1
-:label: example-table
+The {myst:directive}`csv-table` directive is used to create a table from comma-separated values (CSV) data.
+Block markup and inline markup within cells is supported. Line ends are recognized within quoted cells.
 
-Training, Validation
-0,        5
-13720,    2744
+```{csv-table} Frozen Delights!
+:header: "Treat", "Quantity", "Description"
+
+"Albatross", 2.99, "On a stick!"
+"Crunchy Frog", 1.49, "If we took the bones out
+it wouldn't be crunchy, now would it?"
+"Gannet Ripple", 1.99, "On a stick!"
 ```
-````
+
+## <span style="background: -webkit-linear-gradient(20deg, #09009f, #E743D9); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">Complex Tables with Style</span>
+
+It is also possible to write tables in raw HTML with `rowspan` and `colspan`, as well as for example:
+
+```{myst}
+:::{table} Area Comparisons (written in fancy HTML)
+:label: tbl:areas-html
+
+<table>
+<tr><th rowspan="2">Projection</th><th colspan="3" align="center">Area in square miles</th></tr>
+<tr><th align="right">Large Horizontal Area</th><th align="right" style="background: -webkit-linear-gradient(20deg, #09009f, #E743D9); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">Large Vertical Area</th><th align="right">Smaller Square Area<th></tr>
+<tr><td>Albers Equal Area</td><td align="right">7,498.7</td><td align="right">10,847.3</td><td align="right">35.8</td></tr>
+<tr><td>Web Mercator</td><td align="right">13,410.0</td><td align="right">18,271.4</td><td align="right">63.0</td></tr>
+<tr><td>Difference</td><td align="right" style="background-color: red;color: white">5,911.3</td><td align="right">7,424.1</td><td align="right">27.2</td></tr>
+<tr><td><bold>Percent Difference</bold></td><td align="right" style="background-color: green;color: white">44%</td><td align="right">41%</td><td align="right">43%</td></tr>
+</table>
+:::
+```
+
+:::{note} Styles are Only for HTML
+CSS styles are currently only used for HTML outputs and are not carried through to all export targets (e.g. LaTeX) and are primarily used for web.
+:::
+
 ## Notebook outputs as tables
 
 You can embed Jupyter Notebook outputs as tables.

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -36,6 +36,11 @@ You can use the {myst:directive}`table` directive to add a caption to a markdown
 :::
 ```
 
+```{note}
+You may have inline markdown in the table caption, however, if it includes backticks, you must use a [colon fence](#example-fence).
+```
+
+
 ## List Tables
 
 ````{myst}
@@ -52,10 +57,18 @@ You can use the {myst:directive}`table` directive to add a caption to a markdown
 ```
 ````
 
-```{note}
-You may have inline markdown in the table caption, however, if it includes backticks, you must use a [colon fence](#example-fence).
-```
+## CSV Tables
 
+````{myst}
+```{csv-table} This table title
+:header-rows: 1
+:label: example-table
+
+Training, Validation
+0,        5
+13720,    2744
+```
+````
 ## Notebook outputs as tables
 
 You can embed Jupyter Notebook outputs as tables.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15414,6 +15414,7 @@
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",
+        "csv-parse": "^5.5.5",
         "js-yaml": "^4.1.0",
         "myst-common": "^1.2.0",
         "myst-spec-ext": "^1.2.0",
@@ -15421,6 +15422,11 @@
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.7"
       }
+    },
+    "packages/myst-directives/node_modules/csv-parse": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.5.tgz",
+      "integrity": "sha512-erCk7tyU3yLWAhk6wvKxnyPtftuy/6Ak622gOO7BCJ05+TYffnPCJF905wmOQm+BpkX54OdAl8pveJwUdpnCXQ=="
     },
     "packages/myst-execute": {
       "version": "0.0.5",

--- a/packages/myst-directives/package.json
+++ b/packages/myst-directives/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "classnames": "^2.3.2",
+    "csv-parse": "^5.5.5",
     "js-yaml": "^4.1.0",
     "myst-common": "^1.2.0",
     "myst-spec-ext": "^1.2.0",

--- a/packages/myst-directives/src/index.ts
+++ b/packages/myst-directives/src/index.ts
@@ -7,7 +7,7 @@ import { figureDirective } from './figure.js';
 import { iframeDirective } from './iframe.js';
 import { imageDirective } from './image.js';
 import { includeDirective } from './include.js';
-import { tableDirective, listTableDirective } from './table.js';
+import { csvTableDirective, tableDirective, listTableDirective } from './table.js';
 import { asideDirective } from './aside.js';
 import { glossaryDirective } from './glossary.js';
 import { mathDirective } from './math.js';
@@ -21,6 +21,7 @@ import { rawDirective } from './raw.js';
 export const defaultDirectives = [
   admonitionDirective,
   bibliographyDirective,
+  csvTableDirective,
   codeDirective,
   codeCellDirective,
   dropdownDirective,
@@ -51,7 +52,7 @@ export { figureDirective } from './figure.js';
 export { iframeDirective } from './iframe.js';
 export { imageDirective } from './image.js';
 export { includeDirective } from './include.js';
-export { listTableDirective, tableDirective } from './table.js';
+export { csvTableDirective, listTableDirective, tableDirective } from './table.js';
 export { asideDirective } from './aside.js';
 export { mathDirective } from './math.js';
 export { mdastDirective } from './mdast.js';

--- a/packages/myst-directives/src/table.ts
+++ b/packages/myst-directives/src/table.ts
@@ -1,6 +1,7 @@
-import type { DirectiveSpec, DirectiveData, GenericNode } from 'myst-common';
+import type { DirectiveSpec, DirectiveData, DirectiveContext, GenericNode } from 'myst-common';
 import { fileError, normalizeLabel, RuleId } from 'myst-common';
 import type { VFile } from 'vfile';
+import { parse } from 'csv-parse/sync';
 
 export const tableDirective: DirectiveSpec = {
   name: 'table',
@@ -159,6 +160,97 @@ export const listTableDirective: DirectiveSpec = {
       class: data.options?.class,
       children,
     };
+    return [container];
+  },
+};
+
+export const csvTableDirective: DirectiveSpec = {
+  name: 'csv-table',
+  arg: {
+    type: 'myst',
+  },
+  options: {
+    label: {
+      type: String,
+      alias: ['name'],
+    },
+    'header-rows': {
+      type: Number,
+      // nonnegative int
+    },
+    class: {
+      type: String,
+      // class_option: list of strings?
+      doc: `CSS classes to add to your table. Special classes include:
+
+- \`full-width\`: changes the table environment to cover two columns in LaTeX`,
+    },
+    align: {
+      type: String,
+      // choice(['left', 'center', 'right'])
+    },
+    delim: {
+      type: String,
+    },
+    escape: {
+      type: String,
+    },
+    keepspace: {
+      type: Boolean,
+    },
+    quote: {
+      type: String,
+    },
+  },
+  body: {
+    type: String,
+    required: true,
+  },
+  run(data: DirectiveData, vfile: VFile, ctx: DirectiveContext): GenericNode[] {
+    const delimiter = (data.options?.delimiter ?? ',') as string;
+    const records = parse(data.body as string, {
+      delimiter,
+      ltrim: !data.options?.keepspace,
+      escape: (data.options?.escape ?? delimiter) as string,
+      quote: (data.options?.quote ?? '"') as string,
+    });
+
+    const { label, identifier } = normalizeLabel(data.options?.label as string | undefined) || {};
+
+    let headerCount = (data.options?.['header-rows'] as number) || 0;
+    const rows = records.map((record: any, recordIndex: number) => {
+      const cells = record.map((cell: string) => {
+        const rawCells = ctx.parseMyst(cell, recordIndex);
+        if (!(rawCells.length === 1 && rawCells[0].type === 'paragraph')) {
+          throw new Error(`Expected a single paragraph node, encountered ${rawCells[0].type}`);
+        }
+        return {
+          type: 'tableCell',
+          header: headerCount > 0 ? true : undefined,
+          children: rawCells[0].children,
+        };
+      });
+      headerCount -= 1;
+      // Parsing produes multiple nodes
+      return {
+        type: 'tableRow',
+        children: cells,
+      };
+    });
+    const table = {
+      type: 'table',
+      align: data.options?.align,
+      children: rows,
+    };
+    const container = {
+      type: 'container',
+      kind: 'table',
+      identifier: identifier,
+      label: label,
+      class: data.options?.class,
+      children: [...(data.arg as GenericNode[]), table],
+    };
+
     return [container];
   },
 };

--- a/packages/myst-directives/src/table.ts
+++ b/packages/myst-directives/src/table.ts
@@ -283,7 +283,7 @@ export const csvTableDirective: DirectiveSpec = {
         headerCells = parseCSV(data.options.header as string, ctx, data.options as ParseCsvOptions);
       } catch (error) {
         fileError(vfile, 'csv-table directive header must be valid CSV-formatted MyST', {
-          node: select('mystDirectiveOption[name="tags"]', data.node) ?? data.node,
+          node: select('mystDirectiveOption[name="header"]', data.node) ?? data.node,
           ruleId: RuleId.directiveOptionsCorrect,
         });
       }

--- a/packages/myst-transforms/src/html.ts
+++ b/packages/myst-transforms/src/html.ts
@@ -95,6 +95,14 @@ const defaultHtmlToMdastOptions: Record<keyof HtmlTransformOptions, any> = {
     _brKeep(h: H, node: any) {
       return h(node, '_break');
     },
+    span(h: H, node: any) {
+      const attrs = addClassAndIdentifier(node);
+      return h(node, 'span', attrs, all(h, node));
+    },
+    div(h: H, node: any) {
+      const attrs = addClassAndIdentifier(node);
+      return h(node, 'div', attrs, all(h, node));
+    },
     a(h: H, node: any) {
       const attrs = addClassAndIdentifier(node);
       attrs.url = String(node.properties.href || '');

--- a/packages/myst-transforms/tests/html.yml
+++ b/packages/myst-transforms/tests/html.yml
@@ -8,25 +8,31 @@ cases:
     after:
       type: root
       children:
-        - type: paragraph
+        - type: div
           children:
-            - type: text
-              value: '*some text*'
+            - type: paragraph
+              children:
+                - type: text
+                  value: '*some text*'
   - title: style
     before:
       type: root
       children:
         - type: html
-          value: <div><p><em>some text</em></p></div>
+          value: '<div style="background: red"><p><em>some text</em></p></div>'
     after:
       type: root
       children:
-        - type: paragraph
+        - type: div
+          style:
+            background: red
           children:
-            - type: emphasis
+            - type: paragraph
               children:
-                - type: text
-                  value: some text
+                - type: emphasis
+                  children:
+                    - type: text
+                      value: some text
   - title: image
     before:
       type: root


### PR DESCRIPTION
Implements https://docutils.sourceforge.io/docs/ref/rst/directives.html#csv-table-1, addressing need on #189 

- [ ] Support URL / file?
- [x] Support headings?
- [x] Handle invalid markup

See #893.