### PR TITLE
📖 Small updates to contributing and include docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 This page contains pointers and links to help you contribute to this project.
 
+> [!TIP]
+> See [our comprehensive contributing guide](https://mystmd.org/guide/contributing) for more information about how to contribute to the project.
+> This page helps you get started, but that resource has much more information.
+
+<!-- MYST START -->
+
 ## Our team compass
 
 The [Executable Books Team Compass][compass] is a source of truth for our team structure and policy.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,4 +4,5 @@ short_title: Contribution Guide
 ---
 
 ```{include} ../CONTRIBUTING.md
+:start-after: "<!-- MYST START -->"
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,6 +3,8 @@ title: Contribution Guide
 short_title: Contribution Guide
 ---
 
+% start-after doesn't currently work with {include} so this will just include the whole file
+% Tracking issue: https://github.com/executablebooks/mystmd/issues/1096
 ```{include} ../CONTRIBUTING.md
 :start-after: "<!-- MYST START -->"
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,5 +6,5 @@ short_title: Contribution Guide
 % start-after doesn't currently work with {include} so this will just include the whole file
 % Tracking issue: https://github.com/executablebooks/mystmd/issues/1096
 ```{include} ../CONTRIBUTING.md
-:start-after: "<!-- MYST START -->"
+:start-after: <!-- MYST START -->
 ```

--- a/docs/embed.md
+++ b/docs/embed.md
@@ -29,6 +29,10 @@ Here's a cool figure.
 
 ## The `{embed}` directive
 
+The `{embed}` directive allows you to insert snippets of content at the time a page is rendered.
+
+See {myst:directive}`the {embed} directive documentation <embed>` for details about all the arguments you can give to `{embed}`.
+
 The {myst:directive}`embed` directive can be used like so:
 
 ````myst
@@ -51,6 +55,7 @@ For example, the following references the admonitions list in [](admonitions.md)
 ```{embed} #admonitions-list
 
 ```
+
 
 ### The `![](#embed)` short-hand
 
@@ -109,6 +114,8 @@ For instructions on how to embed notebook content, see [](./reuse-jupyter-output
 
 If a portion of your content is in a separate file that is **not already included in your project** you can use the {myst:directive}`include` directive to parse and include that content.
 This directive is helpful for including content snippets, such as a table, equation, that you want to keep in a different file on disk, but present as if it were one document. In addition to Markdown, MyST will also parse `.ipynb`, `.tex`, and `.html`.
+
+See {myst:directive}`the {include} directive documentation <include>` for details about all the arguments you can give to `{include}`.
 
 :::{prf:example} Equation Bank
 :label: eg:equation-bank


### PR DESCRIPTION
I noticed that we were pulling in the `# Contributing` title markdown in our `{include}` statement for the contributing guide. I decided to try using the `start-after` argument to see if we can remove that content from the MyST site. In the process I also added an easier-to-find link to the reference docs for both `{embed}` and `{include}`.

### Question: Am I using `{include}` wrong?

I used the `start-after` argument similar to how it's used in Sphinx, and assumed it'd work since it is documented. However it's not cutting off the top part of the included page. I wonder if this is a bug or if I'm using it incorrectly. @rowanc1 or @fwkoch do you have guidance?

### Blockers

- [ ] https://github.com/executablebooks/mystmd/issues/1096