### PR TITLE
🏫 Add reviewers and editors to frontmatter

### DIFF
--- a/.changeset/light-teachers-give.md
+++ b/.changeset/light-teachers-give.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Allow referencing contributors with ref:

--- a/.changeset/pretty-berries-ring.md
+++ b/.changeset/pretty-berries-ring.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Make no-give-name warning less agressive

--- a/.changeset/seven-waves-serve.md
+++ b/.changeset/seven-waves-serve.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Add reviewers and editors to frontmatter

--- a/.changeset/weak-lemons-burn.md
+++ b/.changeset/weak-lemons-burn.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+More care around name warnings - do not warn on explicitly defined parts

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -92,10 +92,16 @@ The following table lists the available frontmatter fields, a brief description 
   - a valid date formatted string
   - page can override project
 * - `authors`
-  - a list of author objects
+  - a list of author objects, see [](#authors)
+  - page can override project
+* - `reviewers`
+  - a list of author objects or string ids, see [](#other-contributors)
+  - page can override project
+* - `editors`
+  - a list of author objects or string ids, see [](#other-contributors)
   - page can override project
 * - `affiliations`
-  - a list of affiliation objects
+  - a list of affiliation objects, see [](#affiliations)
   - page can override project
 * - `doi`
   - a valid DOI, either URL or id
@@ -107,13 +113,13 @@ The following table lists the available frontmatter fields, a brief description 
   - boolean (true/false)
   - page can override project
 * - `license`
-  - a license object or a string
+  - a license object or a string, see [](#licenses)
   - page can override project
 * - `copyright`
   - a string
   - page can override project
 * - `funding`
-  - a funding object
+  - a funding object, see [](#funding)
   - page can override project
 * - `github`
   - a valid GitHub URL or `owner/reponame`
@@ -246,6 +252,8 @@ The `authors` field is a list of `author` objects. Available fields in the autho
   - description
 * - `name`
   - a string OR CSL-JSON author object - the author’s full name; if a string, this will be parsed automatically. Otherwise, the object may contain `given`, `surname`, `non_dropping_particle`, `dropping_particle`, `suffix`, and full name `literal`
+* - `id`
+  - a string - a local identifier that can be used to reference a repeated author
 * - `orcid`
   - a string - a valid ORCID identifier with or without the URL
 * - `corresponding`
@@ -322,6 +330,12 @@ The `authors` field is a list of `author` objects. Available fields in the autho
 * - `fax`
   - for people who still use these machines, beep, boop, beeeep! 📠🎶
 ````
+
+(other-contributors)=
+
+### Reviewers, Editors, Funding Recipients
+
+Other contributors besides authors may be listed elsewhere in the frontmatter. These include `reviewers`, `editors`, and [funding](#funding) award `investigators` and `recipients`. For all of these fields, you may use a full [author object](#authors), or you may use the string `id` from an existing author object defined elsewhere in your frontmatter.
 
 (affiliations)=
 
@@ -440,7 +454,7 @@ affiliations:
 * - field
   - description
 * - `id`
-  - a string - a local identifier that can be used to easily reference a repeated affiliation
+  - a string - a local identifier that can be used to reference a repeated affiliation
 * - `name`
   - a string - the affiliation name. Either `name` or `institution` is required
 * - `institution`
@@ -493,6 +507,8 @@ The date field is a string and should conform to a valid Javascript data format.
 
 Where the latter example in that list are valid [IETF timestamps](https://datatracker.ietf.org/doc/html/rfc2822#page-14)
 
+(licenses)=
+
 ## Licenses
 
 This field can be set to a string value directly or to a License object.
@@ -533,7 +549,7 @@ It may be as simple as a single funding statement:
 funding: This work was supported by University.
 ```
 
-Funding may also specify award id, name, sources ([affiliation object or reference](#affiliations)), investigators ([contributor objects or references](#authors)), and recipients ([contributor objects or references](#authors)).
+Funding may also specify award id, name, sources ([affiliation object or reference](#affiliations)), investigators ([contributor objects or references](#other-contributors)), and recipients ([contributor objects or references](#other-contributors)).
 
 ```yaml
 authors:

--- a/packages/myst-frontmatter/src/affiliations/validators.ts
+++ b/packages/myst-frontmatter/src/affiliations/validators.ts
@@ -57,12 +57,19 @@ export function validateAffiliation(input: any, opts: ValidationOptions) {
     opts,
   );
   if (value === undefined) return undefined;
+  // If affiliation only has an id, give it a matching name; this is equivalent to the case
+  // where a simple string is provided as an affiliation.
+  if (Object.keys(value).length === 1 && value.id) {
+    value.name = value.id;
+  }
   const output: Affiliation = {};
   if (defined(value.id)) {
     output.id = validateString(value.id, incrementOptions('id', opts));
   }
   if (defined(value.name)) {
     output.name = validateString(value.name, incrementOptions('name', opts));
+  } else {
+    validationWarning('affiliation should include name/institution', opts);
   }
   if (defined(value.department)) {
     output.department = validateString(value.department, incrementOptions('department', opts));
@@ -119,13 +126,6 @@ export function validateAffiliation(input: any, opts: ValidationOptions) {
   }
   if (defined(value.fax)) {
     output.fax = validateString(value.fax, incrementOptions('fax', opts));
-  }
-  // If affiliation only has an id, give it a matching name; this is equivalent to the case
-  // where a simple string is provided as an affiliation.
-  if (Object.keys(output).length === 1 && output.id) {
-    return stashPlaceholder(output.id);
-  } else if (!output.name) {
-    validationWarning('affiliation should include name/institution', opts);
   }
   return output;
 }

--- a/packages/myst-frontmatter/src/contributors/authors.yml
+++ b/packages/myst-frontmatter/src/contributors/authors.yml
@@ -182,7 +182,20 @@ cases:
           email: example@example.com
           corresponding: true
     warnings: 1
-  - title: Warn if author has no family name
+  - title: Allow no family name if defined explicitly
+    raw:
+      authors:
+        - name:
+            literal: Someone
+            given: Someone
+    normalized:
+      authors:
+        - id: contributors-generated-uid-0
+          name: 'Someone'
+          nameParsed:
+            literal: 'Someone'
+            given: Someone
+  - title: Warn if computed literal starts with comma
     raw:
       authors:
         - name:
@@ -195,7 +208,20 @@ cases:
             literal: ', Someone'
             given: Someone
     warnings: 1
-  - title: Warn if author has no given name
+  - title: Allow explicit literal to start with comma
+    raw:
+      authors:
+        - name:
+            literal: ', Someone'
+            given: Someone
+    normalized:
+      authors:
+        - id: contributors-generated-uid-0
+          name: ', Someone'
+          nameParsed:
+            literal: ', Someone'
+            given: Someone
+  - title: Warn if parsed author name has no given name
     raw:
       authors:
         - name: Someone
@@ -207,6 +233,18 @@ cases:
             literal: 'Someone'
             family: Someone
     warnings: 1
+  - title: Allow no given name if defined explicitly
+    raw:
+      authors:
+        - name:
+            family: Someone
+    normalized:
+      authors:
+        - id: contributors-generated-uid-0
+          name: 'Someone'
+          nameParsed:
+            literal: 'Someone'
+            family: Someone
   - title: Parsed name is maintained
     raw:
       authors:
@@ -227,26 +265,38 @@ cases:
             non_dropping_particle: von
             family: Junior
             suffix: Jr.
-  - title: Name object with lots of commas warns
+  - title: Name object with explicit commas is ok
     raw:
       authors:
         - name:
-            literal: Commas, here, are, great,
-            given: Commas,
-            non_dropping_particle: here,
-            family: are,
-            suffix: warnings,
+            literal: Doe, John, III, M.D.
+            family: Doe
+            given: John
+            suffix: III, M.D.
     normalized:
       authors:
         - id: contributors-generated-uid-0
-          name: Commas, here, are, great,
+          name: Doe, John, III, M.D.
           nameParsed:
-            literal: Commas, here, are, great,
-            given: Commas,
-            non_dropping_particle: here,
-            family: are,
-            suffix: warnings,
-    warnings: 4
+            literal: Doe, John, III, M.D.
+            family: Doe
+            given: John
+            suffix: III, M.D.
+  - title: Name that parses to values with commas warns
+    raw:
+      authors:
+        - name:
+            literal: Doe, John, III, M.D.
+    normalized:
+      authors:
+        - id: contributors-generated-uid-0
+          name: Doe, John, III, M.D.
+          nameParsed:
+            literal: Doe, John, III, M.D.
+            family: Doe, John
+            given: M.D.
+            suffix: III
+    warnings: 1
   - title: Name string with extra comma warns
     raw:
       authors:

--- a/packages/myst-frontmatter/src/contributors/authors.yml
+++ b/packages/myst-frontmatter/src/contributors/authors.yml
@@ -342,3 +342,29 @@ cases:
             given: Just A.
             family: Name
     warnings: 1
+  - title: author as id resolves as placeholder
+    raw:
+      author:
+        id: Just A. Name
+    normalized:
+      authors:
+        - id: Just A. Name
+          name: Just A. Name
+          nameParsed:
+            literal: Just A. Name
+            given: Just A.
+            family: Name
+  - title: reviewer as ref resolves as placeholder
+    raw:
+      reviewer:
+        ref: Just A. Name
+    normalized:
+      reviewers:
+        - Just A. Name
+      contributors:
+        - id: Just A. Name
+          name: Just A. Name
+          nameParsed:
+            literal: Just A. Name
+            given: Just A.
+            family: Name

--- a/packages/myst-frontmatter/src/contributors/contributors.yml
+++ b/packages/myst-frontmatter/src/contributors/contributors.yml
@@ -262,3 +262,37 @@ cases:
             literal: John Doe
             family: Doe
             given: John
+  - title: author as id reference resolves to object
+    raw:
+      reviewers:
+        - id: janedoe
+          name: Jane Doe
+          nameParsed:
+            literal: Jane Doe
+            family: Doe
+            given: Jane
+        - id: johndoe
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            family: Doe
+            given: John
+      author: janedoe
+    normalized:
+      reviewers:
+        - janedoe
+        - johndoe
+      authors:
+        - id: janedoe
+          name: Jane Doe
+          nameParsed:
+            literal: Jane Doe
+            family: Doe
+            given: Jane
+      contributors:
+        - id: johndoe
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            family: Doe
+            given: John

--- a/packages/myst-frontmatter/src/contributors/contributors.yml
+++ b/packages/myst-frontmatter/src/contributors/contributors.yml
@@ -166,3 +166,99 @@ cases:
             family: Author
             given: Test
     errors: 1
+  - title: editor/reviewer added to collaborators
+    raw:
+      reviewer: Jane Doe
+      editor: John Doe
+    normalized:
+      reviewers:
+        - Jane Doe
+      editors:
+        - John Doe
+      contributors:
+        - id: Jane Doe
+          name: Jane Doe
+          nameParsed:
+            literal: Jane Doe
+            family: Doe
+            given: Jane
+        - id: John Doe
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            family: Doe
+            given: John
+  - title: editor/reviewer collaborators pass
+    raw:
+      reviewers:
+        - janedoe
+      editors:
+        - johndoe
+      contributors:
+        - id: janedoe
+          name: Jane Doe
+          nameParsed:
+            literal: Jane Doe
+            family: Doe
+            given: Jane
+        - id: johndoe
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            family: Doe
+            given: John
+    normalized:
+      reviewers:
+        - janedoe
+      editors:
+        - johndoe
+      contributors:
+        - id: janedoe
+          name: Jane Doe
+          nameParsed:
+            literal: Jane Doe
+            family: Doe
+            given: Jane
+        - id: johndoe
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            family: Doe
+            given: John
+  - title: editor/reviewer authors pass
+    raw:
+      reviewers:
+        - janedoe
+      editors:
+        - johndoe
+      authors:
+        - id: janedoe
+          name: Jane Doe
+          nameParsed:
+            literal: Jane Doe
+            family: Doe
+            given: Jane
+        - id: johndoe
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            family: Doe
+            given: John
+    normalized:
+      reviewers:
+        - janedoe
+      editors:
+        - johndoe
+      authors:
+        - id: janedoe
+          name: Jane Doe
+          nameParsed:
+            literal: Jane Doe
+            family: Doe
+            given: Jane
+        - id: johndoe
+          name: John Doe
+          nameParsed:
+            literal: John Doe
+            family: Doe
+            given: John

--- a/packages/myst-frontmatter/src/funding/types.ts
+++ b/packages/myst-frontmatter/src/funding/types.ts
@@ -2,8 +2,17 @@ export type Award = {
   id?: string;
   name?: string;
   description?: string;
+  /**
+   * Sources are affiliation ids.
+   * If an object is provided for this field, it will be moved to affiliations
+   * and replaced with id reference.
+   */
   sources?: string[]; // These are affiliation ids
-  /** Recipients and investigators are added to author list; these are references */
+  /**
+   * Recipients and investigators are author/contributor ids.
+   * If an object is provided for these fields, it will be moved to contributors
+   * and replaced with id reference.
+   */
   recipients?: string[];
   investigators?: string[];
 };

--- a/packages/myst-frontmatter/src/page/validators.ts
+++ b/packages/myst-frontmatter/src/page/validators.ts
@@ -17,6 +17,8 @@ import { FRONTMATTER_ALIASES } from '../site/validators.js';
 
 export const USE_PROJECT_FALLBACK = [
   'authors',
+  'reviewers',
+  'editors',
   'date',
   'doi',
   'arxiv',

--- a/packages/myst-frontmatter/src/site/types.ts
+++ b/packages/myst-frontmatter/src/site/types.ts
@@ -13,6 +13,14 @@ export type SiteFrontmatter = {
   banner?: string | null;
   bannerOptimized?: string;
   authors?: Contributor[];
+
+  /**
+   * Reviewers and editors are author/contributor ids.
+   * If an object is provided for these fields, it will be moved to contributors
+   * and replaced with id reference.
+   */
+  reviewers?: string[];
+  editors?: string[];
   affiliations?: Affiliation[];
   venue?: Venue;
   github?: string;

--- a/packages/myst-frontmatter/src/site/validators.ts
+++ b/packages/myst-frontmatter/src/site/validators.ts
@@ -211,7 +211,7 @@ export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: Va
     }
   }
 
-  // Contributor resolution should happen last
+  // Author/Contributor/Affiliation resolution should happen last
   const stashContribAuthors = stash.contributors?.filter((contrib) =>
     stash.authorIds?.includes(contrib.id),
   );

--- a/packages/myst-frontmatter/src/site/validators.ts
+++ b/packages/myst-frontmatter/src/site/validators.ts
@@ -27,6 +27,8 @@ export const SITE_FRONTMATTER_KEYS = [
   'banner',
   'bannerOptimized',
   'authors',
+  'reviewers',
+  'editors',
   'contributors',
   'venue',
   'github',
@@ -39,6 +41,8 @@ export const SITE_FRONTMATTER_KEYS = [
 
 export const FRONTMATTER_ALIASES = {
   author: 'authors',
+  reviewer: 'reviewers',
+  editor: 'editors',
   contributor: 'contributors',
   affiliation: 'affiliations',
   export: 'exports',
@@ -132,6 +136,36 @@ export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: Va
           'contributors',
           (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
           incrementOptions(`contributors.${index}`, opts),
+        );
+      },
+    );
+  }
+  if (defined(value.reviewers)) {
+    output.reviewers = validateList(
+      value.reviewers,
+      { coerce: true, ...incrementOptions('reviewers', opts) },
+      (reviewer, ind) => {
+        return validateAndStashObject(
+          reviewer,
+          stash,
+          'contributors',
+          (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
+          incrementOptions(`reviewers.${ind}`, opts),
+        );
+      },
+    );
+  }
+  if (defined(value.editors)) {
+    output.editors = validateList(
+      value.editors,
+      { coerce: true, ...incrementOptions('editors', opts) },
+      (editor, ind) => {
+        return validateAndStashObject(
+          editor,
+          stash,
+          'contributors',
+          (v: any, o: ValidationOptions) => validateContributor(v, stash, o),
+          incrementOptions(`editors.${ind}`, opts),
         );
       },
     );

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.spec.ts
@@ -477,7 +477,47 @@ describe('fillPageFrontmatter', () => {
     });
     expect(opts.messages.warnings?.length).toBeFalsy();
   });
-  it('relevant contributors from project are persisted when referenced in page', async () => {
+  it('irrelevant contributors from project are dropped', async () => {
+    expect(
+      fillPageFrontmatter(
+        {
+          authors: [
+            {
+              id: 'jd',
+              name: 'John Doe',
+              nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
+              affiliations: ['univa'],
+            },
+          ],
+          affiliations: [{ id: 'univa', name: 'University A' }],
+        },
+        {
+          contributors: [
+            {
+              id: 'jn',
+              name: 'Just A. Name',
+              nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+              affiliations: ['univb'],
+            },
+          ],
+          affiliations: [{ id: 'univb', name: 'University B' }],
+        },
+        opts,
+      ),
+    ).toEqual({
+      authors: [
+        {
+          id: 'jd',
+          name: 'John Doe',
+          nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
+          affiliations: ['univa'],
+        },
+      ],
+      affiliations: [{ id: 'univa', name: 'University A' }],
+    });
+    expect(opts.messages.warnings?.length).toBeFalsy();
+  });
+  it('relevant contributors from project are persisted when referenced in page funding', async () => {
     expect(
       fillPageFrontmatter(
         {
@@ -542,6 +582,112 @@ describe('fillPageFrontmatter', () => {
             },
           ],
         },
+      ],
+    });
+    expect(opts.messages.warnings?.length).toBeFalsy();
+  });
+  it('relevant contributors from project are persisted when referenced in page reviewers', async () => {
+    expect(
+      fillPageFrontmatter(
+        {
+          authors: [
+            {
+              id: 'jd',
+              name: 'John Doe',
+              nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
+              affiliations: ['univa'],
+            },
+          ],
+          affiliations: [{ id: 'univa', name: 'University A' }],
+          reviewers: ['jn'],
+        },
+        {
+          contributors: [
+            {
+              id: 'jn',
+              name: 'Just A. Name',
+              nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+              affiliations: ['univb'],
+            },
+          ],
+          affiliations: [{ id: 'univb', name: 'University B' }],
+        },
+        opts,
+      ),
+    ).toEqual({
+      authors: [
+        {
+          id: 'jd',
+          name: 'John Doe',
+          nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
+          affiliations: ['univa'],
+        },
+      ],
+      reviewers: ['jn'],
+      contributors: [
+        {
+          id: 'jn',
+          name: 'Just A. Name',
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          affiliations: ['univb'],
+        },
+      ],
+      affiliations: [
+        { id: 'univa', name: 'University A' },
+        { id: 'univb', name: 'University B' },
+      ],
+    });
+    expect(opts.messages.warnings?.length).toBeFalsy();
+  });
+  it('relevant authors from project are persisted when referenced in page editors', async () => {
+    expect(
+      fillPageFrontmatter(
+        {
+          authors: [
+            {
+              id: 'jd',
+              name: 'John Doe',
+              nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
+              affiliations: ['univa'],
+            },
+          ],
+          affiliations: [{ id: 'univa', name: 'University A' }],
+          editors: ['jn'],
+        },
+        {
+          authors: [
+            {
+              id: 'jn',
+              name: 'Just A. Name',
+              nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+              affiliations: ['univb'],
+            },
+          ],
+          affiliations: [{ id: 'univb', name: 'University B' }],
+        },
+        opts,
+      ),
+    ).toEqual({
+      authors: [
+        {
+          id: 'jd',
+          name: 'John Doe',
+          nameParsed: { literal: 'John Doe', given: 'John', family: 'Doe' },
+          affiliations: ['univa'],
+        },
+      ],
+      editors: ['jn'],
+      contributors: [
+        {
+          id: 'jn',
+          name: 'Just A. Name',
+          nameParsed: { literal: 'Just A. Name', given: 'Just A.', family: 'Name' },
+          affiliations: ['univb'],
+        },
+      ],
+      affiliations: [
+        { id: 'univa', name: 'University A' },
+        { id: 'univb', name: 'University B' },
       ],
     });
     expect(opts.messages.warnings?.length).toBeFalsy();

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
@@ -55,7 +55,7 @@ export function fillPageFrontmatter(
     };
   }
 
-  // Gather all contributors and affiliations from funding sources
+  // Gather all contributor and affiliation ids from funding sources
   const contributorIds: Set<string> = new Set();
   const affiliationIds: Set<string> = new Set();
   frontmatter.funding?.forEach((fund) => {
@@ -70,6 +70,14 @@ export function fillPageFrontmatter(
         affiliationIds.add(aff);
       });
     });
+  });
+
+  // Gather all contributor ids from reviewers and editors
+  frontmatter.reviewers?.forEach((reviewer) => {
+    contributorIds.add(reviewer);
+  });
+  frontmatter.editors?.forEach((editor) => {
+    contributorIds.add(editor);
   });
 
   if (frontmatter.authors?.length || contributorIds.size) {

--- a/packages/myst-frontmatter/src/utils/referenceStash.spec.ts
+++ b/packages/myst-frontmatter/src/utils/referenceStash.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import type { ValidationOptions } from 'simple-validators';
 import { validateContributor } from '../contributors/validators';
-import { validateAndStashObject } from './referenceStash';
+import { isStashPlaceholder, validateAndStashObject } from './referenceStash';
 
 let opts: ValidationOptions;
 
@@ -205,5 +205,27 @@ describe('validateAndStashObject', () => {
       ],
     });
     expect(opts.messages.warnings?.length).toEqual(1);
+  });
+});
+
+describe('isStashPlaceholder', () => {
+  it.each([
+    [{}, false],
+    [{ name: 'name' }, false],
+    [{ id: 'name' }, false],
+    [{ name: 'name', id: 'name' }, true],
+    [{ name: 'name', id: 'id' }, false],
+    [{ name: 'name', id: 'name', extra: 'name' }, false],
+    [{ name: 'name', nameParsed: { literal: 'name', family: 'name' } }, false],
+    [{ id: 'name', nameParsed: { literal: 'name', family: 'name' } }, false],
+    [{ name: 'name', id: 'name', nameParsed: { literal: 'name' } }, true],
+    [{ name: 'name', id: 'name', nameParsed: { literal: 'name', family: 'name' } }, true],
+    [{ name: 'name', id: 'name', nameParsed: { family: 'name' } }, false],
+    [
+      { name: 'name', id: 'name', nameParsed: { literal: 'name', family: 'name' }, extra: 'name' },
+      false,
+    ],
+  ])(`%s - %s`, async (input, result) => {
+    expect(isStashPlaceholder(input as any)).toBe(result);
   });
 });


### PR DESCRIPTION
This reuses the same `stash` infrastructure that as `funding` recipients/investigators.

On the final resolved frontmatter, `editors` and `reviewers` are lists of string ids which index into `contributors` and `authors` (each of those is still a full object).

(The actual editor/reviewer changes are pretty straightforward `frontmatter` updates - there was just another related edge case I ironed out to slightly complicate things...)

(This addresses a point in #1009)