### PR TITLE
🔌 Load plugins from all site projects, rather than just "current project"

### DIFF
--- a/.changeset/rare-bats-switch.md
+++ b/.changeset/rare-bats-switch.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Load plugins from all site projects


### PR DESCRIPTION
When loading plugins, we were previously only loading from `currentProjectConfig`. This PR updates the loading logic to also look at the `currentSiteConfig` and load all plugins from each of the site's projects.