### PR TITLE
📥 Add downloads to page/project frontmatter and site config

### DIFF
--- a/.changeset/odd-icons-complain.md
+++ b/.changeset/odd-icons-complain.md
@@ -1,0 +1,6 @@
+---
+'myst-config': patch
+'myst-cli': patch
+---
+
+Relax site action validation and move later in the build

--- a/.changeset/purple-ants-tie.md
+++ b/.changeset/purple-ants-tie.md
@@ -1,0 +1,7 @@
+---
+'myst-frontmatter': patch
+'myst-config': patch
+'myst-cli': patch
+---
+
+Add downloads to page/project frontmatter and site config

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -79,6 +79,12 @@ The following table lists the available frontmatter fields, a brief description 
 * - `description`
   - a string (max 500 chars)
   - page & project
+* - `exports`
+  - an export object, see [](#exports)
+  - page & project
+* - `downloads`
+  - a file or export ID, see [](#downloads)
+  - page & project
 * - `tags`
   - a list of strings
   - page only
@@ -506,6 +512,45 @@ The date field is a string and should conform to a valid Javascript data format.
 - `2022-12-14` - `YYYY-MM-DD`
 
 Where the latter example in that list are valid [IETF timestamps](https://datatracker.ietf.org/doc/html/rfc2822#page-14)
+
+(exports)=
+
+## Exports
+
+You may define desired static exports in page or project frontmatter. In the export object, you may specify a filename, format, and/or template, as well as the article(s) you wish to include in your export. You may also provide any additional options required by your template in the export object. Formats currently supported by MyST include `pdf`, `tex`, `typst`, `docx`, `jats`, and `meca`. For examples of how to create exports, see [](./creating-pdf-documents.md). You can also explore the [MyST templating](myst:jtex) documentation for a deeper dive into defining templates.
+
+After defining `exports` in your frontmatter, you may build them with the `myst build` [CLI command](./quickstart-myst-documents.md).
+
+The following table shows the available properties for each export. You must define at least one of `format`, `output`, or `template` for MyST to be able to perform your output. You may also specify a string instead of a full export object; this string will be inferred to be either the export format or the output filename.
+
+```{list-table} Frontmatter export definitions
+:header-rows: 1
+:name: table-frontmatter-exports
+* - field
+  - description
+* - `id`
+  - a string - a local identifier that can be used to reference the export
+* - `format`
+  - one of `pdf` (built with $\LaTeX$ or Typst, depending on the template), `tex` (raw $\LaTeX$ files), `pdf+tex` (both PDF and raw $\LaTeX$ files) `typst` (raw Typst files and built PDF file), `docx`, `md`, `jats`, or `meca`
+* - `template`
+  - a string - name of an existing [MyST template](https://github.com/myst-templates) or a local path to a template folder. Templates are only available for `pdf`, `tex`, `typst`, and `docx` formats.
+* - `output`
+  - a string - export output filename with a valid extension or destination folder
+* - `zip`
+  - a boolean - if `true`, zip the output - only applies for multi-file exports `tex`, `pdf+tex` and `typst`.
+* - `articles`
+  - a list of strings - path(s) to articles to include in your export - this is required for exports defined in project frontmatter; for page frontmatter, the default article will be the page itself. Not all exports currently support multiple articles.
+* - `toc`
+  - a string - path to jupyterbook `_toc.yml` file - may be used as an alternative to listing `articles`
+* - `sub_articles`
+  - a list of strings - path(s) to sub-articles for `jats` export
+```
+
+(downloads)=
+
+## Downloads
+
+Downloads are files you want available on your MyST site. They may be defined at the project or the page level. In your frontmatter, `downloads` may include (a) relative paths to local files or (b) export `id` values to indicate you would like a specific export available as a download.
 
 (licenses)=
 

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -83,7 +83,7 @@ The following table lists the available frontmatter fields, a brief description 
   - an export object, see [](#exports)
   - page & project
 * - `downloads`
-  - a file or export ID, see [](#downloads)
+  - a download object, see [](#downloads)
   - page & project
 * - `tags`
   - a list of strings
@@ -550,7 +550,53 @@ The following table shows the available properties for each export. You must def
 
 ## Downloads
 
-Downloads are files you want available on your MyST site. They may be defined at the project or the page level. In your frontmatter, `downloads` may include (a) relative paths to local files or (b) export `id` values to indicate you would like a specific export available as a download.
+Downloads are downloadable files or useful links you want available on your MyST site. They may be defined at the project or the page level. In your frontmatter, a download may only specify one of `id`, `file`, or `url`. Descriptions of these fields and other available fields are in the table below.
+
+```{list-table} Frontmatter download definitions
+:header-rows: 1
+:name: table-frontmatter-downloads
+* - field
+  - description
+* - `id`
+  - a string - reference to an existing `export` identifier. The referenced export may be defined in a different file. If `id` is defined, `file`/`url` are not allowed.
+* - `file`
+  - a string - a path to a local file. If `file` is defined, `id`/`url` are not allowed.
+* - `url`
+  - a string - either a full URL or a relative URL of a page in your MyST project. If `url` is defined, `id`/`file` are not allowed.
+* - `title`
+  - a string - title of the `downloads` entry. This will show up as text on the link in your MyST site. `title` is recommended for all downloads, but only required for `url` values; files will default to `filename` title
+* - `filename`
+  - a string - name of the file upon download. By default, this will match the original filename. `url` values do no require a `filename`; if provided, the `url` will be treated as a download link rather than page navigation.
+* - `static`
+  - a boolean - this is automatically set to `true` for local files and `false` otherwise. You may also explicitly set this to `false`; this will bypass any attempt to find the file locally and will keep the value for `url` exactly as it is provided.
+```
+
+You may include the raw source of a file as a download by referencing the file itself in the download frontmatter. For example inside file `index.md`, you may do:
+
+```yaml
+downloads:
+  file: index.md
+  title: Source File
+```
+
+The following example has several downloads: the source file, as above, an exported pdf, a remote file, and a link to another website:
+
+```yaml
+exports:
+  - output: paper.pdf
+    template: lapreprint-typst
+    id: my-paper
+downloads:
+  - file: index.md
+    title: Source File
+  - id: my-paper
+    title: Publication
+  - url: https://example.com/files/script.py
+    filename: script.py
+    title: Sample Code
+  - url: https://example.com/more-info
+    title: More Info
+```
 
 (licenses)=
 

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -284,7 +284,7 @@ function resolveSiteAction(
       url: action.url,
       filename: action.filename,
       format: action.format,
-      internal: action.internal ?? isInternalUrl(action.url),
+      internal: isInternalUrl(action.url),
       static: false,
     };
   }
@@ -324,7 +324,7 @@ function resolveSiteAction(
       url: action.url,
       filename: action.filename,
       format: action.format,
-      internal: action.internal ?? isInternalUrl(action.url),
+      internal: isInternalUrl(action.url),
       static: false,
     };
   }
@@ -359,7 +359,6 @@ function resolveSiteAction(
     url: `/${fileHash}`,
     filename,
     format: action.format ?? EXT_TO_FORMAT[path.extname(resolvedFile)],
-    internal: action.internal,
     static: true,
   };
 }

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -64,7 +64,7 @@ export async function resolvePageDownloads(
   session: ISession,
   file: string,
   projectPath?: string,
-): Promise<SiteAction[]> {
+): Promise<SiteAction[] | undefined> {
   const state = session.store.getState();
   if (!projectPath) {
     projectPath = selectors.selectCurrentProjectPath(state);
@@ -108,7 +108,7 @@ export async function resolvePageDownloads(
       return resolveSiteAction(session, download as SiteAction, file, 'downloads');
     })
     .filter((download): download is SiteAction => !!download);
-  return resolvedDownloads ?? [];
+  return resolvedDownloads;
 }
 
 /**
@@ -172,7 +172,7 @@ export async function localToManifestProject(
   const exports = projConfigFile ? await resolvePageExports(session, projConfigFile) : [];
   const downloads = projConfigFile
     ? await resolvePageDownloads(session, projConfigFile, projectPath)
-    : [];
+    : undefined;
   const banner = await transformBanner(
     session,
     path.join(projectPath, 'myst.yml'),

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -257,7 +257,17 @@ function resolveSiteManifestAction(
   action: SiteAction,
   file?: string,
 ): SiteAction | undefined {
-  if (action.static === false || !action.url) return { ...action };
+  if (!action.url) return { ...action };
+  if (action.static === false) {
+    if (!isUrl(action.url)) {
+      addWarningForFile(
+        session,
+        file,
+        `Non-static site action "${action.url}" should be a valid URL`,
+      );
+    }
+    return { ...action };
+  }
   // Cases where url does not exist as a local file
   if (!fs.existsSync(action.url)) {
     if (action.static) {

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { hashAndCopyStaticFile } from 'myst-cli-utils';
 import { RuleId, TemplateOptionType } from 'myst-common';
-import type { PageDownload, SiteAction, SiteManifest } from 'myst-config';
+import type { SiteAction, SiteExport, SiteManifest } from 'myst-config';
 import {
   EXT_TO_FORMAT,
   ExportFormats,
@@ -25,7 +25,7 @@ import { getRawFrontmatterFromFile } from '../../frontmatter.js';
 
 type ManifestProject = Required<SiteManifest>['projects'][0];
 
-export async function resolvePageExports(session: ISession, file: string): Promise<PageDownload[]> {
+export async function resolvePageExports(session: ISession, file: string): Promise<SiteExport[]> {
   const exports = (
     await collectExportOptions(
       session,
@@ -63,7 +63,7 @@ export async function resolvePageDownloads(
   session: ISession,
   file: string,
   projectPath?: string,
-): Promise<PageDownload[]> {
+): Promise<SiteAction[]> {
   const state = session.store.getState();
   if (!projectPath) {
     projectPath = selectors.selectCurrentProjectPath(state);
@@ -81,7 +81,7 @@ export async function resolvePageDownloads(
   });
   const pageFrontmatter = await getRawFrontmatterFromFile(session, file, projectPath);
   const resolvedDownloads = pageFrontmatter?.downloads
-    ?.map((download) => {
+    ?.map((download): SiteAction | undefined => {
       let format: ExportFormats | undefined;
       let downloadFile: string;
       const exp = expLookup[download.file];
@@ -108,9 +108,9 @@ export async function resolvePageDownloads(
           });
         },
       );
-      return { format, filename: path.basename(downloadFile), url: `/${fileHash}` } as PageDownload;
+      return { format, filename: path.basename(downloadFile), url: `/${fileHash}` };
     })
-    .filter((download): download is PageDownload => !!download);
+    .filter((download): download is SiteAction => !!download);
   return resolvedDownloads ?? [];
 }
 

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -261,15 +261,6 @@ function resolveSiteAction(
 ): SiteAction | undefined {
   const title = action.title;
   if (action.static === false) {
-    if (!isUrl(action.url)) {
-      addWarningForFile(
-        session,
-        file,
-        `Non-static resource "${action.url}" in ${property} should be a valid URL`,
-        'error',
-      );
-      return undefined;
-    }
     if (!title) {
       addWarningForFile(
         session,

--- a/packages/myst-cli/src/build/utils/collectExportOptions.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.ts
@@ -307,16 +307,7 @@ async function getExportListFromFile(
   opts: ExportOptions,
 ): Promise<Export[]> {
   const { disableTemplate } = opts;
-  let rawFrontmatter: Record<string, any> | undefined;
-  const state = session.store.getState();
-  if (
-    projectPath &&
-    path.resolve(sourceFile) === selectors.selectLocalConfigFile(state, projectPath)
-  ) {
-    rawFrontmatter = selectors.selectLocalProjectConfig(state, projectPath);
-  } else {
-    rawFrontmatter = await getRawFrontmatterFromFile(session, sourceFile, projectPath);
-  }
+  const rawFrontmatter = await getRawFrontmatterFromFile(session, sourceFile, projectPath);
   const exportList = getExportListFromRawFrontmatter(session, rawFrontmatter, sourceFile);
   const exportListWithTemplate = exportList
     .map((exp) => {

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path';
 import { getFrontmatter } from 'myst-transforms';
 import type { Export, Licenses, PageFrontmatter } from 'myst-frontmatter';
 import {
@@ -89,6 +90,10 @@ export async function getRawFrontmatterFromFile(
   file: string,
   projectPath?: string,
 ) {
+  const state = session.store.getState();
+  if (projectPath && resolve(file) === selectors.selectLocalConfigFile(state, projectPath)) {
+    return selectors.selectLocalProjectConfig(state, projectPath);
+  }
   const cache = castSession(session);
   if (!cache.$getMdast(file)) await loadFile(session, file, projectPath);
   const result = cache.$getMdast(file);

--- a/packages/myst-config/src/site/site.spec.ts
+++ b/packages/myst-config/src/site/site.spec.ts
@@ -88,16 +88,18 @@ describe('validateSiteAction', () => {
     };
     expect(validateSiteAction(siteAction, opts)).toEqual(siteAction);
   });
-  it('invalid url errors', async () => {
+  it('relative url passes', async () => {
     expect(validateSiteAction({ title: 'example', url: '/a/b/c/d' }, opts)).toEqual({
       title: 'example',
       url: '/a/b/c/d',
     });
     expect(opts.messages.errors?.length).toEqual(undefined);
   });
-  it('invalid url errors', async () => {
-    expect(validateSiteAction({ title: 'example', url: '?something' }, opts)).toBeUndefined();
-    expect(opts.messages.errors?.length).toEqual(1);
+  it('invalid url passes', async () => {
+    expect(validateSiteAction({ title: 'example', url: '?something' }, opts)).toEqual({
+      title: 'example',
+      url: '?something',
+    });
   });
   it('valid path returns self', async () => {
     expect(validateSiteAction({ title: 'example', url: '/a/b' }, opts)).toEqual({
@@ -124,7 +126,6 @@ describe('validateSiteConfig', () => {
         {
           projects: [{ path: 'my-proj', slug: '/my/proj' }],
           nav: [{ title: 'cool folder', children: 'a' }],
-          actions: [{ title: 'Go To Example', url: 'bad_url', static: false }],
           domains: ['example.com'],
         },
         opts,
@@ -132,10 +133,9 @@ describe('validateSiteConfig', () => {
     ).toEqual({
       projects: [],
       nav: [],
-      actions: [],
       domains: [],
     });
-    expect(opts.messages.errors?.length).toEqual(4);
+    expect(opts.messages.errors?.length).toEqual(3);
   });
   it('invalid required values error', async () => {
     expect(

--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -18,6 +18,7 @@ export interface SiteAction {
   title: string;
   url: string;
   filename?: string;
+  format?: ExportFormats;
   internal?: boolean;
   static?: boolean;
 }
@@ -31,10 +32,10 @@ export type SiteConfig = SiteFrontmatter & {
   template?: string;
 };
 
-export type PageDownload = {
-  format?: ExportFormats;
-  filename: string;
+export type SiteExport = {
   url: string;
+  filename: string;
+  format?: ExportFormats;
 };
 
 type ManifestProjectItem = {
@@ -49,8 +50,7 @@ type ManifestProjectItem = {
   banner?: string | null;
   bannerOptimized?: string;
   tags?: string[];
-  exports?: PageDownload[];
-  downloads?: PageDownload[];
+  exports?: SiteExport[];
 };
 
 type ManifestProject = {
@@ -63,8 +63,9 @@ type ManifestProject = {
   banner?: string | null;
   bannerOptimized?: string;
   tags?: string[];
-  downloads?: PageDownload[];
-} & Omit<ProjectFrontmatter, 'downloads'>;
+  downloads: SiteAction[];
+  exports?: SiteExport[];
+} & Omit<ProjectFrontmatter, 'downloads' | 'exports'>;
 
 export type SiteManifest = SiteFrontmatter & {
   myst: string;

--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -1,4 +1,4 @@
-import type { Export, ProjectFrontmatter, SiteFrontmatter } from 'myst-frontmatter';
+import type { ExportFormats, ProjectFrontmatter, SiteFrontmatter } from 'myst-frontmatter';
 
 export interface SiteProject {
   slug?: string;
@@ -31,6 +31,12 @@ export type SiteConfig = SiteFrontmatter & {
   template?: string;
 };
 
+export type PageDownload = {
+  format?: ExportFormats;
+  filename: string;
+  url: string;
+};
+
 type ManifestProjectItem = {
   title: string;
   short_title?: string;
@@ -43,7 +49,8 @@ type ManifestProjectItem = {
   banner?: string | null;
   bannerOptimized?: string;
   tags?: string[];
-  exports?: Export[];
+  exports?: PageDownload[];
+  downloads?: PageDownload[];
 };
 
 type ManifestProject = {
@@ -56,7 +63,8 @@ type ManifestProject = {
   banner?: string | null;
   bannerOptimized?: string;
   tags?: string[];
-} & ProjectFrontmatter;
+  downloads?: PageDownload[];
+} & Omit<ProjectFrontmatter, 'downloads'>;
 
 export type SiteManifest = SiteFrontmatter & {
   myst: string;

--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -62,7 +62,7 @@ type ManifestProject = {
   banner?: string | null;
   bannerOptimized?: string;
   tags?: string[];
-  downloads: SiteAction[];
+  downloads?: SiteAction[];
   exports?: SiteExport[];
 } & Omit<ProjectFrontmatter, 'downloads' | 'exports'>;
 

--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -50,7 +50,6 @@ type ManifestProjectItem = {
   banner?: string | null;
   bannerOptimized?: string;
   tags?: string[];
-  exports?: SiteExport[];
 };
 
 type ManifestProject = {

--- a/packages/myst-config/src/site/validators.ts
+++ b/packages/myst-config/src/site/validators.ts
@@ -103,13 +103,13 @@ export function validateSiteAction(input: any, opts: ValidationOptions) {
   );
   if (value === undefined) return undefined;
   const title = validateString(value.title, incrementOptions('title', opts));
+  const url = validateString(value.url, incrementOptions('url', opts));
+  if (!title || !url) return undefined;
+  const output: SiteAction = { title, url };
   if (defined(value.static)) {
-    value.static = validateBoolean(value.static, incrementOptions('static', opts));
+    output.static = validateBoolean(value.static, incrementOptions('static', opts));
   }
-  const actionUrlValidator = value.static ? validateString : validateUrlOrPath;
-  const url = actionUrlValidator(value.url, incrementOptions('url', opts));
-  if (title === undefined || !url) return undefined;
-  return value as SiteAction;
+  return output;
 }
 
 export function validateSiteConfigKeys(

--- a/packages/myst-frontmatter/src/downloads/downloads.yml
+++ b/packages/myst-frontmatter/src/downloads/downloads.yml
@@ -5,7 +5,7 @@ cases:
       download: my-file.pdf
     normalized:
       downloads:
-        - file: my-file.pdf
+        - url: my-file.pdf
   - title: download ref coerces to id
     raw:
       download:
@@ -20,12 +20,12 @@ cases:
           format: md
     normalized:
       downloads:
-        - file: my-file.pdf
+        - url: my-file.pdf
           format: md
-  - title: download with file and id errors
+  - title: download with url and id errors
     raw:
       downloads:
-        - file: my-file.pdf
+        - url: my-file.pdf
           id: my-file
     normalized: {}
     errors: 1
@@ -38,14 +38,14 @@ cases:
   - title: full download object passes
     raw:
       downloads:
-        - file: my-file.pdf
+        - url: my-file.pdf
           format: md
           title: My File
           static: true
           internal: false
     normalized:
       downloads:
-        - file: my-file.pdf
+        - url: my-file.pdf
           format: md
           title: My File
           static: true

--- a/packages/myst-frontmatter/src/downloads/downloads.yml
+++ b/packages/myst-frontmatter/src/downloads/downloads.yml
@@ -35,7 +35,7 @@ cases:
         - format: md
     normalized: {}
     errors: 1
-  - title: full download object passes
+  - title: cannot set internal
     raw:
       downloads:
         - url: my-file.pdf
@@ -49,4 +49,19 @@ cases:
           format: md
           title: My File
           static: true
-          internal: false
+    warnings: 1
+  - title: full download object passes
+    raw:
+      downloads:
+        - url: my-file.pdf
+          format: md
+          title: My File
+          static: true
+          filename: file.md
+    normalized:
+      downloads:
+        - url: my-file.pdf
+          format: md
+          title: My File
+          static: true
+          filename: file.md

--- a/packages/myst-frontmatter/src/downloads/downloads.yml
+++ b/packages/myst-frontmatter/src/downloads/downloads.yml
@@ -22,18 +22,25 @@ cases:
       downloads:
         - url: my-file.pdf
           format: md
+  - title: empty downloads persists as empty list
+    raw:
+      downloads: []
+    normalized:
+      downloads: []
   - title: download with url and id errors
     raw:
       downloads:
         - url: my-file.pdf
           id: my-file
-    normalized: {}
+    normalized:
+      downloads: []
     errors: 1
   - title: download with neither file nor id errors
     raw:
       downloads:
         - format: md
-    normalized: {}
+    normalized:
+      downloads: []
     errors: 1
   - title: cannot set internal
     raw:

--- a/packages/myst-frontmatter/src/downloads/downloads.yml
+++ b/packages/myst-frontmatter/src/downloads/downloads.yml
@@ -1,0 +1,52 @@
+title: Downloads
+cases:
+  - title: download string coerces to file
+    raw:
+      download: my-file.pdf
+    normalized:
+      downloads:
+        - file: my-file.pdf
+  - title: download ref coerces to id
+    raw:
+      download:
+        ref: my-file
+    normalized:
+      downloads:
+        - id: my-file
+  - title: downloads file and format pass
+    raw:
+      downloads:
+        - file: my-file.pdf
+          format: md
+    normalized:
+      downloads:
+        - file: my-file.pdf
+          format: md
+  - title: download with file and id errors
+    raw:
+      downloads:
+        - file: my-file.pdf
+          id: my-file
+    normalized: {}
+    errors: 1
+  - title: download with neither file nor id errors
+    raw:
+      downloads:
+        - format: md
+    normalized: {}
+    errors: 1
+  - title: full download object passes
+    raw:
+      downloads:
+        - file: my-file.pdf
+          format: md
+          title: My File
+          static: true
+          internal: false
+    normalized:
+      downloads:
+        - file: my-file.pdf
+          format: md
+          title: My File
+          static: true
+          internal: false

--- a/packages/myst-frontmatter/src/downloads/index.ts
+++ b/packages/myst-frontmatter/src/downloads/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js';
+export * from './validators.js';

--- a/packages/myst-frontmatter/src/downloads/types.ts
+++ b/packages/myst-frontmatter/src/downloads/types.ts
@@ -6,6 +6,5 @@ export type Download = {
   id?: string;
   url?: string;
   filename?: string;
-  internal?: boolean;
   static?: boolean;
 };

--- a/packages/myst-frontmatter/src/downloads/types.ts
+++ b/packages/myst-frontmatter/src/downloads/types.ts
@@ -1,0 +1,11 @@
+import type { ExportFormats } from '../index.js';
+
+export type Download = {
+  title?: string;
+  format?: ExportFormats;
+  id?: string;
+  url?: string;
+  filename?: string;
+  internal?: boolean;
+  static?: boolean;
+};

--- a/packages/myst-frontmatter/src/downloads/validators.ts
+++ b/packages/myst-frontmatter/src/downloads/validators.ts
@@ -1,0 +1,67 @@
+import type { ValidationOptions } from 'simple-validators';
+import {
+  defined,
+  incrementOptions,
+  validateBoolean,
+  validateList,
+  validateObjectKeys,
+  validateString,
+  validationError,
+} from 'simple-validators';
+import { validateExportFormat } from '../exports/validators.js';
+import type { Download } from './types.js';
+
+const DOWNLOAD_KEY_OBJECT = {
+  required: [],
+  optional: ['title', 'file', 'id', 'format', 'internal', 'static'],
+  alias: {
+    ref: 'id',
+  },
+};
+
+export function validateDownload(input: any, opts: ValidationOptions): Download | undefined {
+  if (typeof input === 'string') {
+    input = { url: input };
+  }
+  const value = validateObjectKeys(input, DOWNLOAD_KEY_OBJECT, opts);
+  if (value === undefined) return undefined;
+  const output: Download = {};
+  if (defined(value.id)) {
+    output.id = validateString(value.id, incrementOptions('id', opts));
+  }
+  if (defined(value.url)) {
+    output.url = validateString(value.url, incrementOptions('url', opts));
+  }
+  if (output.url && output.id) {
+    return validationError(`download must define only one of id and file/url, not both`, opts);
+  }
+  if (!output.url && !output.id) {
+    return validationError(`download must define either id or file/url`, opts);
+  }
+  if (defined(value.title)) {
+    output.title = validateString(value.title, incrementOptions('title', opts));
+  }
+  if (defined(value.format)) {
+    output.format = validateExportFormat(value.format, incrementOptions('format', opts));
+  }
+  if (defined(value.internal)) {
+    output.internal = validateBoolean(value.internal, incrementOptions('internal', opts));
+  }
+  if (defined(value.static)) {
+    output.static = validateBoolean(value.static, incrementOptions('static', opts));
+  }
+  return output;
+}
+
+export function validateDownloadsList(input: any, opts: ValidationOptions): Download[] | undefined {
+  if (input === undefined) return undefined;
+  const output = validateList(
+    input,
+    { coerce: true, ...incrementOptions('downloads', opts) },
+    (exp, ind) => {
+      return validateDownload(exp, incrementOptions(`downloads.${ind}`, opts));
+    },
+  );
+  if (!output || output.length === 0) return undefined;
+  return output;
+}

--- a/packages/myst-frontmatter/src/downloads/validators.ts
+++ b/packages/myst-frontmatter/src/downloads/validators.ts
@@ -63,6 +63,6 @@ export function validateDownloadsList(input: any, opts: ValidationOptions): Down
       return validateDownload(exp, incrementOptions(`downloads.${ind}`, opts));
     },
   );
-  if (!output || output.length === 0) return undefined;
+  if (!output) return undefined;
   return output;
 }

--- a/packages/myst-frontmatter/src/downloads/validators.ts
+++ b/packages/myst-frontmatter/src/downloads/validators.ts
@@ -13,9 +13,10 @@ import type { Download } from './types.js';
 
 const DOWNLOAD_KEY_OBJECT = {
   required: [],
-  optional: ['title', 'file', 'id', 'format', 'internal', 'static'],
+  optional: ['title', 'url', 'id', 'filename', 'format', 'internal', 'static'],
   alias: {
     ref: 'id',
+    file: 'url',
   },
 };
 
@@ -40,6 +41,9 @@ export function validateDownload(input: any, opts: ValidationOptions): Download 
   }
   if (defined(value.title)) {
     output.title = validateString(value.title, incrementOptions('title', opts));
+  }
+  if (defined(value.filename)) {
+    output.filename = validateString(value.filename, incrementOptions('filename', opts));
   }
   if (defined(value.format)) {
     output.format = validateExportFormat(value.format, incrementOptions('format', opts));

--- a/packages/myst-frontmatter/src/downloads/validators.ts
+++ b/packages/myst-frontmatter/src/downloads/validators.ts
@@ -13,7 +13,7 @@ import type { Download } from './types.js';
 
 const DOWNLOAD_KEY_OBJECT = {
   required: [],
-  optional: ['title', 'url', 'id', 'filename', 'format', 'internal', 'static'],
+  optional: ['title', 'url', 'id', 'filename', 'format', 'static'],
   alias: {
     ref: 'id',
     file: 'url',
@@ -47,9 +47,6 @@ export function validateDownload(input: any, opts: ValidationOptions): Download 
   }
   if (defined(value.format)) {
     output.format = validateExportFormat(value.format, incrementOptions('format', opts));
-  }
-  if (defined(value.internal)) {
-    output.internal = validateBoolean(value.internal, incrementOptions('internal', opts));
   }
   if (defined(value.static)) {
     output.static = validateBoolean(value.static, incrementOptions('static', opts));

--- a/packages/myst-frontmatter/src/exports/exports.yml
+++ b/packages/myst-frontmatter/src/exports/exports.yml
@@ -441,3 +441,34 @@ cases:
       exports:
         - format: pdf
     errors: 1
+  - title: export allows id
+    raw:
+      exports:
+        - format: pdf
+          id: my-pdf
+    normalized:
+      exports:
+        - format: pdf
+          id: my-pdf
+  - title: download string coerces to file
+    raw:
+      download: my-file.pdf
+    normalized:
+      downloads:
+        - file: my-file.pdf
+  - title: download id coerces to file
+    raw:
+      download:
+        id: my-file
+    normalized:
+      downloads:
+        - file: my-file
+  - title: downloads file and format pass
+    raw:
+      downloads:
+        - file: my-file.pdf
+          format: md
+    normalized:
+      downloads:
+        - file: my-file.pdf
+          format: md

--- a/packages/myst-frontmatter/src/exports/exports.yml
+++ b/packages/myst-frontmatter/src/exports/exports.yml
@@ -450,25 +450,3 @@ cases:
       exports:
         - format: pdf
           id: my-pdf
-  - title: download string coerces to file
-    raw:
-      download: my-file.pdf
-    normalized:
-      downloads:
-        - file: my-file.pdf
-  - title: download id coerces to file
-    raw:
-      download:
-        id: my-file
-    normalized:
-      downloads:
-        - file: my-file
-  - title: downloads file and format pass
-    raw:
-      downloads:
-        - file: my-file.pdf
-          format: md
-    normalized:
-      downloads:
-        - file: my-file.pdf
-          format: md

--- a/packages/myst-frontmatter/src/exports/types.ts
+++ b/packages/myst-frontmatter/src/exports/types.ts
@@ -28,8 +28,3 @@ export type Export = {
   sub_articles?: string[];
   /** MECA: to, from later */
 } & Record<string, any>;
-
-export type Download = {
-  format?: ExportFormats;
-  file: string;
-};

--- a/packages/myst-frontmatter/src/exports/types.ts
+++ b/packages/myst-frontmatter/src/exports/types.ts
@@ -17,7 +17,8 @@ export type ExportArticle = {
 } & Record<string, any>;
 
 export type Export = {
-  format?: ExportFormats; // TODO: Optional if template is defined
+  id?: string;
+  format?: ExportFormats;
   template?: string | null;
   output?: string;
   zip?: boolean;
@@ -27,3 +28,8 @@ export type Export = {
   sub_articles?: string[];
   /** MECA: to, from later */
 } & Record<string, any>;
+
+export type Download = {
+  format?: ExportFormats;
+  file: string;
+};

--- a/packages/myst-frontmatter/src/exports/validators.ts
+++ b/packages/myst-frontmatter/src/exports/validators.ts
@@ -13,7 +13,7 @@ import {
 import { PAGE_FRONTMATTER_KEYS } from '../page/types.js';
 import { PROJECT_FRONTMATTER_KEYS } from '../project/types.js';
 import { FRONTMATTER_ALIASES } from '../site/validators.js';
-import type { Download, Export, ExportArticle } from './types.js';
+import type { Export, ExportArticle } from './types.js';
 import { ExportFormats } from './types.js';
 
 const EXPORT_KEY_OBJECT = {
@@ -43,14 +43,6 @@ const EXPORT_ARTICLE_KEY_OBJECT = {
     ...PAGE_FRONTMATTER_KEYS,
     ...Object.keys(FRONTMATTER_ALIASES),
   ],
-};
-
-const DOWNLOAD_KEY_OBJECT = {
-  required: ['file'],
-  optional: ['format'],
-  alias: {
-    id: 'file',
-  },
 };
 
 export const EXT_TO_FORMAT: Record<string, ExportFormats> = {
@@ -95,20 +87,10 @@ export function validateExportsList(input: any, opts: ValidationOptions): Export
   return output;
 }
 
-export function validateDownloadsList(input: any, opts: ValidationOptions): Download[] | undefined {
-  if (input === undefined) return undefined;
-  const output = validateList(
-    input,
-    { coerce: true, ...incrementOptions('downloads', opts) },
-    (exp, ind) => {
-      return validateDownload(exp, incrementOptions(`downloads.${ind}`, opts));
-    },
-  );
-  if (!output || output.length === 0) return undefined;
-  return output;
-}
-
-function validateExportFormat(input: any, opts: ValidationOptions): ExportFormats | undefined {
+export function validateExportFormat(
+  input: any,
+  opts: ValidationOptions,
+): ExportFormats | undefined {
   if (input === undefined) return undefined;
   if (input === 'tex+pdf') input = 'pdf+tex';
   if (input === 'jats') input = 'xml';
@@ -282,19 +264,4 @@ export function validateExport(input: any, opts: ValidationOptions): Export | un
     }
   }
   return validExport;
-}
-
-export function validateDownload(input: any, opts: ValidationOptions): Download | undefined {
-  if (typeof input === 'string') {
-    input = { file: input };
-  }
-  const value = validateObjectKeys(input, DOWNLOAD_KEY_OBJECT, opts);
-  if (value === undefined) return undefined;
-  const file = validateString(value.file, incrementOptions('file', opts));
-  if (file === undefined) return undefined;
-  const output: Download = { file };
-  if (defined(value.format)) {
-    output.format = validateExportFormat(value.format, incrementOptions('format', opts));
-  }
-  return output;
 }

--- a/packages/myst-frontmatter/src/index.ts
+++ b/packages/myst-frontmatter/src/index.ts
@@ -1,6 +1,7 @@
 export * from './affiliations/index.js';
 export * from './biblio/index.js';
 export * from './contributors/index.js';
+export * from './downloads/index.js';
 export * from './exports/index.js';
 export * from './funding/index.js';
 export * from './jupytext/index.js';

--- a/packages/myst-frontmatter/src/project/types.ts
+++ b/packages/myst-frontmatter/src/project/types.ts
@@ -1,5 +1,6 @@
 import type { Biblio } from '../biblio/types.js';
-import type { Download, Export } from '../exports/types.js';
+import type { Download } from '../downloads/types.js';
+import type { Export } from '../exports/types.js';
 import type { Licenses } from '../licenses/types.js';
 import type { Numbering } from '../numbering/types.js';
 import type { ProjectSettings } from '../settings/types.js';

--- a/packages/myst-frontmatter/src/project/types.ts
+++ b/packages/myst-frontmatter/src/project/types.ts
@@ -1,5 +1,5 @@
 import type { Biblio } from '../biblio/types.js';
-import type { Export } from '../exports/types.js';
+import type { Download, Export } from '../exports/types.js';
 import type { Licenses } from '../licenses/types.js';
 import type { Numbering } from '../numbering/types.js';
 import type { ProjectSettings } from '../settings/types.js';
@@ -24,6 +24,7 @@ export const PROJECT_AND_PAGE_FRONTMATTER_KEYS = [
   'math',
   'abbreviations',
   'exports',
+  'downloads',
   'settings', // We maybe want to move this into site frontmatter in the future
   // Do not add any project specific keys here!
   ...SITE_FRONTMATTER_KEYS,
@@ -59,6 +60,7 @@ export type ProjectAndPageFrontmatter = SiteFrontmatter & {
   /** Abbreviations used throughout the project */
   abbreviations?: Record<string, string>;
   exports?: Export[];
+  downloads?: Download[];
   settings?: ProjectSettings;
 };
 

--- a/packages/myst-frontmatter/src/project/validators.ts
+++ b/packages/myst-frontmatter/src/project/validators.ts
@@ -12,7 +12,7 @@ import {
   validateUrl,
 } from 'simple-validators';
 import { validateBiblio } from '../biblio/validators.js';
-import { validateExportsList } from '../exports/validators.js';
+import { validateDownloadsList, validateExportsList } from '../exports/validators.js';
 import { validateLicenses } from '../licenses/validators.js';
 import { validateNumbering } from '../numbering/validators.js';
 import { FRONTMATTER_ALIASES, validateSiteFrontmatterKeys } from '../site/validators.js';
@@ -104,6 +104,10 @@ export function validateProjectAndPageFrontmatterKeys(
   if (defined(value.exports)) {
     const exports = validateExportsList(value.exports, opts);
     if (exports) output.exports = exports;
+  }
+  if (defined(value.downloads)) {
+    const downloads = validateDownloadsList(value.downloads, opts);
+    if (downloads) output.downloads = downloads;
   }
   if (value.thumbnail === null) {
     // It is possible for the thumbnail to explicitly be null.

--- a/packages/myst-frontmatter/src/project/validators.ts
+++ b/packages/myst-frontmatter/src/project/validators.ts
@@ -12,7 +12,8 @@ import {
   validateUrl,
 } from 'simple-validators';
 import { validateBiblio } from '../biblio/validators.js';
-import { validateDownloadsList, validateExportsList } from '../exports/validators.js';
+import { validateDownloadsList } from '../downloads/validators.js';
+import { validateExportsList } from '../exports/validators.js';
 import { validateLicenses } from '../licenses/validators.js';
 import { validateNumbering } from '../numbering/validators.js';
 import { FRONTMATTER_ALIASES, validateSiteFrontmatterKeys } from '../site/validators.js';

--- a/packages/myst-frontmatter/src/site/validators.ts
+++ b/packages/myst-frontmatter/src/site/validators.ts
@@ -46,6 +46,7 @@ export const FRONTMATTER_ALIASES = {
   contributor: 'contributors',
   affiliation: 'affiliations',
   export: 'exports',
+  download: 'downloads',
   jupyter: 'thebe',
   part: 'parts',
   ack: 'acknowledgments',


### PR DESCRIPTION
Previously, when you built a MyST site, all the `exports` defined on a page became **Downloads** and there was no other way to define additional or different downloads.

This PR adds `downloads` to page/project frontmatter as a place to specify (1) paths to local files and/or (2) export `id` values. Then, when you build your site, no longer do all the exports show up as downloads but only the specific `downloads` you specify.

This also makes improvements to site actions outlined here: https://github.com/executablebooks/mystmd/pull/1048