### PR TITLE
🐛 Inline expression parsing

### DIFF
--- a/.changeset/gorgeous-pans-love.md
+++ b/.changeset/gorgeous-pans-love.md
@@ -1,0 +1,5 @@
+---
+"myst-execute": patch
+---
+
+Better error messages when connection to Jupyter fails

--- a/.changeset/shy-taxis-rhyme.md
+++ b/.changeset/shy-taxis-rhyme.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Cell metadata from jupyter should not be serialized to `meta` on the block.

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -1,4 +1,4 @@
-import { NotebookCell, RuleId, fileWarn } from 'myst-common';
+import { NotebookCell, RuleId, copyNode, fileWarn } from 'myst-common';
 import type { GenericNode, GenericParent } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 import { nanoid } from 'nanoid';
@@ -22,7 +22,7 @@ import type { IUserExpressionMetadata } from '../transforms/index.js';
 
 function blockParent(cell: ICell, children: GenericNode[]) {
   const type = cell.cell_type === CELL_TYPES.code ? NotebookCell.code : NotebookCell.content;
-  return { type: 'block', meta: JSON.stringify({ type, ...cell.metadata }), children };
+  return { type: 'block', data: copyNode({ type, ...cell.metadata }), children };
 }
 
 /**

--- a/packages/myst-execute/src/execute.ts
+++ b/packages/myst-execute/src/execute.ts
@@ -320,7 +320,7 @@ export async function kernelExecutionTransform(tree: GenericParent, vfile: VFile
         .startNew(sessionOpts)
         .catch((err) => {
           log.debug((err as Error).stack);
-          log.error('Jupyter connection error');
+          log.error(`Jupyter Connection Error: ${(err as Error).message}`);
         })
         .then(async (conn) => {
           if (!conn) return;


### PR DESCRIPTION
Fixes a bug where the inline expressions were not getting picked up properly in the mystmd side when they were previously executed in JupyterLab-MyST.