### PR TITLE
🐛 Fix bug causing pdf exports to fail

### DIFF
--- a/.changeset/flat-moose-work.md
+++ b/.changeset/flat-moose-work.md
@@ -1,0 +1,6 @@
+---
+'myst-common': patch
+'myst-cli': patch
+---
+
+Fix bug causing pdf exports to fail

--- a/packages/myst-cli/src/build/utils/collectExportOptions.spec.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.spec.ts
@@ -279,7 +279,7 @@ describe('resolveFormat', () => {
     ).toBe(ExportFormats.docx);
     expect(vfile.messages.length).toBe(0);
   });
-  it('errors if format cannot be determined from template', async () => {
+  it('defaults to pdf if format cannot be determined from template', async () => {
     const vfile = new VFile();
     expect(
       resolveFormat(vfile, {
@@ -287,8 +287,7 @@ describe('resolveFormat', () => {
         output: 'out.pdf',
         template: 'template',
       }),
-    ).toBe(undefined);
-    expect(vfile.messages.length).toBe(1);
+    ).toBe(ExportFormats.pdf);
   });
 });
 

--- a/packages/myst-cli/src/build/utils/collectExportOptions.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.ts
@@ -127,26 +127,18 @@ export function resolveFormat(vfile: VFile, exp: Export): ExportFormats | undefi
       suggestedOutputFormat = EXT_TO_FORMAT[ext];
     }
   }
-  if (!exp.template) {
-    if (exp.format) return suggestedPdfFormat;
-    return suggestedOutputFormat ?? suggestedPdfFormat;
-  }
-  if (exp.template.endsWith('-tex')) return suggestedPdfFormat;
-  if (exp.template.endsWith('-typst')) return ExportFormats.typst;
-  if (exp.template.endsWith('-docx')) return ExportFormats.docx;
-  if (fs.existsSync(exp.template)) {
+  if (exp.template?.endsWith('-tex')) return suggestedPdfFormat;
+  if (exp.template?.endsWith('-typst')) return ExportFormats.typst;
+  if (exp.template?.endsWith('-docx')) return ExportFormats.docx;
+  if (exp.template && fs.existsSync(exp.template)) {
     const templateFiles = fs.readdirSync(exp.template);
     const templateTexFiles = templateFiles.filter((file) => file.endsWith('.tex'));
     const templateTypFiles = templateFiles.filter((file) => file.endsWith('.typ'));
     if (templateTexFiles.length && !templateTypFiles.length) return suggestedPdfFormat;
     if (!templateTexFiles.length && templateTypFiles.length) return ExportFormats.typst;
   }
-  fileError(
-    vfile,
-    `Cannot determine export type from template ${exp.template} - you must specify export 'format'`,
-    { ruleId: RuleId.exportFormatDetermined },
-  );
-  return undefined;
+  if (exp.format) return suggestedPdfFormat;
+  return suggestedOutputFormat ?? suggestedPdfFormat;
 }
 
 /**

--- a/packages/myst-common/src/ruleids.ts
+++ b/packages/myst-common/src/ruleids.ts
@@ -22,7 +22,6 @@ export enum RuleId {
   texRenders = 'tex-renders',
   exportExtensionCorrect = 'export-extension-correct',
   exportArticleExists = 'export-article-exists',
-  exportFormatDetermined = 'export-format-determined',
   // Parse rules
   texParses = 'tex-parses',
   jatsParses = 'jats-parses',


### PR DESCRIPTION
The latest release changed how export format was determined. It introduced a bug where an error was rasied if it wasn't sure if it had a LaTeX or Typst PDF template, e.g. this export currently errors:

```
    - format: pdf
      template: volcanica
      article_type: Report
      toc: _toc.yml
      output: my-document.pdf
```

This PR restores the previous behaviour where the above export is just assumed to be a LaTeX template.