### PR TITLE
📓 Respect part aliases in parts frontmatter and extractPart function

### DIFF
--- a/.changeset/fast-pigs-breathe.md
+++ b/.changeset/fast-pigs-breathe.md
@@ -1,0 +1,6 @@
+---
+'myst-frontmatter': patch
+'myst-common': patch
+---
+
+Respect part aliases in parts frontmatter and extractPart function

--- a/.changeset/flat-pears-poke.md
+++ b/.changeset/flat-pears-poke.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Allow getCitation node to be optional

--- a/packages/myst-cli/src/transforms/dois.ts
+++ b/packages/myst-cli/src/transforms/dois.ts
@@ -183,7 +183,7 @@ export async function getCitation(
   session: ISession,
   vfile: VFile,
   doiString: string,
-  node: GenericNode,
+  node?: GenericNode,
 ): Promise<SingleCitationRenderer | null> {
   if (!doi.validate(doiString)) return null;
   const data = await resolveDoiOrg(session, doiString);

--- a/packages/myst-common/src/extractParts.spec.ts
+++ b/packages/myst-common/src/extractParts.spec.ts
@@ -174,6 +174,76 @@ describe('extractPart', () => {
       ],
     });
   });
+  it('part aliases are respected as part', async () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          children: [{ type: 'text', value: 'no part' }],
+        },
+        {
+          type: 'block' as any,
+          data: { part: 'Acknowledgements' },
+          children: [{ type: 'text', value: 'e between g and m' }],
+        },
+      ],
+    };
+    expect(extractPart(tree, 'acknowledgments')).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          data: { part: 'acknowledgments' },
+          children: [{ type: 'text', value: 'e between g and m' }],
+        },
+      ],
+    });
+    expect(tree).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          children: [{ type: 'text', value: 'no part' }],
+        },
+      ],
+    });
+  });
+  it('part aliases are respected as input', async () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          children: [{ type: 'text', value: 'no part' }],
+        },
+        {
+          type: 'block' as any,
+          data: { part: 'Acknowledgments' },
+          children: [{ type: 'text', value: 'no e between g and m' }],
+        },
+      ],
+    };
+    expect(extractPart(tree, 'ack')).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          data: { part: 'acknowledgments' },
+          children: [{ type: 'text', value: 'no e between g and m' }],
+        },
+      ],
+    });
+    expect(tree).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          children: [{ type: 'text', value: 'no part' }],
+        },
+      ],
+    });
+  });
 });
 
 describe('extractImplicitPart', () => {

--- a/packages/myst-common/src/extractParts.ts
+++ b/packages/myst-common/src/extractParts.ts
@@ -3,13 +3,27 @@ import type { GenericNode, GenericParent } from './types.js';
 import { remove } from 'unist-util-remove';
 import { selectAll } from 'unist-util-select';
 import { copyNode, toText } from './utils.js';
+import { FRONTMATTER_ALIASES } from 'myst-frontmatter';
 
 function coercePart(part?: string | string[]): string[] {
   if (!part) {
     // Prevent an undefined, null or empty part comparison
     return [];
   }
-  return typeof part === 'string' ? [part.toLowerCase()] : part.map((s) => s.toLowerCase());
+  if (typeof part === 'string') return coercePart([part]);
+  const parts: string[] = [];
+  part
+    .map((p) => p.toLowerCase())
+    .forEach((p) => {
+      parts.push(p);
+      Object.entries(FRONTMATTER_ALIASES).forEach(([alias, value]) => {
+        if (p === alias || p === value) {
+          if (!parts.includes(value)) parts.unshift(value);
+          if (!parts.includes(alias)) parts.push(alias);
+        }
+      });
+    });
+  return parts;
 }
 
 /**

--- a/packages/myst-frontmatter/src/page/validators.ts
+++ b/packages/myst-frontmatter/src/page/validators.ts
@@ -5,7 +5,6 @@ import {
   validateList,
   validateObjectKeys,
   validateString,
-  validateObject,
   validationError,
   validateBoolean,
 } from 'simple-validators';
@@ -57,7 +56,11 @@ export function validatePageFrontmatterKeys(value: Record<string, any>, opts: Va
   const partsOptions = incrementOptions('parts', opts);
   let parts: Record<string, any> | undefined;
   if (defined(value.parts)) {
-    parts = validateObject(value.parts, partsOptions);
+    parts = validateObjectKeys(
+      value.parts,
+      { optional: PAGE_KNOWN_PARTS, alias: FRONTMATTER_ALIASES },
+      { keepExtraKeys: true, suppressWarnings: true, ...partsOptions },
+    );
   }
   PAGE_KNOWN_PARTS.forEach((partKey) => {
     if (defined(value[partKey])) {

--- a/packages/myst-frontmatter/src/site/types.ts
+++ b/packages/myst-frontmatter/src/site/types.ts
@@ -37,6 +37,8 @@ export const FRONTMATTER_ALIASES = {
   part: 'parts',
   ack: 'acknowledgments',
   acknowledgements: 'acknowledgments',
+  acknowledgment: 'acknowledgments',
+  acknowledgement: 'acknowledgments',
   availability: 'data_availability',
   dataAvailability: 'data_availability',
   'data-availability': 'data_availability',


### PR DESCRIPTION
We have some "known parts" that we respect in frontmatter validation, e.g. `acknowledgments`, `abstract`. These also have aliases (in the same pattern as other frontmatter aliases), e.g. `acknowledgments` -> `acknowledgements`, `ack`.

However, these aliases were only respected for _top-level_ frontmatter keys; they were not respected when nested under `parts`, nor when called upon in `extractPart`.

Examples:
```
---
ack: Thank you!
---
```
would coerce to 
```
---
parts:
  acknowledgments: Thank you!
---
```
but
```
---
parts:
  ack: Thank you!
---
```
would remain unchanged during validation.

Also, `extractPart(tree, 'ack')` would not pick up on `part: acknowledgments`.

This PR updates frontmatter and `extractPart` to respect the aliases and coerce/extract consistently.
