### PR TITLE
Change `:name: ` to `:label: ` to standardize label syntax

### DIFF
--- a/docs/accessibility-and-performance.md
+++ b/docs/accessibility-and-performance.md
@@ -26,7 +26,7 @@ The real-world deployment of your site will depend on the infrastructure that yo
 Lighthouse is a tool included in Chrome that measures accessibility, performance, and search engine performance (see [lighthouse on GitHub](https://github.com/GoogleChrome/lighthouse)). Although not perfect, the tool does do a good job at highlighting issues with performance, search engine crawling, and accessibility. These scores indicate the real-world performance of a site as well as can effect search engine rankings.
 
 ```{figure} ./images/lighthouse-2022_09_15.png
-:name: lighthouse
+:label: lighthouse
 Lighthouse score run Sept 15, 2022 on deployed site using Curvenote's global CDN.
 ```
 
@@ -49,12 +49,12 @@ Some performance and accessibility considerations:
 As a comparison to JupyterBook or Quarto, which are both static site generators for scientific content, and assets built by Sphinx and Pandoc, respectively. There are improvements possible primarily in the bundling of Javascript assets, which is very difficult to do in the Sphinx build process, for example.
 
 ```{figure} ./images/lighthouse-jb-2022_09_15.png
-:name: lighthouse-jb
+:label: lighthouse-jb
 Lighthouse score run Sept 15, 2022 on deployed site, the majority of issues are around bundling assets, reducing javascript used, optimizing images, and speed to initial page load.
 ```
 
 ```{figure} ./images/lighthouse-quarto-2022_09_15.png
-:name: lighthouse-quarto
+:label: lighthouse-quarto
 Lighthouse score run Sept 15, 2022 on deployed site, the majority of issues are image sizing, main-thread work, and high network payloads.
 ```
 ````

--- a/docs/admonitions.md
+++ b/docs/admonitions.md
@@ -16,7 +16,7 @@ Try changing `tip` to `warning`!
 In MyST we call these kind of directives {myst:directive}`admonitions <admonition>`, however, they are almost always used through their _named_ directives, like `{note}` or `{danger}`. Admonitions can be styled as `simple` or as a `dropdown`, and can optionally hide the icon using the {myst:directive}`admonition.class` option. There are ten kinds[^docutils-admonitions] of admonitions available:
 
 ```{list-table} Named admonitions that can be used as directives
-:name: admonitions-list
+:label: admonitions-list
 * - 🔵 `note`
   - 🟠 `attention`
 * - 🔵 `important`

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -60,7 +60,7 @@ This syntax follows the [pandoc citation syntax](https://pandoc.org/MANUAL.html#
 
 ```{list-table} Examples of Markdown citations
 :header-rows: 1
-:name: table-pandoc-citations
+:label: table-pandoc-citations
 * - Markdown
   - Rendered
   - Explanation

--- a/docs/code.md
+++ b/docs/code.md
@@ -36,7 +36,7 @@ The above code is not a directive, it is just standard markdown syntax, which ca
 
 ````{myst}
 ```{code} python
-:name: my-program
+:label: my-program
 :caption: Creating a TensorMesh using SimPEG
 from discretize import TensorMesh
 

--- a/docs/contribute-add-feature.md
+++ b/docs/contribute-add-feature.md
@@ -229,7 +229,7 @@ $ cd demo
 and add a new file `main.md` in which we will write the following:
 
 ```{code-block} markdown
-:name: main-md
+:label: main-md
 :filename: demo/main.md
 
 # Demo

--- a/docs/creating-pdf-documents.md
+++ b/docs/creating-pdf-documents.md
@@ -6,7 +6,7 @@ description: Export to over 400 journal templates from a MyST Markdown file, whi
 You can render your MyST documents as print-ready scientific papers, by converting to $\LaTeX$ and render to over 400 journal templates already available. Alternatively, you can also render your documents as Beamer presentations or as [Microsoft Word](./creating-word-documents.md) to share with other collaborators.
 
 ```{figure} ./images/pdf-exports.png
-:name: fig-export-to-pdf
+:label: fig-export-to-pdf
 :width: 100%
 
 Export to over 400 journal templates from a MyST Markdown file, which uses $\LaTeX$ and can create print-ready, multi-column, professional PDF documents.

--- a/docs/creating-word-documents.md
+++ b/docs/creating-word-documents.md
@@ -6,7 +6,7 @@ description: Export to Microsoft Word directly from MyST Markdown.
 You can render your MyST documents as Microsoft Word documents.
 
 ```{figure} ./images/word-export.png
-:name: fig-export-to-word
+:label: fig-export-to-word
 :width: 50%
 
 Export to a Microsoft Word document to easily share with your colleagues.
@@ -44,7 +44,7 @@ Based on the `output` field in the export list in the [frontmatter](#export-fron
 The default export creates links for cross references and citations, and the first time this is opened Microsoft Word asks you if you would like to link these. **Click Yes**.
 
 ```{figure} ./images/export-word-link.png
-:name: export-word-link
+:label: export-word-link
 :width: 40%
 
 Allow word to fix links for cross-references and citations.
@@ -61,7 +61,7 @@ Currently MyST export does not fully create math in Word's format, instead, $\La
 4. Click convert
 
 ```{figure} ./images/convert-word-equations.png
-:name: convert-word-equations
+:label: convert-word-equations
 :width: 100%
 
 To fix equations in Word, use the equation toolbar to select `LaTeX` and from the dropdown select, all professional, then click convert.

--- a/docs/cross-references.md
+++ b/docs/cross-references.md
@@ -26,7 +26,7 @@ Targets are custom anchors that you can refer to elsewhere, for example, a figur
 
 ````{myst}
 ```{figure} https://source.unsplash.com/random/500x200/?mountain
-:name: my-fig
+:label: my-fig
 :align: center
 
 My **bold** mountain 🏔🚠.
@@ -194,7 +194,7 @@ or as a `figure` directive, where you can then add a caption. If you are referri
 
 ```markdown
 :::{figure} #my-cell
-:name: fig-my-cell
+:label: fig-my-cell
 :::
 ```
 
@@ -208,7 +208,7 @@ See more about reusing Jupyter outputs in figures, adding placeholders, and othe
 The following example embeds a figure from [](./interactive-notebooks.ipynb), and can be used in cross references [](#fig-altair-horsepower).
 
 ```{figure} #altair-horsepower
-:name: fig-altair-horsepower
+:label: fig-altair-horsepower
 This figure has been included from [](./interactive-notebooks.ipynb) and can be referred to in cross-references through a different label.
 ```
 

--- a/docs/documents-exports.md
+++ b/docs/documents-exports.md
@@ -11,7 +11,7 @@ Below are supported export types and links to documentation for further reading:
 
 ```{list-table} Frontmatter Export Formats
 :header-rows: 1
-:name: table-export-docs
+:label: table-export-docs
 - * Export type
   * Learn more
 - * `pdf`

--- a/docs/embed.md
+++ b/docs/embed.md
@@ -15,13 +15,13 @@ For the examples below, we are defining a figure with a label:
 
 ```markdown
 :::{figure} https://source.unsplash.com/random/400x200?beach,ocean
-:name: myLabel
+:label: myLabel
 Here's a cool figure.
 :::
 ```
 
 :::{figure} https://source.unsplash.com/random/400x200?beach,ocean
-:name: myLabel
+:label: myLabel
 Here's a cool figure.
 :::
 ::::

--- a/docs/figures.md
+++ b/docs/figures.md
@@ -45,7 +45,7 @@ There are two directives that can be used to add additional information about th
 
 ````{myst}
 ```{figure} https://source.unsplash.com/random/400x200?beach,ocean
-:name: myFigure
+:label: myFigure
 :alt: Random image of the beach or ocean!
 :align: center
 
@@ -63,7 +63,7 @@ Subfigures can be created by omitting the directive argument to figure, and havi
 These will be numbered as `Figure 1a` and `Figure 1b`, etc. For example:
 
 :::{figure}
-:name: subFigure
+:label: subFigure
 :align: left
 
 ![Banff, Canada](https://source.unsplash.com/random/600x225?banff)
@@ -76,7 +76,7 @@ You can also cross-reference either the whole figure [@subFigure], or an individ
 
 ```{myst}
 :::{figure}
-:name: my-figure
+:label: my-figure
 :align: left
 
 (my-figure-fruit)=

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -62,7 +62,7 @@ The following table lists the available frontmatter fields, a brief description 
 
 ```{list-table} A list of available frontmatter fields and their behavior across projects and pages
 :header-rows: 1
-:name: table-frontmatter
+:label: table-frontmatter
 
 * - field
   - description
@@ -241,7 +241,7 @@ banner: banner.png
 ```
 
 :::{figure} ./images/article-theme.png
-:name: banner-example
+:label: banner-example
 Example of a banner in a site using the `article-theme`.
 :::
 
@@ -253,7 +253,7 @@ The `authors` field is a list of `author` objects. Available fields in the autho
 
 ````{list-table} Frontmatter information for authors
 :header-rows: 1
-:name: table-frontmatter-authors
+:label: table-frontmatter-authors
 * - field
   - description
 * - `name`
@@ -456,7 +456,7 @@ affiliations:
 
 ````{list-table} Frontmatter information for affiliations
 :header-rows: 1
-:name: table-frontmatter-affiliations
+:label: table-frontmatter-affiliations
 * - field
   - description
 * - `id`
@@ -522,7 +522,7 @@ For usage information, see [](./documents-exports.md).
 
 ```{list-table} Frontmatter export definitions
 :header-rows: 1
-:name: table-frontmatter-exports
+:label: table-frontmatter-exports
 * - field
   - description
 * - `id`
@@ -574,7 +574,7 @@ Below is a list of all possible downloads configuration.
 
 ```{list-table} Frontmatter download definitions
 :header-rows: 1
-:name: table-frontmatter-downloads
+:label: table-frontmatter-downloads
 * - field
   - description
 * - `id`
@@ -603,7 +603,7 @@ String values for licenses should be a valid “Identifier” string from the [S
 
 ```{list-table}
 :header-rows: 1
-:name: table-common-licenses
+:label: table-common-licenses
 
 * - Common Content Licenses
   - Common Code Licenses

--- a/docs/proofs-and-theorems.md
+++ b/docs/proofs-and-theorems.md
@@ -39,7 +39,7 @@ The vector $\hat y$ is called the **orthogonal projection** of $y$ onto $S$.
 :::
 
 ```{list-table} Proof kinds that can be used as directives
-:name: proof-list
+:label: proof-list
 :header-rows: 0
 
 * - `prf:algorithm`

--- a/docs/quickstart-jupyter-lab-myst.md
+++ b/docs/quickstart-jupyter-lab-myst.md
@@ -80,7 +80,7 @@ jupyter lab
 
 :::{figure} ./images/jupyterlab-myst.png
 :width: 100%
-:name: jupyterlab-myst
+:label: jupyterlab-myst
 
 MyST in JupyterLab, showing frontmatter and admonitions that are natively rendered! 🎉
 :::

--- a/docs/quickstart-myst-documents.md
+++ b/docs/quickstart-myst-documents.md
@@ -114,7 +114,7 @@ This will produce a document that looks like:
 
 :::{figure} ./images/frontmatter-before.png
 :width: 80%
-:name: frontmatter-before-pdf
+:label: frontmatter-before-pdf
 :class: framed
 
 The myst theme for the `01-paper.md` page using inline document and author information.
@@ -145,7 +145,7 @@ Once these are added, the myst theme (in this case the `book-theme` template) ca
 
 :::{figure} ./images/frontmatter-after.png
 :width: 80%
-:name: frontmatter-after
+:label: frontmatter-after
 :class: framed
 
 The myst theme for the `01-paper.md` page after the frontmatter changes are added. Compare this to what it looked like before in [](#frontmatter-before-pdf). The structure of the HTML page has also been improved, including meta tags that are available to search engines and other programmatic indexers.
@@ -199,7 +199,7 @@ If you have replaced both of these citations, you can now safely remove the text
 This will have created a **References** section at the bottom of the page automatically!
 
 :::{figure} ./images/references.png
-:name: references
+:label: references
 :class: framed
 
 The references are shown automatically at the bottom of the page, and linked to the correct DOI source!
@@ -224,7 +224,7 @@ with:
 
 ```markdown
 :::{figure} ./images/citations.png
-:name: citations
+:label: citations
 Citations are rendered with a popup directly inline.
 :::
 ```
@@ -247,7 +247,7 @@ See [](./figures.md) for more information about adding and referencing figures a
 The "`Figure 1`" text will be automatically filled in, for example, [](#figure-hover).
 
 :::{figure} ./images/figure-hover.gif
-:name: figure-hover
+:label: figure-hover
 :width: 60%
 :class: framed
 When you cross-reference content in MyST, they become hover-references, allowing you to stay in context when you are reading.
@@ -326,7 +326,7 @@ The export process will run for any known files with `docx` specified in the `ex
 In this case, the default word template was used, resulting in a document formatted like this:
 
 :::{figure} ./images/export-docx.png
-:name: export-docx
+:label: export-docx
 :width: 80%
 Exporting your article to `docx` using `myst export --docx`.
 :::
@@ -437,7 +437,7 @@ You can now see your two-column PDF in a submission ready format for the journal
 Notice also that the PDF has converted dynamic images to a static alternative (e.g. GIFs are now PNGs).
 
 :::{figure} ./images/export-pdf.png
-:name: export-pdf
+:label: export-pdf
 :width: 80%
 Exporting the article to a two column PDF with appropriate metadata to submit to a Journal.
 :::

--- a/docs/quickstart-myst-markdown.md
+++ b/docs/quickstart-myst-markdown.md
@@ -127,7 +127,7 @@ To create a cross-reference, you need to label a "target", like a figure, sectio
 
 ````{myst}
 ```{figure} https://source.unsplash.com/random/500x200/?mountain
-:name: my-fig
+:label: my-fig
 :align: center
 
 My **bold** mountain 🏔🚠.

--- a/docs/quickstart-myst-websites.md
+++ b/docs/quickstart-myst-websites.md
@@ -109,7 +109,7 @@ The example site in this tutorial only has three pages and by default the `01-pa
 
 :::{figure} ./images/frontmatter-before.png
 :width: 50%
-:name: frontmatter-before
+:label: frontmatter-before
 :class: framed
 
 The myst theme for the `01-paper.md` page without any changes made.
@@ -206,7 +206,7 @@ Saving the `myst.yml` will have triggered a "full site rebuild"[^myst-start] and
 
 :::{figure} ./images/frontmatter-site-title.png
 :width: 50%
-:name: frontmatter-site-title
+:label: frontmatter-site-title
 
 The site title will control site meta tags, and the browser-tab title, which is appended to each page title in the `book-theme`.
 :::

--- a/docs/reuse-jupyter-outputs.md
+++ b/docs/reuse-jupyter-outputs.md
@@ -9,7 +9,7 @@ thumbnail: thumbnails/reuse-jupyter-outputs.png
 Notebooks often hold computations that are useful to show in other articles. MyST allows you to add a label, and cross reference and/or embed these outputs directly in other articles. By linking directly to the notebook you can improve the reproducibility of your technical work.
 
 ```{figure} ./images/reuse-jupyter-outputs.png
-:name: reuse-jupyter-outputs
+:label: reuse-jupyter-outputs
 A scientific article with two figures created in Jupyter Notebooks. Each figure can be labeled directly in the notebook and reused in any other page directly.
 ```
 
@@ -45,7 +45,7 @@ The labeled output can also be used in `figure` directive, where you can then ad
 or
 
 :::{figure} #my-cell
-:name: fig-my-cell
+:label: fig-my-cell
 :::
 ```
 

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -41,7 +41,7 @@ You can use the {myst:directive}`table` directive to add a caption to a markdown
 ````{myst}
 ```{list-table} This table title
 :header-rows: 1
-:name: example-table
+:label: example-table
 
 * - Training
   - Validation

--- a/packages/myst-parser/docs/extending/directives.md
+++ b/packages/myst-parser/docs/extending/directives.md
@@ -4,7 +4,7 @@ Let's explore creating a `figure` directive, which takes an image `src` as an `a
 
 ````markdown
 ```{figure} ../image.png
-:name: my-figure
+:label: my-figure
 
 A cool caption! 😎
 ```

--- a/packages/myst-parser/tests/directives.math.md
+++ b/packages/myst-parser/tests/directives.math.md
@@ -24,7 +24,7 @@ w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 Math directive:
 .
 ```{math}
-:name: a-test
+:label: a-test
 w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 ```
 .

--- a/packages/myst-parser/tests/roles.references.md
+++ b/packages/myst-parser/tests/roles.references.md
@@ -1,12 +1,12 @@
 Testing named figures and numbered references:
 .
 ```{figure} https://jupyterbook.org/_static/logo.png
-:name: test3
+:label: test3
 The Jupyter Book Logo!
 ```
 
 ```{figure} https://jupyterbook.org/_static/logo.png
-:name: test4
+:label: test4
 The Jupyter Book Logo again!
 ```
 The reference to {ref}`test3` and {ref}`test4`.


### PR DESCRIPTION
This is an attempt at very-dumbly swapping out `:name: ` and replacing it with `:label: `, since I believe that is the preferred nomenclature moving forward. I saw a few different uses in the docs and it was confusing me.

This is just a find/replace, so it might miss some stuff, but I wanted to see how far I'd get by doing it the easy way.

- closes #1068 