### PR TITLE
🐛 findExpression allows undefined metadata

### DIFF
--- a/.changeset/chilly-mice-yell.md
+++ b/.changeset/chilly-mice-yell.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Avoid undefined bug when finding expressions

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -99,7 +99,9 @@ export async function processNotebook(
         const block = blockParent(cell, cellMdast.children) as GenericNode;
 
         // Embed expression results into expression
-        const userExpressions = block.data?.[metadataSection] as IUserExpressionMetadata[];
+        const userExpressions = block.data?.[metadataSection] as
+          | IUserExpressionMetadata[]
+          | undefined;
         const inlineNodes = selectAll('inlineExpression', block) as InlineExpression[];
         inlineNodes.forEach((inlineExpression) => {
           const data = findExpression(userExpressions, inlineExpression.value);

--- a/packages/myst-cli/src/transforms/inlineExpressions.ts
+++ b/packages/myst-cli/src/transforms/inlineExpressions.ts
@@ -19,10 +19,10 @@ export interface IUserExpressionsMetadata {
 }
 
 export function findExpression(
-  expressions: IUserExpressionMetadata[],
+  expressions: IUserExpressionMetadata[] | undefined,
   value: string,
 ): IUserExpressionMetadata | undefined {
-  return expressions.find((expr) => expr.expression === value);
+  return expressions?.find((expr) => expr.expression === value);
 }
 
 function processLatex(value: string) {


### PR DESCRIPTION
Fixing the bug reported in discord:
https://discord.com/channels/1083088970059096114/1224500421402431580/1224500421402431580