### PR TITLE
🚦 Change severity of the error messages

### DIFF
--- a/.changeset/sixty-ducks-hug.md
+++ b/.changeset/sixty-ducks-hug.md
@@ -1,0 +1,6 @@
+---
+"myst-config": patch
+"myst-cli": patch
+---
+
+Add error_rules to turn off warnings and errors in the CLI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Below is a list of relevant repositories and a brief description of each.
 - [MyST Templates](https://github.com/myst-templates): Repositories that contain templates for rendering MyST documents into various outputs like LaTeX, JATS, Typst, and Docx.
 
 > [!NOTE]
-> There are many repositories with similar functionality in the `executablebooks/` organization. Many of these are based around the [Sphinx documentation ecosystem](https://sphinx-doc.org). For example, the [MyST-NB repository](https://github.com/executablebooks/myst-nb) is a Sphinx extension for Jupyter notebooks, and the [MyST Parser repository](https://github.com/executablebooks/myst-parser) is a MyST markdown parser for Sphinx.
+> There are many repositories with similar functionality in the `executablebooks/` organization. Many of these are based around the [Sphinx documentation ecosystem](https://www.sphinx-doc.org). For example, the [MyST-NB repository](https://github.com/executablebooks/myst-nb) is a Sphinx extension for Jupyter notebooks, and the [MyST Parser repository](https://github.com/executablebooks/myst-parser) is a MyST markdown parser for Sphinx.
 
 ## Contribution workflow
 

--- a/docs/creating-pdf-documents.md
+++ b/docs/creating-pdf-documents.md
@@ -35,7 +35,7 @@ exports:
 ---
 ```
 
-To build the exports, use the `myst build` command, which will work with your [project structure](./project-overview.md) if it exists and create a document in the output path that you specify.
+To build the exports, use the `myst build` command, which will work with your project structure if it exists and create a document in the output path that you specify.
 
 ```bash
 myst build my-document.md --pdf
@@ -54,7 +54,7 @@ The default PDF renderer uses $\LaTeX$ to create PDFs, which means that to work 
 As an alternative, for faster PDF builds, you may use [Typst](#rendering-pdfs-with-typst) instead.
 ```
 
-The rendering process for scientific PDFs uses $\LaTeX$ and makes use of the [`jtex`](myst:jtex) templating library, to convert to $\LaTeX$ the [`myst-to-tex`](myst:myst-to-tex) packages is used. The libraries work together for sharing information about [frontmatter](./frontmatter.md) (e.g. title, keywords, authors, and affiliations).
+The rendering process for scientific PDFs uses $\LaTeX$ and makes use of the [`jtex`](myst:jtex) templating library, to convert to $\LaTeX$ the `myst-to-tex` packages is used. The libraries work together for sharing information about [frontmatter](./frontmatter.md) (e.g. title, keywords, authors, and affiliations).
 
 ```{mermaid}
 flowchart LR

--- a/docs/creating-word-documents.md
+++ b/docs/creating-word-documents.md
@@ -29,7 +29,7 @@ exports:
 ---
 ```
 
-To build the exports, use the `myst build` command, which will work with your [project structure](./project-overview.md) if it exists and create a document in the output path that you specify.
+To build the exports, use the `myst build` command, which will work with your project structure if it exists and create a document in the output path that you specify.
 
 ```bash
 myst build my-document.md --docx
@@ -69,7 +69,7 @@ To fix equations in Word, use the equation toolbar to select `LaTeX` and from th
 
 ## Rendering Word with `myst-to-docx`
 
-The rendering process for word documents uses the [`myst-to-docx`](myst:myst-to-docx) package. The library works together with `mystmd` for sharing information about [frontmatter](./frontmatter.md) (e.g. title, keywords, authors, and affiliations).
+The rendering process for word documents uses the `myst-to-docx` package. The library works together with `mystmd` for sharing information about [frontmatter](./frontmatter.md) (e.g. title, keywords, authors, and affiliations).
 
 ```{mermaid}
 flowchart LR

--- a/docs/execute-notebooks.md
+++ b/docs/execute-notebooks.md
@@ -8,7 +8,7 @@ thumbnail: thumbnails/execute-notebooks.png
 ## Overview
 
 :::{warning} MyST Execution is in Beta
-We are adding support for executing markdown notebooks and ipynb files, including inline execution. As we are adding this functionality we appreciate any feedback from the community on how it is working in your environments. Please add [issues](https://github.com/executablebooks/MyST/issues/new) or join [Discord](https://discord.MyST.org/) to give feedback.
+We are adding support for executing markdown notebooks and ipynb files, including inline execution. As we are adding this functionality we appreciate any feedback from the community on how it is working in your environments. Please add [issues](https://github.com/executablebooks/mystmd/issues/new) or join [Discord](https://discord.mystmd.org/) to give feedback.
 :::
 
 The MyST CLI can execute your notebooks and markdown files by passing the `--execute` flag to the `start` and `build` commands, i.e.:
@@ -18,15 +18,18 @@ myst start --execute
 myst build --execute
 ```
 
-If the flag is passed, notebook cells and inline execution will be executed and the original notebook values ignored. By default, execution is disabled and will use the notebook outputs already saved in the notebook (for text-based notebooks, there are no outputs). The notebook outputs are cached based on the source to allow for speedy editing workflows of text without having to re-execute your notebooks. 
+If the flag is passed, notebook cells and inline execution will be executed and the original notebook values ignored. By default, execution is disabled and will use the notebook outputs already saved in the notebook (for text-based notebooks, there are no outputs). The notebook outputs are cached based on the source to allow for speedy editing workflows of text without having to re-execute your notebooks.
 
 ## Launching a Server
 
 MyST performs execution of notebooks by communication with a Jupyter Server. Jupyter Server is distributed as a Python package, which can be installed from PyPI or conda-forge, e.g.
+
 ```bash
 pip install jupyter-server
 ```
+
 Jupyter Server is only responsible for orchestrating execution of your code. To actually perform execution, you must also install a kernel. For Python, this might be `ipykernel`, e.g.
+
 ```bash
 pip install ipykernel
 ```
@@ -35,6 +38,7 @@ If Jupyter Server is installed and the `--execute` flag is passed to `myst start
 
 :::{note}
 Advanced users may wish to connect to non-local Jupyter Servers, e.g. those running on a remote server. It is possible to instruct MyST to connect to a remote server by setting the `JUPYTER_BASE_URL` and `JUPYTER_TOKEN` environment variables, e.g.
+
 ```bash
 # Set local environment variable
 port="8888"
@@ -52,11 +56,13 @@ myst build --execute
 # Stop server!
 kill %1
 ```
+
 :::
 
 ## Caching Outputs
 
 By default MyST caches the execution of a notebook according to its executable content. In simple terms, this means that MyST avoids re-running a kernel over a notebook if the notebook's code and inline-expressions do not change. This may not always be correct; if the execution environment (e.g. installed Python packages) changes, you may wish to re-run the notebook. For now, you can clear the execution cache with
+
 ```bash
 myst clean --execute
 ```

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -39,7 +39,7 @@ Without the extension installed, remember to format the contents of the section 
 
 :::{note} Using `jupytext` or a Markdown-based notebook?
 :class: dropdown
-If your Jupyter Notebook is described as a markdown file (e.g. using [jupytext](https://jupytext.readthedocs.io/en/latest/formats.html), or [MyST](https://jupyterbook.org/en/stable/file-types/myst-notebooks.html)), then this should be included in the frontmatter section as usual in addition to the `jupyter` key that defines the kernel and jupytext metadata.
+If your Jupyter Notebook is described as a markdown file (e.g. using [jupytext](https://jupytext.readthedocs.io/en/latest/formats-markdown.html), or [MyST](https://jupyterbook.org/en/stable/file-types/myst-notebooks.html)), then this should be included in the frontmatter section as usual in addition to the `jupyter` key that defines the kernel and jupytext metadata.
 :::
 
 ### In a `myst.yml` file

--- a/docs/integrating-jupyter.md
+++ b/docs/integrating-jupyter.md
@@ -256,7 +256,7 @@ For more on working locally see [](#start-a-local-jupyter-server).
 
 ```{danger} On securing a Jupyter server
 :class: dropdown
-If you intend to run a dedicate single user Jupyter server accessible over a network please carefully read and follow [the advice provided by the Jupyter server team here](https://jupyter-notebook.readthedocs.io/en/stable/public_server.html).
+If you intend to run a dedicate single user Jupyter server accessible over a network please carefully read and follow [the advice provided by the Jupyter server team here](https://jupyter-server.readthedocs.io/en/stable/operators/security.html).
 
 MyST Websites will work best, be safer and be more robust when backed by Jupyter services such as BinderHub or JupyterHub.
 ```

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -48,6 +48,17 @@ project:
     - directives.mjs
     - unsplash.mjs
     - latex.mjs
+  error_rules:
+    - rule: link-resolves
+      severity: ignore
+      keys:
+        - /robots.txt
+        - /sitemap.xml
+        - /jtex/template-yml
+        - /jtex
+        - /jtex/create-a-latex-template
+        - /jtex/create-a-beamer-template
+        - /jtex/contribute-a-template
 site:
   title: MyST Markdown Guide
   domains:

--- a/docs/proofs-and-theorems.md
+++ b/docs/proofs-and-theorems.md
@@ -85,7 +85,7 @@ You can refer to a proof using the standard link syntax:
 :::{tip} Compatibility with Sphinx Proof
 :class: dropdown
 
-You may also use the the `{prf:ref}` role like: `` {prf:ref}`my-theorem` ``, which will replace the reference with the theorem number like so: {prf:ref}`my-theorem`. When an explicit text is provided, this caption will serve as the title of the reference. For example, `` {prf:ref}`Orthogonal-Projection-Theorem <my-theorem>`  `` will produce: {prf:ref}`Orthogonal-Projection-Theorem <my-theorem>`.
+You may also use the the `{prf:ref}` role like: `` {prf:ref}`my-theorem` ``, which will replace the reference with the theorem number like so: {prf:ref}`my-theorem`. When an explicit text is provided, this caption will serve as the title of the reference. For example, ``{prf:ref}`Orthogonal-Projection-Theorem <my-theorem>` `` will produce: {prf:ref}`Orthogonal-Projection-Theorem <my-theorem>`.
 :::
 
 ## Hiding Proof Content
@@ -198,7 +198,7 @@ $$
 :::
 ```
 
-_Source:_ [QuantEcon](https://python-advanced.quantecon.org/von_neumann_model.html#Duality)
+_Source:_ [QuantEcon](https://python-advanced.quantecon.org)
 
 ### Criteria
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -70,4 +70,4 @@ project:
         - https://flaky-connection.com
 ```
 
-The `severity` of each rule can be set to `ignore`, `warn`, or `error`. If the rule is triggered, then the severity will be adopted rather than the default log message severity. To find out the rule ID, run myst in debug mode to get the error (and optional key) printed to the console.
+The `severity` of each rule can be set to `ignore`, `warn`, or `error`. If the rule is triggered, then the severity listed will be adopted rather than the default log message severity. The default severity for rules included in the list is `ignore`, which means that simply listing the rule IDs as strings will ignore those rules. To discover the rule ID, run myst in debug mode to get the error (and optional key) printed to the console. For example, the above configuration updates will no longer warn on `math-eqnarray-replaced` and will also ignore the two links when running `myst build --check-links --strict` in continuous integration.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -52,3 +52,21 @@ beamer
 
     - `true`: Add `\begin{frame}` environment for each block, delimited by `+++`, and enable presentation outline with block metadata `+++ {"outline":true}`
     - `false` (default): No extra `\begin{frame}` environment will be used
+
+## Error Rules
+
+The `error_rules` list in the project configuration can be used to disable logging rules in the CLI:
+
+```{code-block} yaml
+:filename: myst.yml
+project:
+  error_rules:
+    - rule: math-eqnarray-replaced
+      severity: ignore
+    - rule: doi-check
+      severity: ignore
+      keys:
+        - bibtex_key
+```
+
+The `severity` of each rule can be set to `ignore`, `warn`, or `error`. If the rule is triggered, then the severity will be adopted rather than the default log message severity.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -55,7 +55,7 @@ beamer
 
 ## Error Rules
 
-The `error_rules` list in the project configuration can be used to disable logging rules in the CLI:
+The `error_rules` list in the project configuration can be used to disable or modify logging rules in the CLI:
 
 ```{code-block} yaml
 :filename: myst.yml
@@ -63,10 +63,11 @@ project:
   error_rules:
     - rule: math-eqnarray-replaced
       severity: ignore
-    - rule: doi-check
+    - rule: link-resolves
       severity: ignore
       keys:
-        - bibtex_key
+        - /known-internal-link
+        - https://flaky-connection.com
 ```
 
-The `severity` of each rule can be set to `ignore`, `warn`, or `error`. If the rule is triggered, then the severity will be adopted rather than the default log message severity.
+The `severity` of each rule can be set to `ignore`, `warn`, or `error`. If the rule is triggered, then the severity will be adopted rather than the default log message severity. To find out the rule ID, run myst in debug mode to get the error (and optional key) printed to the console.

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -415,9 +415,10 @@ export async function processSite(session: ISession, opts?: ProcessOptions): Pro
     if (hasWarnings[0] > 0) {
       const pluralE = hasWarnings[0] > 1 ? 's' : '';
       const pluralW = hasWarnings[1] > 1 ? 's' : '';
-      throw new Error(
+      session.log.error(
         `Site has ${hasWarnings[0]} error${pluralE} and ${hasWarnings[1]} warning${pluralW}, stopping build.`,
       );
+      process.exit(1);
     }
   }
   if (opts?.writeFiles ?? true) {

--- a/packages/myst-cli/src/transforms/links.ts
+++ b/packages/myst-cli/src/transforms/links.ts
@@ -206,6 +206,7 @@ export async function checkLinksTransform(
         addWarningForFile(session, file, `Link for "${url}" did not resolve.${status}`, 'error', {
           position,
           ruleId: RuleId.linkResolves,
+          key: url,
         });
         return url as string;
       }),

--- a/packages/myst-config/src/errorRules/errorRules.yml
+++ b/packages/myst-config/src/errorRules/errorRules.yml
@@ -1,0 +1,23 @@
+title: Error Rules
+kind: config
+cases:
+  - title: error rules
+    raw:
+      error_rules:
+        - math-eqnarray-replaced
+    normalized:
+      error_rules:
+        - id: math-eqnarray-replaced
+  - title: error rules with params
+    raw:
+      error_rules:
+        - rule: a-rule
+          data:
+            - one
+            - two
+    normalized:
+      error_rules:
+        - id: a-rule
+          data:
+            - one
+            - two

--- a/packages/myst-config/src/errorRules/errorRules.yml
+++ b/packages/myst-config/src/errorRules/errorRules.yml
@@ -8,16 +8,27 @@ cases:
     normalized:
       error_rules:
         - id: math-eqnarray-replaced
+          severity: ignore
+  - title: error rules - incorrect severity
+    raw:
+      error_rules:
+        - rule: math-eqnarray-replaced
+          severity: nope
+    normalized:
+      error_rules: []
+    errors: 1
   - title: error rules with params
     raw:
       error_rules:
         - rule: a-rule
-          data:
+          keys:
             - one
             - two
     normalized:
       error_rules:
         - id: a-rule
-          data:
-            - one
-            - two
+          severity: ignore
+          key: one
+        - id: a-rule
+          severity: ignore
+          key: two

--- a/packages/myst-config/src/errorRules/index.ts
+++ b/packages/myst-config/src/errorRules/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js';
+export * from './validators.js';

--- a/packages/myst-config/src/errorRules/types.ts
+++ b/packages/myst-config/src/errorRules/types.ts
@@ -1,0 +1,4 @@
+export type ErrorRule = {
+  id: string;
+  severity?: 'ignore' | 'warn' | 'error';
+} & Record<string, any>;

--- a/packages/myst-config/src/errorRules/types.ts
+++ b/packages/myst-config/src/errorRules/types.ts
@@ -1,4 +1,5 @@
 export type ErrorRule = {
   id: string;
-  severity?: 'ignore' | 'warn' | 'error';
+  severity: 'ignore' | 'warn' | 'error';
+  key?: string;
 } & Record<string, any>;

--- a/packages/myst-config/src/errorRules/validators.ts
+++ b/packages/myst-config/src/errorRules/validators.ts
@@ -1,0 +1,63 @@
+import type { ValidationOptions } from 'simple-validators';
+import {
+  defined,
+  incrementOptions,
+  validateChoice,
+  validateList,
+  validateObjectKeys,
+  validateString,
+} from 'simple-validators';
+import type { ErrorRule } from './types.js';
+
+const ERROR_RULE_KEY_OBJECT = {
+  required: ['id'],
+  optional: ['severity'],
+  alias: {
+    rule: 'id',
+  },
+};
+
+export function validateErrorRule(input: any, opts: ValidationOptions): ErrorRule | undefined {
+  if (typeof input === 'string') {
+    input = { id: input };
+  }
+  const value = validateObjectKeys(input, ERROR_RULE_KEY_OBJECT, {
+    ...opts,
+    suppressWarnings: true,
+    keepExtraKeys: true,
+  });
+  if (value === undefined) return undefined;
+  const id = validateString(value.id, incrementOptions('id', opts));
+  if (!id) return undefined;
+  const output: ErrorRule = { id };
+  if (defined(value.severity)) {
+    const choice = validateChoice(value.severity, {
+      ...incrementOptions('severity', opts),
+      choices: ['ignore', 'warn', 'error'],
+    }) as ErrorRule['severity'];
+    if (choice) output.severity = choice;
+  }
+  // Put the unknown fields back on the object
+  const knownFields = [...ERROR_RULE_KEY_OBJECT.required, ...ERROR_RULE_KEY_OBJECT.optional];
+  Object.entries(value).forEach(([key, entry]) => {
+    if (knownFields.includes(key)) return;
+    output[key] = entry;
+  });
+  return output;
+}
+
+export function validateErrorRuleList(
+  input: any,
+  opts: ValidationOptions,
+): ErrorRule[] | undefined {
+  if (input === undefined) return undefined;
+  const output = validateList(
+    input,
+    { coerce: true, ...incrementOptions('error_rules', opts) },
+    (exp, ind) => {
+      return validateErrorRule(exp, incrementOptions(`error_rules.${ind}`, opts));
+    },
+  );
+  if (!output) return undefined;
+  return output;
+}

--- a/packages/myst-config/src/project/types.ts
+++ b/packages/myst-config/src/project/types.ts
@@ -1,4 +1,5 @@
 import type { ProjectFrontmatter } from 'myst-frontmatter';
+import type { ErrorRule } from '../errorRules/types.js';
 
 export const VERSION = 1;
 
@@ -7,4 +8,5 @@ export type ProjectConfig = ProjectFrontmatter & {
   index?: string;
   exclude?: string[];
   plugins?: string[];
+  error_rules?: ErrorRule[];
 };

--- a/packages/myst-config/src/project/validators.ts
+++ b/packages/myst-config/src/project/validators.ts
@@ -11,10 +11,11 @@ import {
   validateString,
   validateList,
 } from 'simple-validators';
+import { validateErrorRuleList } from '../errorRules/validators.js';
 import type { ProjectConfig } from './types.js';
 
 const PROJECT_CONFIG_KEYS = {
-  optional: ['remote', 'index', 'exclude', 'plugins', ...PROJECT_FRONTMATTER_KEYS],
+  optional: ['remote', 'index', 'exclude', 'plugins', 'error_rules', ...PROJECT_FRONTMATTER_KEYS],
   alias: FRONTMATTER_ALIASES,
 };
 
@@ -44,6 +45,11 @@ function validateProjectConfigKeys(value: Record<string, any>, opts: ValidationO
         return validateString(file, incrementOptions(`plugins.${index}`, opts));
       },
     );
+  }
+
+  if (defined(value.error_rules)) {
+    const error_rules = validateErrorRuleList(value.error_rules, opts);
+    if (error_rules) output.error_rules = error_rules;
   }
   return output;
 }

--- a/packages/myst-config/tests/examples.spec.ts
+++ b/packages/myst-config/tests/examples.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import type { ValidationOptions } from 'simple-validators';
+import { glob } from 'glob';
+import { validateSiteConfig, validateProjectConfig } from '../src';
+
+type TestFile = {
+  title: string;
+  kind?: 'config' | 'site';
+  cases: TestCase[];
+};
+
+type TestCase = {
+  title: string;
+  skip: boolean;
+  raw: string;
+  normalized?: string;
+  warnings?: number;
+  errors?: number;
+  opts?: Record<string, boolean>;
+};
+
+const files = await glob(
+  [path.join(__dirname, '*.yml'), path.join(__dirname, '..', 'src', '**', '*.yml')],
+  {
+    ignore: path.join(__dirname, '..', 'src', 'utils', '*.yml'),
+  },
+);
+
+const only = ''; // Can set this to a test title
+
+const casesList = files
+  .map((file) => ({ name: file, data: fs.readFileSync(file).toString() }))
+  .map((file) => {
+    const tests = yaml.load(file.data) as TestFile;
+    tests.title = tests.title ?? file.name;
+    return tests;
+  });
+
+casesList.forEach(({ title, kind, cases }) => {
+  const casesToUse = cases.filter((c) => (!only && !c.skip) || (only && c.title === only));
+  const skippedCases = cases.filter((c) => c.skip || (only && c.title !== only));
+  if (casesToUse.length === 0) return;
+  describe(title, () => {
+    if (skippedCases.length > 0) {
+      // Log to test output for visibility
+      test.skip.each(skippedCases.map((c): [string, TestCase] => [c.title, c]))('%s', () => {});
+    }
+    test.each(casesToUse.map((c): [string, TestCase] => [c.title, c]))(
+      '%s',
+      (_, { raw, normalized, warnings, errors }) => {
+        const opts: ValidationOptions = { property: '', messages: {} };
+        const validator = kind === 'config' ? validateProjectConfig : validateSiteConfig;
+        const result = validator(raw, opts);
+        if (only) {
+          // This runs in "only" mode
+          console.log(raw);
+        }
+        // Print the warnings and errors if they are not expected
+        if ((opts.messages.warnings?.length ?? 0) !== (warnings ?? 0)) {
+          console.log(opts.messages.warnings);
+        }
+        if ((opts.messages.errors?.length ?? 0) !== (errors ?? 0)) {
+          console.log(opts.messages.errors);
+        }
+        expect(result).toEqual(normalized);
+        expect(opts.messages.warnings?.length ?? 0).toBe(warnings ?? 0);
+        expect(opts.messages.errors?.length ?? 0).toBe(errors ?? 0);
+
+        // Test that normalized frontmatter is idempotent
+        expect(validator(normalized, opts)).toEqual(normalized);
+      },
+    );
+  });
+});


### PR DESCRIPTION
This adds a `error_rules` to the project configuration, which can be used to disable logging rules in the CLI.