### PR TITLE
🪆 Add support for nested parsing

### DIFF
--- a/.changeset/mean-windows-hammer.md
+++ b/.changeset/mean-windows-hammer.md
@@ -1,0 +1,6 @@
+---
+"myst-common": minor
+"myst-parser": minor
+---
+
+Add support for nested parsing via a context object

--- a/packages/myst-common/src/index.ts
+++ b/packages/myst-common/src/index.ts
@@ -38,6 +38,7 @@ export type {
   DirectiveData,
   RoleData,
   DirectiveSpec,
+  DirectiveContext,
   RoleSpec,
   ParseTypes,
   MystPlugin,

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -85,7 +85,7 @@ export type RoleData = {
 };
 
 export type DirectiveContext = {
-  parseMyST: (source: string) => GenericParent;
+  parseMyST: (source: string, offset?: number) => GenericParent;
 };
 
 export type DirectiveSpec = {

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -85,9 +85,8 @@ export type RoleData = {
 };
 
 export type DirectiveContext = {
-  parseMyST: (source: string) => GenericParent
+  parseMyST: (source: string) => GenericParent;
 };
-
 
 export type DirectiveSpec = {
   name: string;

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -85,7 +85,7 @@ export type RoleData = {
 };
 
 export type DirectiveContext = {
-  parseMyST: (source: string, offset?: number) => GenericParent;
+  parseMyst: (source: string, offset?: number) => GenericParent;
 };
 
 export type DirectiveSpec = {

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -84,6 +84,11 @@ export type RoleData = {
   body?: ParseTypes;
 };
 
+export type DirectiveContext = {
+  parseMyST: (source: string) => GenericParent
+};
+
+
 export type DirectiveSpec = {
   name: string;
   alias?: string[];
@@ -92,7 +97,7 @@ export type DirectiveSpec = {
   options?: Record<string, OptionDefinition>;
   body?: BodyDefinition;
   validate?: (data: DirectiveData, vfile: VFile) => DirectiveData;
-  run: (data: DirectiveData, vfile: VFile) => GenericNode[];
+  run: (data: DirectiveData, vfile: VFile, ctx: DirectiveContext) => GenericNode[];
 };
 
 export type RoleSpec = {

--- a/packages/myst-parser/src/directives.ts
+++ b/packages/myst-parser/src/directives.ts
@@ -14,7 +14,7 @@ import type { Directive } from 'myst-spec';
 
 type MystDirectiveNode = GenericNode & {
   name: string;
-}
+};
 /**
  * Apply directive `run()` methods to build directive ASTs.
  *

--- a/packages/myst-parser/src/directives.ts
+++ b/packages/myst-parser/src/directives.ts
@@ -15,11 +15,9 @@ type MystDirectiveNode = GenericNode & {
   name: string;
 };
 
-
 export type DirectiveContext = {
   parseMyST: (source: string) => GenericParent;
 };
-
 
 /**
  * Apply directive `run()` methods to build directive ASTs.
@@ -28,7 +26,12 @@ export type DirectiveContext = {
  * @param specs - record mapping from names to directive implementations
  * @param vfile
  */
-export function applyDirectives(tree: GenericParent, specs: DirectiveSpec[], vfile: VFile, ctx: DirectiveContext) {
+export function applyDirectives(
+  tree: GenericParent,
+  specs: DirectiveSpec[],
+  vfile: VFile,
+  ctx: DirectiveContext,
+) {
   // Record mapping from alias-or-name to directive spec
   const specLookup: Record<string, DirectiveSpec> = {};
   specs.forEach((spec) => {

--- a/packages/myst-parser/src/directives.ts
+++ b/packages/myst-parser/src/directives.ts
@@ -2,6 +2,7 @@ import type {
   GenericNode,
   DirectiveData,
   DirectiveSpec,
+  DirectiveContext,
   ParseTypes,
   GenericParent,
 } from 'myst-common';
@@ -13,12 +14,7 @@ import type { Directive } from 'myst-spec';
 
 type MystDirectiveNode = GenericNode & {
   name: string;
-};
-
-export type DirectiveContext = {
-  parseMyST: (source: string) => GenericParent;
-};
-
+}
 /**
  * Apply directive `run()` methods to build directive ASTs.
  *
@@ -209,6 +205,10 @@ export function applyDirectives(
     if (validate) {
       data = validate(data, vfile);
     }
-    node.children = run(data, vfile, ctx);
+    node.children = run(data, vfile, {
+      // Implement a parseMyST function that accepts _relative_ line numbers
+      parseMyST: (source: string, offset: number = 0) =>
+        ctx.parseMyST(source, offset + node.pos[0]),
+    });
   });
 }

--- a/packages/myst-parser/src/directives.ts
+++ b/packages/myst-parser/src/directives.ts
@@ -206,9 +206,9 @@ export function applyDirectives(
       data = validate(data, vfile);
     }
     node.children = run(data, vfile, {
-      // Implement a parseMyST function that accepts _relative_ line numbers
-      parseMyST: (source: string, offset: number = 0) =>
-        ctx.parseMyST(source, offset + node.pos[0]),
+      // Implement a parseMyst function that accepts _relative_ line numbers
+      parseMyst: (source: string, offset: number = 0) =>
+        ctx.parseMyst(source, offset + node.pos[0]),
     });
   });
 }

--- a/packages/myst-parser/src/directives.ts
+++ b/packages/myst-parser/src/directives.ts
@@ -15,10 +15,23 @@ type MystDirectiveNode = GenericNode & {
   name: string;
 };
 
+
+export type DirectiveContext = {};
+
+
+/**
+ * Apply directive `run()` methods to build directive ASTs.
+ *
+ * @param tree - raw MDAST containing mystDirectives
+ * @param specs - record mapping from names to directive implementations
+ * @param vfile
+ */
 export function applyDirectives(tree: GenericParent, specs: DirectiveSpec[], vfile: VFile) {
+  // Record mapping from alias-or-name to directive spec
   const specLookup: Record<string, DirectiveSpec> = {};
   specs.forEach((spec) => {
     const names = [spec.name];
+    // Wrap single-string `alias` fields as an array
     if (spec.alias) {
       names.push(...(typeof spec.alias === 'string' ? [spec.alias] : spec.alias));
     }
@@ -32,6 +45,7 @@ export function applyDirectives(tree: GenericParent, specs: DirectiveSpec[], vfi
       }
     });
   });
+  // Find all raw directive nodes
   const nodes = selectAll('mystDirective', tree) as MystDirectiveNode[];
   nodes.forEach((node) => {
     const { name } = node;
@@ -190,6 +204,6 @@ export function applyDirectives(tree: GenericParent, specs: DirectiveSpec[], vfi
     if (validate) {
       data = validate(data, vfile);
     }
-    node.children = run(data, vfile);
+    node.children = run(data, vfile, ctx);
   });
 }

--- a/packages/myst-parser/src/directives.ts
+++ b/packages/myst-parser/src/directives.ts
@@ -47,8 +47,9 @@ export function applyDirectives(
     });
   });
   // Find all raw directive nodes
-  const nodes = selectAll('mystDirective', tree) as MystDirectiveNode[];
+  const nodes = selectAll('mystDirective[processed=false]', tree) as MystDirectiveNode[];
   nodes.forEach((node) => {
+    delete node.processed; // Indicate that the directive has been processed
     const { name } = node;
     const spec = specLookup[name];
     if (!spec) {

--- a/packages/myst-parser/src/directives.ts
+++ b/packages/myst-parser/src/directives.ts
@@ -208,7 +208,7 @@ export function applyDirectives(
     node.children = run(data, vfile, {
       // Implement a parseMyst function that accepts _relative_ line numbers
       parseMyst: (source: string, offset: number = 0) =>
-        ctx.parseMyst(source, offset + node.pos[0]),
+        ctx.parseMyst(source, offset + node.position!.start.line),
     });
   });
 }

--- a/packages/myst-parser/src/directives.ts
+++ b/packages/myst-parser/src/directives.ts
@@ -16,7 +16,9 @@ type MystDirectiveNode = GenericNode & {
 };
 
 
-export type DirectiveContext = {};
+export type DirectiveContext = {
+  parseMyST: (source: string) => GenericParent;
+};
 
 
 /**
@@ -26,7 +28,7 @@ export type DirectiveContext = {};
  * @param specs - record mapping from names to directive implementations
  * @param vfile
  */
-export function applyDirectives(tree: GenericParent, specs: DirectiveSpec[], vfile: VFile) {
+export function applyDirectives(tree: GenericParent, specs: DirectiveSpec[], vfile: VFile, ctx: DirectiveContext) {
   // Record mapping from alias-or-name to directive spec
   const specLookup: Record<string, DirectiveSpec> = {};
   specs.forEach((spec) => {

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -93,7 +93,7 @@ export function mystParse(content: string, opts?: Options) {
   const parsedOpts = parseOptions(opts);
   const tokenizer = createTokenizer(parsedOpts);
   const tree = tokensToMyst(content, tokenizer.parse(content, { vfile }), parsedOpts.mdast);
-  applyDirectives(tree, parsedOpts.directives, parsedOpts.vfile);
+  applyDirectives(tree, parsedOpts.directives, parsedOpts.vfile, { parseMyST: (source: string) => mystParse(source, opts) });
   applyRoles(tree, parsedOpts.roles, parsedOpts.vfile);
   return tree;
 }

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -95,7 +95,7 @@ export function mystParse(content: string, opts?: Options) {
   const tokenizer = createTokenizer(parsedOpts);
   const tree = tokensToMyst(content, tokenizer.parse(content, { vfile }), parsedOpts.mdast);
   applyDirectives(tree, parsedOpts.directives, parsedOpts.vfile, {
-    parseMyST: (source: string, offset: number = 0) => {
+    parseMyst: (source: string, offset: number = 0) => {
       const mdast = mystParse(source, opts);
       // Fix-up the node's (global) position offsets
       visit(mdast, (node) => {

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -96,15 +96,15 @@ export function mystParse(content: string, opts?: Options) {
   const tree = tokensToMyst(content, tokenizer.parse(content, { vfile }), parsedOpts.mdast);
   applyDirectives(tree, parsedOpts.directives, parsedOpts.vfile, {
     parseMyST: (source: string, offset: number = 0) => {
-      const tree = mystParse(source, opts);
+      const mdast = mystParse(source, opts);
       // Fix-up the node's (global) position offsets
-      visit(tree, (node) => {
+      visit(mdast, (node) => {
         if (node.position) {
           node.position.start.line += offset;
           node.position.end.line += offset;
         }
       });
-      return tree;
+      return mdast;
     },
   });
   applyRoles(tree, parsedOpts.roles, parsedOpts.vfile);

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -93,7 +93,9 @@ export function mystParse(content: string, opts?: Options) {
   const parsedOpts = parseOptions(opts);
   const tokenizer = createTokenizer(parsedOpts);
   const tree = tokensToMyst(content, tokenizer.parse(content, { vfile }), parsedOpts.mdast);
-  applyDirectives(tree, parsedOpts.directives, parsedOpts.vfile, { parseMyST: (source: string) => mystParse(source, opts) });
+  applyDirectives(tree, parsedOpts.directives, parsedOpts.vfile, {
+    parseMyST: (source: string) => mystParse(source, opts),
+  });
   applyRoles(tree, parsedOpts.roles, parsedOpts.vfile);
   return tree;
 }

--- a/packages/myst-parser/src/roles.ts
+++ b/packages/myst-parser/src/roles.ts
@@ -82,8 +82,9 @@ export function applyRoles(tree: GenericParent, specs: RoleSpec[], vfile: VFile)
       }
     });
   });
-  const nodes = selectAll('mystRole', tree) as MystRoleNode[];
+  const nodes = selectAll('mystRole[processed=false]', tree) as MystRoleNode[];
   nodes.forEach((node) => {
+    delete node.processed; // Indicate that the role has been processed
     const { name } = node;
     const spec = specLookup[name];
     if (!spec) {

--- a/packages/myst-parser/src/tokensToMyst.ts
+++ b/packages/myst-parser/src/tokensToMyst.ts
@@ -380,6 +380,7 @@ const defaultMdast: Record<string, TokenHandlerSpec> = {
         options: t.meta?.options,
         value: t.content || undefined,
         tight: t.meta?.tight || undefined,
+        processed: false,
       };
     },
   },
@@ -418,6 +419,7 @@ const defaultMdast: Record<string, TokenHandlerSpec> = {
       return {
         name: t.info,
         value: t.content,
+        processed: false,
       };
     },
   },

--- a/packages/myst-parser/tests/recursiveParsing.spec.ts
+++ b/packages/myst-parser/tests/recursiveParsing.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest';
+import { VFile } from 'vfile';
+import { mystParse } from '../src';
+import { basicTransformations } from 'myst-transforms';
+import { selectAll } from 'unist-util-select';
+import type { DirectiveSpec, GenericNode } from 'myst-common';
+import { subscriptRole } from 'myst-roles';
+
+const parseAgain: DirectiveSpec = {
+  name: 'parse',
+  body: { type: String },
+  run(data, file, ctx) {
+    const lines = (data.body as string).split('\n');
+    const skippedLine = lines.slice(1).join('\n');
+    const result = ctx.parseMyst(skippedLine, 1); // add 1 to the offset!
+    return [
+      { type: 'parse', children: result.children, data: { firstLine: lines[0] } },
+    ] as GenericNode[];
+  },
+};
+
+describe('recursive parsing', () => {
+  test('', () => {
+    const src = `::::{parse}
+first line
+:::{parse}
+second line
+H{sub}\`2\`O
+:::
+::::
+`;
+    const vfile = new VFile();
+    const tree = mystParse(src, { directives: [parseAgain], roles: [subscriptRole] });
+    basicTransformations(tree, vfile, {});
+    const [one, two] = selectAll('parse', tree);
+    expect(one.data?.firstLine).toBe('first line');
+    expect(two.data?.firstLine).toBe('second line');
+    const paragraphs = selectAll('paragraph', tree);
+    expect(paragraphs.length).toBe(1);
+    expect(paragraphs[0].position?.start.line).toBe(5);
+    expect(paragraphs[0].position?.end.line).toBe(5);
+    const text = selectAll('text', tree);
+    expect(text.length).toBe(2);
+    expect(text[0].position?.end.line).toBe(5);
+    expect(text[1].position?.end.line).toBe(5);
+    const subscript = selectAll('subscript', tree);
+    expect(subscript.length).toBe(1);
+    expect(subscript[1].position?.end.line).toBe(5);
+  });
+});

--- a/packages/myst-parser/tests/recursiveParsing.spec.ts
+++ b/packages/myst-parser/tests/recursiveParsing.spec.ts
@@ -31,7 +31,7 @@ H{sub}\`2\`O
 `;
     const vfile = new VFile();
     const tree = mystParse(src, { directives: [parseAgain], roles: [subscriptRole] });
-    basicTransformations(tree, vfile, {});
+    // basicTransformations(tree, vfile, {});
     const [one, two] = selectAll('parse', tree);
     expect(one.data?.firstLine).toBe('first line');
     expect(two.data?.firstLine).toBe('second line');
@@ -40,11 +40,14 @@ H{sub}\`2\`O
     expect(paragraphs[0].position?.start.line).toBe(5);
     expect(paragraphs[0].position?.end.line).toBe(5);
     const text = selectAll('text', tree);
-    expect(text.length).toBe(2);
-    expect(text[0].position?.end.line).toBe(5);
-    expect(text[1].position?.end.line).toBe(5);
-    const subscript = selectAll('subscript', tree);
+    expect(text.length).toBe(3);
+    expect(text[0].position?.start.line).toBe(5);
+    expect(text[1].position?.start.line).toBe(5);
+    expect(text[2].position?.start.line).toBe(5);
+    const mystRole = selectAll('mystRole', tree) as GenericNode[];
+    expect(mystRole.length).toBe(1);
+    expect(mystRole[0].position?.start.line).toBe(5);
+    const subscript = selectAll('subscript', tree) as GenericNode[];
     expect(subscript.length).toBe(1);
-    expect(subscript[1].position?.end.line).toBe(5);
   });
 });

--- a/packages/myst-parser/tests/recursiveParsing.spec.ts
+++ b/packages/myst-parser/tests/recursiveParsing.spec.ts
@@ -1,7 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { VFile } from 'vfile';
 import { mystParse } from '../src';
-import { basicTransformations } from 'myst-transforms';
 import { selectAll } from 'unist-util-select';
 import type { DirectiveSpec, GenericNode } from 'myst-common';
 import { subscriptRole } from 'myst-roles';
@@ -29,9 +27,7 @@ H{sub}\`2\`O
 :::
 ::::
 `;
-    const vfile = new VFile();
     const tree = mystParse(src, { directives: [parseAgain], roles: [subscriptRole] });
-    // basicTransformations(tree, vfile, {});
     const [one, two] = selectAll('parse', tree);
     expect(one.data?.firstLine).toBe('first line');
     expect(two.data?.firstLine).toBe('second line');

--- a/packages/myst-transforms/src/basic.ts
+++ b/packages/myst-transforms/src/basic.ts
@@ -15,7 +15,7 @@ import { removeUnicodeTransform } from './removeUnicode.js';
 import { containerChildrenTransform } from './containers.js';
 import { headingDepthTransform } from './headings.js';
 
-export function basicTransformations(tree: GenericParent, file: VFile, opts: Record<string, any>) {
+export function basicTransformations(tree: GenericParent, file: VFile, opts?: Record<string, any>) {
   // lifting roles and directives must happen before the mystTarget transformation
   liftMystDirectivesAndRolesTransform(tree);
   // Some specifics about the ordering are noted below


### PR DESCRIPTION
This is a simple PR to permit MyST directives to invoke the MyST parser.

I don't know whether we'll want to provide a more explicit set of parsing routines, e.g. `parseInline` and `parseBlock`. My hunch is that we can get to that fairly easily using transforms, so it's not necessary.