### PR TITLE
📤 Refactor exports for more flexibility

### DIFF
--- a/.changeset/afraid-coats-repeat.md
+++ b/.changeset/afraid-coats-repeat.md
@@ -1,0 +1,5 @@
+---
+'myst-common': patch
+---
+
+Add ruleid for determining export format

--- a/.changeset/curvy-stingrays-design.md
+++ b/.changeset/curvy-stingrays-design.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Refactor build for new collectExportOptions

--- a/.changeset/six-pens-sit.md
+++ b/.changeset/six-pens-sit.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Error on no typst executable

--- a/.changeset/thirty-avocados-build.md
+++ b/.changeset/thirty-avocados-build.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Add zip to export frontmatter

--- a/.changeset/twenty-tips-end.md
+++ b/.changeset/twenty-tips-end.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Refactor collectExportOptions for more flexibility

--- a/.changeset/wild-actors-retire.md
+++ b/.changeset/wild-actors-retire.md
@@ -1,0 +1,6 @@
+---
+'myst-frontmatter': patch
+'myst-cli': patch
+---
+
+Update export validation for optional format

--- a/packages/myst-cli/src/build/build.spec.ts
+++ b/packages/myst-cli/src/build/build.spec.ts
@@ -1,59 +1,57 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { ExportFormats } from 'myst-frontmatter';
-import { exportSite, getExportFormats } from './build';
+import { exportSite, getAllowedExportFormats, getRequestedExportFormats } from './build';
 import { Session } from '../session';
 import { config } from '../store/reducers';
 
