### PR TITLE
Add execution to our documentation and test RTD previews

### DIFF
--- a/.github/robots.txt
+++ b/.github/robots.txt
@@ -1,0 +1,5 @@
+# This should disallow all search index crawling of the documentation.
+# we are using RTD *only* for PR previews, and not for hosting the actual docs.
+# So this should be added to the HTML output within readthedocs.
+User-agent: *
+Disallow: /

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,11 +8,13 @@ build:
   os: ubuntu-lts-latest
   tools:
     nodejs: "20"
+    python: "3.11"
   commands:
-    # Install and build our documentation
+    # Install dependencies and build MyST so we're using `main`
     - npm install
     - npm run build
     - npm run --workspace packages/mystmd link
+    - pip install -r docs/requirements.txt
     - myst --version
     - cd docs && BASE_URL=${READTHEDOCS_CANONICAL_URL} myst build --html --execute
     # Move MyST outputs to the ReadTheDocs output folder for inclusion

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,5 @@
+# ReadTheDocs configuration structure
+# ref: https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
   os: ubuntu-lts-latest
@@ -8,9 +10,11 @@ build:
     - npm run build
     - npm run --workspace packages/mystmd link
     - myst --version
-    - cd docs && BASE_URL=${READTHEDOCS_CANONICAL_URL} myst build --html
+    - cd docs && BASE_URL=${READTHEDOCS_CANONICAL_URL} myst build --html --execute
     # TODO: Switch to rsync
     # https://github.com/readthedocs/readthedocs.org/issues/11219
 #    - /usr/bin/rsync -a --mkpath docs/_build/ $READTHEDOCS_OUTPUT/
     - mkdir -p $READTHEDOCS_OUTPUT
     - cp -a docs/_build/* $READTHEDOCS_OUTPUT/
+    # Copy robots.txt to avoid search indexing
+    - cp .github/robots.txt $READTHEDOCS_OUTPUT/robots.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,16 +1,21 @@
 # ReadTheDocs configuration structure
-# ref: https://docs.readthedocs.io/en/stable/config-file/v2.html
+# This is *only meant for PR previews*.
+# Our live documentation is hosted via a Vercel site.
+# ref for docs: https://mystmd.org/guide/contribute-docs
+# ref for RTD config: https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
   os: ubuntu-lts-latest
   tools:
     nodejs: "20"
   commands:
+    # Install and build our documentation
     - npm install
     - npm run build
     - npm run --workspace packages/mystmd link
     - myst --version
     - cd docs && BASE_URL=${READTHEDOCS_CANONICAL_URL} myst build --html --execute
+    # Move MyST outputs to the ReadTheDocs output folder for inclusion
     # TODO: Switch to rsync
     # https://github.com/readthedocs/readthedocs.org/issues/11219
 #    - /usr/bin/rsync -a --mkpath docs/_build/ $READTHEDOCS_OUTPUT/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,8 @@
 # ref for docs: https://mystmd.org/guide/contribute-docs
 # ref for RTD config: https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
+conda:
+  environment: docs/environment.yml
 build:
   os: ubuntu-lts-latest
   tools:
@@ -14,7 +16,6 @@ build:
     - npm install
     - npm run build
     - npm run --workspace packages/mystmd link
-    - pip install -r docs/requirements.txt
     - myst --version
     - cd docs && BASE_URL=${READTHEDOCS_CANONICAL_URL} myst build --html --execute
     # Move MyST outputs to the ReadTheDocs output folder for inclusion

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,6 +23,6 @@ build:
     # https://github.com/readthedocs/readthedocs.org/issues/11219
 #    - /usr/bin/rsync -a --mkpath docs/_build/ $READTHEDOCS_OUTPUT/
     - mkdir -p $READTHEDOCS_OUTPUT
-    - cp -a docs/_build/* $READTHEDOCS_OUTPUT/
+    - cp -a docs/_build/* $READTHEDOCS_OUTPUT
     # Copy robots.txt to avoid search indexing
-    - cp .github/robots.txt $READTHEDOCS_OUTPUT/robots.txt
+    - cp .github/robots.txt $READTHEDOCS_OUTPUT/html/robots.txt

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,5 +6,6 @@ dependencies:
   - numpy
   - altair
   - matplotlib
+  - pandas
   - ipykernel
   - vega_datasets

--- a/docs/notebooks-with-markdown.md
+++ b/docs/notebooks-with-markdown.md
@@ -53,6 +53,8 @@ For example, the following MyST Markdown would re-use the variable defined above
 The value of `hello` is {eval}`there`.
 ```
 
+The value of `hello` is {eval}`there`.
+
 You can also modify the expression at the time of computation, for example:
 
 ```markdown

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-jupyter
-altair
-pandas
-matplotlib

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+jupyter
+altair
+pandas
+matplotlib


### PR DESCRIPTION
This makes two improvements to our documentation:

1. Adds execution to our docs build with `--execute`. This way we can test execution-related changes in the docs.
	- @rowanc1 this needs to be activated in the live docs as well. As-is, this will only impact the docs PR previews.
2. Previews the docs build with ReadTheDocs to confirm that it works.
	- I'm adding a `robots.txt` file that I think will prevent indexing on RTD. 