### PR TITLE
👩‍⚖️ Add copyright to frontmatter

### DIFF
--- a/.changeset/lemon-days-leave.md
+++ b/.changeset/lemon-days-leave.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Add copyright to frontmatter

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -109,6 +109,9 @@ The following table lists the available frontmatter fields, a brief description 
 * - `license`
   - a license object or a string
   - page can override project
+* - `copyright`
+  - a string
+  - page can override project
 * - `funding`
   - a funding object
   - page can override project

--- a/packages/myst-frontmatter/src/page/validators.ts
+++ b/packages/myst-frontmatter/src/page/validators.ts
@@ -31,6 +31,7 @@ export const USE_PROJECT_FALLBACK = [
   'numbering',
   'keywords',
   'funding',
+  'copyright',
   'affiliations',
 ];
 

--- a/packages/myst-frontmatter/src/project/project.yml
+++ b/packages/myst-frontmatter/src/project/project.yml
@@ -58,6 +58,7 @@ cases:
         - requirements.txt
       resources:
         - my-script.sh
+      copyright: Authors et al.
     normalized:
       id: my/project
       title: frontmatter
@@ -109,6 +110,7 @@ cases:
         - requirements.txt
       resources:
         - my-script.sh
+      copyright: Authors et al.
   - title: boolean numbering is valid
     raw:
       numbering: 'false'
@@ -174,3 +176,8 @@ cases:
         what: ok
     warnings: 1
     normalized: {}
+  - title: invalid copyright errors
+    raw:
+      copyright: {}
+    normalized: {}
+    errors: 1

--- a/packages/myst-frontmatter/src/site/types.ts
+++ b/packages/myst-frontmatter/src/site/types.ts
@@ -18,6 +18,7 @@ export type SiteFrontmatter = {
   github?: string;
   keywords?: string[];
   funding?: Funding[];
+  copyright?: string;
   contributors?: Contributor[];
   options?: Record<string, any>;
 };

--- a/packages/myst-frontmatter/src/site/validators.ts
+++ b/packages/myst-frontmatter/src/site/validators.ts
@@ -33,6 +33,7 @@ export const SITE_FRONTMATTER_KEYS = [
   'keywords',
   'affiliations',
   'funding',
+  'copyright',
   'options',
 ];
 
@@ -158,6 +159,9 @@ export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: Va
         return validateFunding(fund, stash, incrementOptions(`funding.${index}`, opts));
       },
     );
+  }
+  if (defined(value.copyright)) {
+    output.copyright = validateString(value.copyright, incrementOptions('copyright', opts));
   }
   if (defined(value.options)) {
     const optionsOptions = incrementOptions('options', opts);


### PR DESCRIPTION
Addresses the need for `copyright` here: https://github.com/executablebooks/mystmd/issues/1009

For now, this is just a string, available at the site/project/page level, with inheritance (e.g. project copyright is used for page copyright unless page redefines it).