-describe('getExportFormats', () => {
-  it('no build target in options and force returns no formats', async () => {
-    expect(getExportFormats({ force: true })).toEqual([]);
-  });
-  it('all build targets false in options and force returns no formats', async () => {
-    expect(
-      getExportFormats({ force: true, docx: false, pdf: false, tex: false, xml: false }),
-    ).toEqual([]);
+describe('get export formats', () => {
+  it('all build targets false in options no formats', async () => {
+    expect(getAllowedExportFormats({ docx: false, pdf: false, tex: false, xml: false })).toEqual(
+      [],
+    );
+    expect(getRequestedExportFormats({ docx: false, pdf: false, tex: false, xml: false })).toEqual(
+      [],
+    );
   });
   it('no build target in options returns all formats', async () => {
-    expect(getExportFormats({})).toEqual([]);
-  });
-  it('all build targets false in options returns no formats', async () => {
-    expect(
-      getExportFormats({ force: false, docx: false, pdf: false, tex: false, xml: false }),
-    ).toEqual([]);
+    expect(getAllowedExportFormats({})).toEqual([]);
+    expect(getRequestedExportFormats({})).toEqual([]);
   });
   it('single build target true in options returns single format', async () => {
-    expect(getExportFormats({ docx: true, pdf: false, tex: false, xml: false })).toEqual([
+    expect(getAllowedExportFormats({ docx: true, pdf: false, tex: false, xml: false })).toEqual([
+      ExportFormats.docx,
+    ]);
+    expect(getRequestedExportFormats({ docx: true, pdf: false, tex: false, xml: false })).toEqual([
       ExportFormats.docx,
     ]);
   });
-  it('single build target true in options and force returns single format', async () => {
-    expect(
-      getExportFormats({ force: true, docx: true, pdf: false, tex: false, xml: false }),
-    ).toEqual([ExportFormats.docx]);
-  });
   it('single build target true in options and all returns all formats', async () => {
-    expect(getExportFormats({ all: true, docx: true, pdf: false, tex: false, xml: false })).toEqual(
-      [
-        ExportFormats.docx,
-        ExportFormats.pdf,
-        ExportFormats.tex,
-        ExportFormats.typst,
-        ExportFormats.xml,
-        ExportFormats.md,
-        ExportFormats.meca,
-      ],
-    );
-  });
-  it('all build targets true in options returns all formats', async () => {
-    expect(getExportFormats({ docx: true, pdf: true, tex: true, xml: true })).toEqual([
+    expect(
+      getAllowedExportFormats({ all: true, docx: true, pdf: false, tex: false, xml: false }),
+    ).toEqual([
       ExportFormats.docx,
       ExportFormats.pdf,
+      ExportFormats.pdftex,
+      ExportFormats.typst,
+      ExportFormats.tex,
+      ExportFormats.xml,
+      ExportFormats.md,
+      ExportFormats.meca,
+    ]);
+    expect(
+      getRequestedExportFormats({ all: true, docx: true, pdf: false, tex: false, xml: false }),
+    ).toEqual([ExportFormats.docx]);
+  });
+  it('all build targets true in options returns all formats', async () => {
+    expect(getAllowedExportFormats({ docx: true, pdf: true, tex: true, xml: true })).toEqual([
+      ExportFormats.docx,
+      ExportFormats.pdf,
+      ExportFormats.pdftex,
+      ExportFormats.typst,
       ExportFormats.tex,
       ExportFormats.xml,
     ]);
-  });
-  it('all build targets true in options and force returns all formats', async () => {
-    expect(getExportFormats({ force: true, docx: true, pdf: true, tex: true, xml: true })).toEqual([
+    expect(getRequestedExportFormats({ docx: true, pdf: true, tex: true, xml: true })).toEqual([
       ExportFormats.docx,
       ExportFormats.pdf,
       ExportFormats.tex,

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -9,7 +9,7 @@ import { buildHtml } from './html/index.js';
 import { buildSite } from './site/prepare.js';
 import type { ExportWithFormat, ExportWithInputOutput } from './types.js';
 import { localArticleExport } from './utils/localArticleExport.js';
-import { collectExportOptions, resolveExportArticles } from './utils/collectExportOptions.js';
+import { collectExportOptions, resolveExportListArticles } from './utils/collectExportOptions.js';
 import { writeJsonLogs } from '../utils/logging.js';
 import { findCurrentProjectAndLoad } from '../config.js';
 
@@ -136,7 +136,7 @@ export async function collectAllBuildExportOptions(
         `Cannot specify format from output "${output}" - please specify format option, e.g. --pdf`,
       );
     }
-    exportOptionsList = resolveExportArticles(
+    exportOptionsList = resolveExportListArticles(
       session,
       files[0],
       [{ format, output: path.join(path.resolve('.'), output) }],
@@ -165,7 +165,7 @@ export async function collectAllBuildExportOptions(
             return fileExportOptionsList;
           }
           // If no requested exports were found, force them to build.
-          return resolveExportArticles(
+          return resolveExportListArticles(
             session,
             file,
             requestedFormats.map((format) => {

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -116,7 +116,7 @@ export async function collectAllBuildExportOptions(
   files: string[],
   opts: BuildOpts,
 ) {
-  const { force, output } = opts;
+  const { output } = opts;
   files = files.map((file) => path.resolve(file));
   if (output && files.length !== 1) {
     throw new Error('When specifying a named output for export, you must list exactly one file.');
@@ -194,7 +194,6 @@ export async function collectAllBuildExportOptions(
             return [];
           }
           const exportOptions = await collectExportOptions(session, files, allowedFormats, {
-            force,
             projectPath: projPath,
           });
           return exportOptions;

--- a/packages/myst-cli/src/build/types.ts
+++ b/packages/myst-cli/src/build/types.ts
@@ -6,10 +6,24 @@ import type { VFile } from 'vfile';
 import type { ISession } from '../session/types.js';
 import type { RendererData } from '../transforms/types.js';
 
-export type ExportWithOutput = Export & {
+type RendererFn = (
+  session: ISession,
+  data: RendererData,
+  doc: RendererDoc,
+  opts: Record<string, any>,
+  staticPath: string,
+  vfile: VFile,
+) => File;
+
+export type ExportWithFormat = Export & {
   format: ExportFormats;
+};
+
+export type ExportWithOutput = ExportWithFormat & {
   articles: ExportArticle[];
   output: string;
+  /** renderer is only used for word exports */
+  renderer?: RendererFn;
 };
 
 export type ExportWithInputOutput = ExportWithOutput & {
@@ -30,14 +44,7 @@ export type ExportOptions = {
   watch?: boolean;
   throwOnFailure?: boolean;
   ci?: boolean;
-  renderer?: (
-    session: ISession,
-    data: RendererData,
-    doc: RendererDoc,
-    opts: Record<string, any>,
-    staticPath: string,
-    vfile: VFile,
-  ) => File;
+  renderer?: RendererFn;
 };
 
 export type ExportFnOptions = {

--- a/packages/myst-cli/src/build/types.ts
+++ b/packages/myst-cli/src/build/types.ts
@@ -1,5 +1,5 @@
 import type { File } from 'docx';
-import type { Export, ExportArticle } from 'myst-frontmatter';
+import type { Export, ExportArticle, ExportFormats } from 'myst-frontmatter';
 import type { RendererDoc } from 'myst-templates';
 import type { LinkTransformer } from 'myst-transforms';
 import type { VFile } from 'vfile';
@@ -7,6 +7,7 @@ import type { ISession } from '../session/types.js';
 import type { RendererData } from '../transforms/types.js';
 
 export type ExportWithOutput = Export & {
+  format: ExportFormats;
   articles: ExportArticle[];
   output: string;
 };

--- a/packages/myst-cli/src/build/types.ts
+++ b/packages/myst-cli/src/build/types.ts
@@ -39,7 +39,6 @@ export type ExportOptions = {
   clean?: boolean;
   glossaries?: boolean;
   zip?: boolean;
-  force?: boolean;
   projectPath?: string;
   watch?: boolean;
   throwOnFailure?: boolean;

--- a/packages/myst-cli/src/build/typst.ts
+++ b/packages/myst-cli/src/build/typst.ts
@@ -57,8 +57,7 @@ export function isTypstAvailable() {
 
 export async function runTypstExecutable(session: ISession, typstFile: string) {
   if (!isTypstAvailable()) {
-    session.log.error('The typst CLI must be installed to build PDFs with typst');
-    return;
+    throw new Error('The typst CLI must be installed to build PDFs with typst');
   }
   if (path.extname(typstFile) !== '.typ') {
     throw new Error(`invalid input file for typst executable: ${typstFile}`);

--- a/packages/myst-cli/src/build/typst.ts
+++ b/packages/myst-cli/src/build/typst.ts
@@ -413,7 +413,7 @@ export async function runTypstPdfExport(
   );
   await runTypstExport(session, file, exportOptions, { ...(opts ?? {}), clean: false });
   const writeFolder = path.dirname(pdfOutput);
-  session.log.info(`🖨 Rendering typst pdf to ${pdfOutput}`);
+  session.log.info(`🖨  Rendering typst pdf to ${pdfOutput}`);
   if (!fs.existsSync(writeFolder)) fs.mkdirSync(writeFolder, { recursive: true });
   fs.copyFileSync(exportOptions.output.replace('.typ', '.pdf'), pdfOutput);
   return { tempFolders: [typFolder] };
@@ -438,29 +438,48 @@ export async function localArticleToTypst(
   await resolveAndLogErrors(
     session,
     exportOptionsList.map(async (exportOptions) => {
-      let exportResults: ExportResults;
-      if (path.extname(exportOptions.output) === '.zip') {
-        exportResults = await runTypstZipExport(session, file, exportOptions, {
-          projectPath,
-          clean: opts.clean,
-          extraLinkTransformers,
-        });
-      } else if (path.extname(exportOptions.output) === '.pdf') {
-        exportResults = await runTypstPdfExport(session, file, exportOptions, {
-          projectPath,
-          clean: opts.clean,
-          extraLinkTransformers,
-        });
-      } else {
-        exportResults = await runTypstExport(session, file, exportOptions, {
-          projectPath,
-          clean: opts.clean,
-          extraLinkTransformers,
-        });
-      }
+      const exportResults = await typstExportRunner(
+        session,
+        file,
+        opts,
+        exportOptions,
+        projectPath,
+        extraLinkTransformers,
+      );
       results.tempFolders.push(...exportResults.tempFolders);
     }),
     opts.throwOnFailure,
   );
   return results;
+}
+
+export async function typstExportRunner(
+  session: ISession,
+  file: string,
+  opts: ExportOptions,
+  exportOptions: ExportWithOutput,
+  projectPath?: string,
+  extraLinkTransformers?: LinkTransformer[],
+): Promise<ExportResults> {
+  let exportResults: ExportResults;
+  if (path.extname(exportOptions.output) === '.zip') {
+    exportResults = await runTypstZipExport(session, file, exportOptions, {
+      projectPath,
+      clean: opts.clean,
+      extraLinkTransformers,
+    });
+  } else if (path.extname(exportOptions.output) === '.pdf') {
+    exportResults = await runTypstPdfExport(session, file, exportOptions, {
+      projectPath,
+      clean: opts.clean,
+      extraLinkTransformers,
+    });
+  } else {
+    exportResults = await runTypstExport(session, file, exportOptions, {
+      projectPath,
+      clean: opts.clean,
+      extraLinkTransformers,
+    });
+  }
+  return exportResults;
 }

--- a/packages/myst-cli/src/build/utils/collectExportOptions.spec.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.spec.ts
@@ -1,0 +1,407 @@
+import { describe, expect, it } from 'vitest';
+import { VFile } from 'vfile';
+import path from 'node:path';
+import { ExportFormats } from 'myst-frontmatter';
+import {
+  resolveArticles,
+  resolveArticlesFromProject,
+  resolveFormat,
+  resolveOutput,
+  resolveTemplate,
+} from './collectExportOptions';
+import type { LocalProject } from '../../project';
+
+describe('resolveArticlesFromProject', () => {
+  it('multipage format uses index if no pages', async () => {
+    const exp: any = { format: ExportFormats.pdf };
+    const proj: Omit<LocalProject, 'bibliography'> = {
+      path: '.',
+      file: 'index.md',
+      index: 'index',
+      pages: [],
+    };
+    const vfile = new VFile();
+    expect(resolveArticlesFromProject(exp, proj, vfile)).toEqual({
+      articles: [{ file: 'index.md', level: 1 }],
+    });
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('multipage format uses pages if available', async () => {
+    const exp: any = { format: ExportFormats.tex };
+    const proj: Omit<LocalProject, 'bibliography'> = {
+      path: '.',
+      file: 'index.md',
+      index: 'index',
+      pages: [
+        {
+          file: 'one.md',
+          level: 1,
+          slug: 'one',
+        },
+        {
+          title: 'two',
+          level: 2,
+        },
+        {
+          file: 'three.md',
+          level: 3,
+          slug: 'three',
+        },
+      ],
+    };
+    const vfile = new VFile();
+    expect(resolveArticlesFromProject(exp, proj, vfile)).toEqual({
+      articles: [
+        {
+          file: 'one.md',
+          level: 1,
+          slug: 'one',
+        },
+        {
+          title: 'two',
+          level: 2,
+        },
+        {
+          file: 'three.md',
+          level: 3,
+          slug: 'three',
+        },
+      ],
+    });
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('jats uses index and pages but removes folders', async () => {
+    const exp: any = { format: ExportFormats.xml };
+    const proj: Omit<LocalProject, 'bibliography'> = {
+      path: '.',
+      file: 'index.md',
+      index: 'index',
+      pages: [
+        {
+          file: 'one.md',
+          level: 1,
+          slug: 'one',
+        },
+        {
+          title: 'two',
+          level: 2,
+        },
+        {
+          file: 'three.md',
+          level: 3,
+          slug: 'three',
+        },
+      ],
+    };
+    const vfile = new VFile();
+    expect(resolveArticlesFromProject(exp, proj, vfile)).toEqual({
+      articles: [{ file: 'index.md', level: 1 }],
+      sub_articles: ['one.md', 'three.md'],
+    });
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('single page format uses index if no pages', async () => {
+    const exp: any = { format: ExportFormats.docx };
+    const proj: Omit<LocalProject, 'bibliography'> = {
+      path: '.',
+      file: 'index.md',
+      index: 'index',
+      pages: [],
+    };
+    const vfile = new VFile();
+    expect(resolveArticlesFromProject(exp, proj, vfile)).toEqual({
+      articles: [{ file: 'index.md', level: 1 }],
+    });
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('single page format uses singe page if available', async () => {
+    const exp: any = { format: ExportFormats.meca };
+    const proj: Omit<LocalProject, 'bibliography'> = {
+      path: '.',
+      file: 'index.md',
+      index: 'index',
+      pages: [
+        {
+          file: 'one.md',
+          level: 1,
+          slug: 'one',
+        },
+      ],
+    };
+    const vfile = new VFile();
+    expect(resolveArticlesFromProject(exp, proj, vfile)).toEqual({
+      articles: [{ file: 'one.md', level: 1, slug: 'one' }],
+    });
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('single page format warns on multiple pages', async () => {
+    const exp: any = { format: ExportFormats.md };
+    const proj: Omit<LocalProject, 'bibliography'> = {
+      path: '.',
+      file: 'index.md',
+      index: 'index',
+      pages: [
+        {
+          title: 'zero',
+          level: 1,
+        },
+        {
+          file: 'one.md',
+          level: 1,
+          slug: 'one',
+        },
+        {
+          file: 'two.md',
+          level: 2,
+          slug: 'two',
+        },
+      ],
+    };
+    const vfile = new VFile();
+    expect(resolveArticlesFromProject(exp, proj, vfile)).toEqual({
+      articles: [{ file: 'one.md', level: 1, slug: 'one' }],
+    });
+    expect(vfile.messages.length).toBe(1);
+  });
+});
+
+describe('resolveTemplate', () => {
+  it('disableTemplate is prioritized', async () => {
+    expect(resolveTemplate('index.md', { template: 'my-template' }, true)).toBe(null);
+  });
+  it('template that does not exist locally passes', async () => {
+    expect(resolveTemplate('index.md', { template: 'my-template' })).toBe('my-template');
+  });
+  it('template that does exist locally resolves to absolute', async () => {
+    expect(resolveTemplate('.', { template: '.' })).toBe(path.resolve('.'));
+  });
+});
+
+describe('resolveFormat', () => {
+  it('non-pdf format returns self', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { format: ExportFormats.md })).toBe(ExportFormats.md);
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('non-pdf format ignores template/output', async () => {
+    const vfile = new VFile();
+    expect(
+      resolveFormat(vfile, {
+        format: ExportFormats.meca,
+        output: 'out.md',
+        template: 'template-typst',
+      }),
+    ).toBe(ExportFormats.meca);
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('pdf format returns pdf if no template/output', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { format: ExportFormats.pdf })).toBe(ExportFormats.pdf);
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('pdf format returns pdf+tex if no template and output is folder', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { format: ExportFormats.pdf, output: 'out' })).toBe(
+      ExportFormats.pdftex,
+    );
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('pdf format is prioritized over wrong output extension if no template', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { format: ExportFormats.pdf, output: 'out.md' })).toBe(
+      ExportFormats.pdf,
+    );
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('returns pdf+tex if no format/template and output is folder', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { output: 'out' })).toBe(ExportFormats.pdftex);
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('returns type from extension if no format/template', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { output: 'out.md' })).toBe(ExportFormats.md);
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('unknown extension defaults to pdf if no format/template', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { output: 'out.bad' })).toBe(ExportFormats.pdf);
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('returns pdf+tex if tex template and output is folder', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { output: 'out', template: 'template-tex' })).toBe(
+      ExportFormats.pdftex,
+    );
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('returns pdf if tex template only', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { template: 'template-tex' })).toBe(ExportFormats.pdf);
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('returns pdf if bad output with tex template', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { output: 'out.bad', template: 'template-tex' })).toBe(
+      ExportFormats.pdf,
+    );
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('returns typst if bad output with typst template', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { output: 'out.bad', template: 'template-typst' })).toBe(
+      ExportFormats.typst,
+    );
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('returns typst if folder output with typst template', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { output: 'out', template: 'template-typst' })).toBe(
+      ExportFormats.typst,
+    );
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('returns typst if format pdf with typst template', async () => {
+    const vfile = new VFile();
+    expect(resolveFormat(vfile, { format: ExportFormats.pdf, template: 'template-typst' })).toBe(
+      ExportFormats.typst,
+    );
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('returns docx if docx template', async () => {
+    const vfile = new VFile();
+    expect(
+      resolveFormat(vfile, {
+        format: ExportFormats.pdf,
+        output: 'out.md',
+        template: 'template-docx',
+      }),
+    ).toBe(ExportFormats.docx);
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('errors if format cannot be determined from template', async () => {
+    const vfile = new VFile();
+    expect(
+      resolveFormat(vfile, {
+        format: ExportFormats.pdf,
+        output: 'out.pdf',
+        template: 'template',
+      }),
+    ).toBe(undefined);
+    expect(vfile.messages.length).toBe(1);
+  });
+});
+
+describe('resolveArticles', () => {
+  it('empty articles/sub_articles error', async () => {
+    const vfile = new VFile();
+    expect(
+      resolveArticles({} as any, '', vfile, {
+        format: ExportFormats.pdf,
+        articles: [],
+        sub_articles: [],
+      }),
+    ).toEqual({ articles: [], sub_articles: [] });
+    expect(vfile.messages.length).toBe(1);
+  });
+  it('empty articles/sub_articles pass for meca', async () => {
+    const vfile = new VFile();
+    expect(
+      resolveArticles({} as any, '', vfile, {
+        format: ExportFormats.meca,
+        articles: [],
+        sub_articles: [],
+      }),
+    ).toEqual({ articles: [], sub_articles: [] });
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('basic resolution/filtering of existing articles/sub_articles', async () => {
+    const vfile = new VFile();
+    expect(
+      resolveArticles({} as any, '', vfile, {
+        format: ExportFormats.pdf,
+        articles: [
+          {
+            title: 'folder',
+            level: 1,
+          },
+          {
+            file: '.',
+            slug: 'index',
+            level: 1,
+          },
+          {
+            file: 'does-not-exist',
+            slug: 'does-not-exist',
+            level: 1,
+          },
+        ],
+        sub_articles: ['does-not-exist', '.'],
+      }),
+    ).toEqual({
+      articles: [
+        {
+          title: 'folder',
+          level: 1,
+        },
+        {
+          file: path.resolve('.'),
+          slug: 'index',
+          level: 1,
+        },
+      ],
+      sub_articles: [path.resolve('.')],
+    });
+    expect(vfile.messages.length).toBe(2);
+  });
+});
+
+describe('resolveOutput', () => {
+  it('output with correct extension passes', async () => {
+    const vfile = new VFile();
+    expect(
+      resolveOutput({} as any, '.', vfile, { format: ExportFormats.pdf, output: 'out.pdf' }),
+    ).toEqual(path.resolve(path.dirname('.'), 'out.pdf'));
+    expect(vfile.messages.length).toBe(0);
+  });
+  it('meca format with zip:false warns', async () => {
+    const vfile = new VFile();
+    expect(
+      resolveOutput({} as any, '.', vfile, {
+        format: ExportFormats.meca,
+        zip: false,
+        output: 'out.zip',
+      }),
+    ).toEqual(path.resolve(path.dirname('.'), 'out.zip'));
+    expect(vfile.messages.length).toBe(1);
+  });
+  it('non-zippable format with zip:true warns', async () => {
+    const vfile = new VFile();
+    expect(
+      resolveOutput({} as any, '.', vfile, {
+        format: ExportFormats.md,
+        zip: true,
+        output: 'out.md',
+      }),
+    ).toEqual(path.resolve(path.dirname('.'), 'out.md'));
+    expect(vfile.messages.length).toBe(1);
+  });
+  it('output with incorrect extension errors', async () => {
+    const vfile = new VFile();
+    expect(
+      resolveOutput({} as any, '.', vfile, { format: ExportFormats.pdf, output: 'out.md' }),
+    ).toEqual(undefined);
+    expect(vfile.messages.length).toBe(1);
+  });
+  it('non-zip output with zip:true warns', async () => {
+    const vfile = new VFile();
+    expect(
+      resolveOutput({} as any, '.', vfile, {
+        format: ExportFormats.pdftex,
+        zip: true,
+        output: 'out.pdf',
+      }),
+    ).toEqual(path.resolve(path.dirname('.'), 'out.pdf'));
+    expect(vfile.messages.length).toBe(1);
+  });
+});

--- a/packages/myst-cli/src/build/utils/defaultNames.ts
+++ b/packages/myst-cli/src/build/utils/defaultNames.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { ExportFormats } from 'myst-frontmatter';
 import type { ISession } from '../../session/types.js';
 import { selectPageSlug } from '../../store/selectors.js';
 import { createSlug } from '../../utils/fileInfo.js';
@@ -29,12 +30,16 @@ export function getDefaultExportFilename(session: ISession, file: string, projec
 export function getDefaultExportFolder(
   session: ISession,
   file: string,
+  format: ExportFormats,
   projectPath?: string,
-  ext?: 'tex' | 'typ',
 ) {
   const subpaths = [projectPath || path.parse(file).dir, '_build', 'exports'];
-  // Extra folder for tex export content
-  if (ext === 'tex') subpaths.push(`${getDefaultExportFilename(session, file, projectPath)}_tex`);
-  if (ext === 'typ') subpaths.push(`${getDefaultExportFilename(session, file, projectPath)}_typst`);
+  // Extra folder for tex/typst export content
+  if (format === ExportFormats.tex) {
+    subpaths.push(`${getDefaultExportFilename(session, file, projectPath)}_tex`);
+  }
+  if (format === ExportFormats.typst) {
+    subpaths.push(`${getDefaultExportFilename(session, file, projectPath)}_typst`);
+  }
   return path.join(...subpaths);
 }

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -1,5 +1,5 @@
 import { getFrontmatter } from 'myst-transforms';
-import type { Export, ExportFormats, Licenses, PageFrontmatter } from 'myst-frontmatter';
+import type { Export, Licenses, PageFrontmatter } from 'myst-frontmatter';
 import {
   validateExportsList,
   fillPageFrontmatter,
@@ -98,7 +98,6 @@ export async function getRawFrontmatterFromFile(
 
 export function getExportListFromRawFrontmatter(
   session: ISession,
-  formats: ExportFormats[],
   rawFrontmatter: Record<string, any> | undefined,
   file: string,
 ): Export[] {
@@ -112,11 +111,7 @@ export function getExportListFromRawFrontmatter(
     }),
   );
   logMessagesFromVFile(session, vfile);
-  if (!exports) return [];
-  const exportOptions: Export[] = exports.filter(
-    (exp: Export | undefined): exp is Export => !!exp && formats.includes(exp.format),
-  );
-  return exportOptions;
+  return exports ?? [];
 }
 
 export function updateFileInfoFromFrontmatter(

--- a/packages/myst-common/src/ruleids.ts
+++ b/packages/myst-common/src/ruleids.ts
@@ -22,6 +22,7 @@ export enum RuleId {
   texRenders = 'tex-renders',
   exportExtensionCorrect = 'export-extension-correct',
   exportArticleExists = 'export-article-exists',
+  exportFormatDetermined = 'export-format-determined',
   // Parse rules
   texParses = 'tex-parses',
   jatsParses = 'jats-parses',

--- a/packages/myst-frontmatter/src/exports/exports.yml
+++ b/packages/myst-frontmatter/src/exports/exports.yml
@@ -262,8 +262,7 @@ cases:
         - out.pdf
     normalized:
       exports:
-        - format: pdf
-          output: out.pdf
+        - output: out.pdf
   - title: pdf extension coerces to format
     raw:
       exports:
@@ -277,15 +276,14 @@ cases:
         - output: out.pdf
     normalized:
       exports:
-        - format: pdf
-          output: out.pdf
-  # - title: export with only template validates
-  #   raw:
-  #     exports:
-  #       - template: template
-  #   normalized:
-  #     exports:
-  #       - template: template
+        - output: out.pdf
+  - title: export with only template validates
+    raw:
+      exports:
+        - template: template
+    normalized:
+      exports:
+        - template: template
   - title: unknown output errors
     raw:
       exports:

--- a/packages/myst-frontmatter/src/exports/exports.yml
+++ b/packages/myst-frontmatter/src/exports/exports.yml
@@ -290,6 +290,20 @@ cases:
         - output: out.bad
     normalized: {}
     errors: 1
+  - title: output folder passes
+    raw:
+      exports:
+        - output: my-folder
+    normalized:
+      exports:
+        - output: my-folder
+  - title: output hidden folder passes
+    raw:
+      exports:
+        - output: .my-folder
+    normalized:
+      exports:
+        - output: .my-folder
   - title: article object passes
     raw:
       exports:
@@ -408,4 +422,22 @@ cases:
         - format: xml
           sub_articles:
             - a.md
+    errors: 1
+  - title: zip passes
+    raw:
+      exports:
+        - format: pdf
+          zip: true
+    normalized:
+      exports:
+        - format: pdf
+          zip: true
+  - title: invalid zip errors
+    raw:
+      exports:
+        - format: pdf
+          zip: pdf
+    normalized:
+      exports:
+        - format: pdf
     errors: 1

--- a/packages/myst-frontmatter/src/exports/types.ts
+++ b/packages/myst-frontmatter/src/exports/types.ts
@@ -17,7 +17,7 @@ export type ExportArticle = {
 } & Record<string, any>;
 
 export type Export = {
-  format: ExportFormats; // TODO: Optional if template is defined
+  format?: ExportFormats; // TODO: Optional if template is defined
   template?: string | null;
   output?: string;
   toc?: string;

--- a/packages/myst-frontmatter/src/exports/types.ts
+++ b/packages/myst-frontmatter/src/exports/types.ts
@@ -20,6 +20,7 @@ export type Export = {
   format?: ExportFormats; // TODO: Optional if template is defined
   template?: string | null;
   output?: string;
+  zip?: boolean;
   toc?: string;
   articles?: ExportArticle[];
   /** sub_articles are only for jats xml export */

--- a/packages/myst-frontmatter/src/exports/validators.ts
+++ b/packages/myst-frontmatter/src/exports/validators.ts
@@ -34,7 +34,7 @@ const EXPORT_ARTICLE_KEY_OBJECT = {
   ],
 };
 
-const EXT_TO_FORMAT = {
+export const EXT_TO_FORMAT: Record<string, ExportFormats> = {
   '.pdf': ExportFormats.pdf,
   '.tex': ExportFormats.tex,
   '.doc': ExportFormats.docx,
@@ -125,22 +125,18 @@ export function singleArticleWithFile(articles?: ExportArticle[]) {
 
 export function validateExport(input: any, opts: ValidationOptions): Export | undefined {
   if (typeof input === 'string') {
+    // If export is a string it may be (1) format, (2) extension, or (3) output filename
     let format: string | undefined;
     let output: string | undefined;
-    if (input.includes('.')) {
+    if (input.startsWith('.')) {
       Object.entries(EXT_TO_FORMAT).forEach(([ext, fmt]) => {
-        if (input === ext) {
-          format = fmt;
-        } else if (input.endsWith(ext)) {
-          output = input;
-        }
+        if (input === ext) format = fmt; // Input is a known, format-specific extension
       });
-      if (!format && !output) {
-        output = input;
-      }
+    } else if (input.includes('.')) {
+      output = input; // Input is filename; format TBD
     }
     if (!format && !output) {
-      format = validateExportFormat(input, opts);
+      format = validateExportFormat(input, opts); // Input is valid format
       if (!format) return undefined;
     }
     input = { format, output };
@@ -162,26 +158,25 @@ export function validateExport(input: any, opts: ValidationOptions): Export | un
     template = validateString(value.template, incrementOptions('template', opts));
   }
   if (defined(value.output)) {
-    output = validateString(value.output, incrementOptions('output', opts));
+    const outputOpts = incrementOptions('output', opts);
+    const outputString = validateString(value.output, outputOpts);
+    if (outputString) {
+      Object.keys(EXT_TO_FORMAT).forEach((ext) => {
+        if (outputString.endsWith(ext)) output = outputString;
+      });
+      if (!output) {
+        return validationError(`unknown export output extension: ${outputString}`, outputOpts);
+      }
+    }
   }
   if (defined(value.format)) {
     format = validateExportFormat(value.format, incrementOptions('format', opts));
     // If format is defined but invalid, validation fails
     if (!format) return undefined;
-  } else if (output) {
-    // If output is defined, format is inferred from output
-    Object.entries(EXT_TO_FORMAT).forEach(([ext, fmt]) => {
-      if (output?.endsWith(ext)) format = fmt;
-    });
-    if (!format) {
-      return validationError(`unable to infer export format from export: ${output}`, opts);
-    }
-  } else {
-    // if (!template) {
-    // TODO: If template is defined, that will tell us the format later!
-    return validationError('unable to determine export format', opts);
   }
-  if (format === undefined && template === undefined) return undefined;
+  if (!format && !template && !output) {
+    return validationError('export must specify one of: format, template, or output', opts);
+  }
   const validExport: Export = { ...value, format, output, template };
   if (defined(value.articles)) {
     const articles = validateList(

--- a/packages/myst-frontmatter/src/exports/validators.ts
+++ b/packages/myst-frontmatter/src/exports/validators.ts
@@ -2,6 +2,7 @@ import type { ValidationOptions } from 'simple-validators';
 import {
   defined,
   incrementOptions,
+  validateBoolean,
   validateEnum,
   validateList,
   validateNumber,
@@ -17,7 +18,17 @@ import { ExportFormats } from './types.js';
 
 const EXPORT_KEY_OBJECT = {
   required: [],
-  optional: ['format', 'template', 'output', 'id', 'name', 'renderer', 'articles', 'sub_articles'],
+  optional: [
+    'format',
+    'template',
+    'output',
+    'zip',
+    'id',
+    'name',
+    'renderer',
+    'articles',
+    'sub_articles',
+  ],
   alias: {
     article: 'articles',
     sub_article: 'sub_articles',
@@ -164,6 +175,10 @@ export function validateExport(input: any, opts: ValidationOptions): Export | un
       Object.keys(EXT_TO_FORMAT).forEach((ext) => {
         if (outputString.endsWith(ext)) output = outputString;
       });
+      // If there is no '.' in the output string (aside from first character) this is assumed to be a folder.
+      if (!outputString.slice(1).includes('.')) {
+        output = outputString;
+      }
       if (!output) {
         return validationError(`unknown export output extension: ${outputString}`, outputOpts);
       }
@@ -178,6 +193,9 @@ export function validateExport(input: any, opts: ValidationOptions): Export | un
     return validationError('export must specify one of: format, template, or output', opts);
   }
   const validExport: Export = { ...value, format, output, template };
+  if (defined(value.zip)) {
+    validExport.zip = validateBoolean(value.zip, incrementOptions('zip', opts));
+  }
   if (defined(value.articles)) {
     const articles = validateList(
       value.articles,


### PR DESCRIPTION
Previously, when defining exports, you _had_ to specify format:
```
---
exports:
  - format: pdf
---
```

This is redundant with extensions...
```
---
exports:
  - format: pdf
    output: index.pdf
---
```

...and templates...
```
---
exports:
  - format: typst
    output: lapreprint-typst
---
```

There is also ambiguity around what `format: pdf` means, e.g. if I want a pdf built with `typst`, this failed since pdf was synonymous with `tex` build:
```
---
exports:
  - format: pdf
    output: lapreprint-typst
---
```

This PR refactors the export collection logic to be more human-friendly.
- Format can now be determined from `format`, `output`, or `template`, redundancy is not required
- `format: pdf` is more flexible and can result in a typst build if typst template or file extension are used
- Export may now specify `zip: true` - previously the only way to zip outputs was provide an `output` with `.zip` extension.

It also centralizes the logic into format-agnostic functions, so the `collectTexExportOptions`, `collectDocxExportOptions`, etc functions are deprecated. _Also_ previously there was some conflation between CLI-provided export options and file-provided export options... this has been separated a bit more cleanly, so all the CLI-provided options are handled in `build`, not in `collectExportOptions`...

👀 ALSO 👀 (Definitely not too much here. Definitely not.) This addresses #1021 by throwing an error when `typst` executable is not available, rather than silently carrying on and encountering other inexplicable errors...