### PR TITLE
🐛 Set notebook path relative to session manager path

### DIFF
--- a/.changeset/tiny-bikes-invite.md
+++ b/.changeset/tiny-bikes-invite.md
@@ -1,0 +1,6 @@
+---
+"myst-execute": patch
+"myst-cli": patch
+---
+
+Define kernel path relative to server base-path

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -223,6 +223,7 @@ export async function transformMdast(
   if (execute) {
     const cachePath = path.join(session.buildPath(), 'execute');
     await kernelExecutionTransform(mdast, vfile, {
+      basePath: session.sourcePath(),
       cache: new LocalDiskCache<(IExpressionResult | IOutput[])[]>(cachePath),
       sessionFactory: () => session.jupyterSessionManager(),
       frontmatter: frontmatter,

--- a/packages/myst-cli/src/session/types.ts
+++ b/packages/myst-cli/src/session/types.ts
@@ -17,6 +17,7 @@ export type ISession = {
   log: Logger;
   reload(): ISession;
   clone(): ISession;
+  sourcePath(): string;
   buildPath(): string;
   sitePath(): string;
   contentPath(): string;

--- a/packages/myst-execute/src/execute.ts
+++ b/packages/myst-execute/src/execute.ts
@@ -259,6 +259,7 @@ function applyComputedOutputsToNodes(
 }
 
 export type Options = {
+  basePath: string;
   cache: ICache<(IExpressionResult | IOutput[])[]>;
   sessionFactory: () => Promise<SessionManager | undefined>;
   frontmatter: PageFrontmatter;
@@ -309,7 +310,7 @@ export async function kernelExecutionTransform(tree: GenericParent, vfile: VFile
     else {
       let sessionConnection: Session.ISessionConnection | undefined;
       const sessionOpts = {
-        path: vfile.path,
+        path: path.relative(opts.basePath, vfile.path),
         type: 'notebook',
         name: path.basename(vfile.path),
         kernel: {

--- a/packages/myst-execute/tests/run.spec.ts
+++ b/packages/myst-execute/tests/run.spec.ts
@@ -78,7 +78,7 @@ casesList.forEach(({ title, cases }) => {
         file.path = path.join(__dirname, 'notebook.ipynb');
 
         await kernelExecutionTransform(before, file, {
-	      basePath: __dirname,
+          basePath: __dirname,
           sessionFactory: async () => await sessionManagerFactory.load(),
           cache: noOpCache,
           frontmatter: {

--- a/packages/myst-execute/tests/run.spec.ts
+++ b/packages/myst-execute/tests/run.spec.ts
@@ -78,6 +78,7 @@ casesList.forEach(({ title, cases }) => {
         file.path = path.join(__dirname, 'notebook.ipynb');
 
         await kernelExecutionTransform(before, file, {
+	  basePath: __dirname,
           sessionFactory: async () => await sessionManagerFactory.load(),
           cache: noOpCache,
           frontmatter: {

--- a/packages/myst-execute/tests/run.spec.ts
+++ b/packages/myst-execute/tests/run.spec.ts
@@ -78,7 +78,7 @@ casesList.forEach(({ title, cases }) => {
         file.path = path.join(__dirname, 'notebook.ipynb');
 
         await kernelExecutionTransform(before, file, {
-	  basePath: __dirname,
+	      basePath: __dirname,
           sessionFactory: async () => await sessionManagerFactory.load(),
           cache: noOpCache,
           frontmatter: {


### PR DESCRIPTION
It turns out that the notebook path that is passed to the session manager should be given relative to the server base-path!