### PR TITLE
🎨 Update `listings` options for tex parsing

### DIFF
--- a/.changeset/small-avocados-sleep.md
+++ b/.changeset/small-avocados-sleep.md
@@ -1,0 +1,5 @@
+---
+"tex-to-myst": patch
+---
+
+Add more listings styles for verbatim environment.

--- a/packages/tex-to-myst/src/verbatim.ts
+++ b/packages/tex-to-myst/src/verbatim.ts
@@ -1,17 +1,65 @@
 import { u } from 'unist-builder';
 import type { Handler } from './types.js';
+import type { VFile } from 'vfile';
+import type { GenericNode } from 'myst-common';
+import { fileWarn, normalizeLabel } from 'myst-common';
+import type { Code } from 'myst-spec-ext';
 
-function parseFirstLine(code?: string) {
+type ListingsProps = {
+  language?: string;
+  caption?: string;
+  label?: string;
+  numbers?: string;
+  firstnumber?: string;
+};
+
+function getListingProperty(line?: string): ListingsProps | false {
+  if (!line || !line.match(/^\s*\[(.*)\]\s*$/)) return false;
+  const props: ListingsProps = {};
+  ['language', 'caption', 'label', 'numbers', 'firstnumber'].forEach((key) => {
+    props[key as keyof typeof props] = line
+      .match(new RegExp(`${key}(?:[\\s]*)?=([^,\\]]*)`))?.[1]
+      .trim();
+  });
+  return props;
+}
+
+function parseFirstLine(vfile: VFile, node: GenericNode) {
+  const code = node.content;
   const lines = code?.split('\n');
   const firstLine = lines?.[0];
-  if (!firstLine) return { value: code?.replace(/(\s)$/, '') };
-  if (!firstLine.match(/language([\s]*)?=/) && !firstLine.match(/caption([\s]*)?=/)) {
-    return { value: code?.replace(/(\s)$/, '') };
-  }
+  const props = getListingProperty(firstLine);
+  if (!lines || props === false) return { value: code?.replace(/(\s)$/, '') };
   const value = lines.slice(1).join('\n').replace(/(\s)$/, '');
-  const caption = firstLine.match(/caption(?:[\s]*)?=([^,\]]*)/)?.[1].trim();
-  const lang = firstLine.match(/language(?:[\s]*)?=([^,\]]*)/)?.[1].trim();
-  return { caption, lang, value };
+  let startingLineNumber = undefined;
+  let showLineNumbers = undefined;
+  if (props.firstnumber) {
+    const number = parseInt(props.firstnumber, 10);
+    if (isNaN(number)) {
+      fileWarn(vfile, 'Unknown code option for "firstnumber", should be an integer.', { node });
+    } else {
+      startingLineNumber = number;
+    }
+  }
+  if (props.numbers) {
+    if (['none', 'left', 'right'].includes(props.numbers)) {
+      if (props.numbers !== 'none') showLineNumbers = true;
+    } else {
+      fileWarn(
+        vfile,
+        "Unknown code option for \"numbers\", should be an 'none', 'left' or 'right'.",
+        { node },
+      );
+    }
+  }
+  return {
+    lang: props.language,
+    value,
+    label: props.label,
+    caption: props.caption,
+    showLineNumbers,
+    startingLineNumber,
+  };
 }
 
 export const VERBATIM_HANDLERS: Record<string, Handler> = {
@@ -21,16 +69,23 @@ export const VERBATIM_HANDLERS: Record<string, Handler> = {
       return;
     }
     state.closeParagraph();
-    const { value, lang, caption } = parseFirstLine(node.content);
-    if (caption) {
+    const { value, lang, showLineNumbers, startingLineNumber, ...props } = parseFirstLine(
+      state.file,
+      node,
+    );
+    const { label, identifier } = normalizeLabel(props.label as string | undefined) || {};
+    const code = u('code', { value, lang, showLineNumbers, startingLineNumber }) as Code;
+    if (props.caption) {
       state.pushNode(
-        u('container', { kind: 'code' }, [
-          u('code', { value, lang }),
-          u('caption', [u('paragraph', [u('text', caption)])]),
+        u('container', { kind: 'code', label, identifier }, [
+          code,
+          u('caption', [u('paragraph', [u('text', props.caption)])]),
         ]),
       );
       return;
     }
-    state.pushNode(u('code', { value, lang }));
+    code.label = label;
+    code.identifier = identifier;
+    state.pushNode(code);
   },
 };

--- a/packages/tex-to-myst/tests/verbatim.yml
+++ b/packages/tex-to-myst/tests/verbatim.yml
@@ -62,6 +62,23 @@ cases:
                   children:
                     - type: text
                       value: Hello world
+  - title: lstlisting and line numbers
+    tex: |
+      \begin{lstlisting}[language=c,numbers=left,firstnumber=2,label=lst:loop]
+          for (int i = 0; i < 10; i++) {
+              /* do something */
+          }
+      \end{lstlisting}
+    tree:
+      type: root
+      children:
+        - type: code
+          lang: c
+          label: lst:loop
+          identifier: lst:loop
+          showLineNumbers: true
+          startingLineNumber: 2
+          value: "    for (int i = 0; i < 10; i++) {\n        /* do something */\n    }"
   - title: comment environment
     tex: |-
       \begin{comment}


### PR DESCRIPTION
This can now parse:

```latex
\begin{lstlisting}[language=c,numbers=left,firstnumber=2]
    for (int i = 0; i < 10; i++) {
        /* do something */
    }
\end{lstlisting}
```