### PR TITLE
🐛 Correctly parse tags in {code-cell}

### DIFF
--- a/.changeset/lucky-trees-doubt.md
+++ b/.changeset/lucky-trees-doubt.md
@@ -1,0 +1,5 @@
+---
+"myst-directives": patch
+---
+
+Correctly place tags in code-block


### PR DESCRIPTION
This now correctly parses tags for `{code-cell}` directives, and works for visibility. The theme still does not do `hide-` but `remove-input`/`remove-cell/`remove-output` now all work in markdown notebooks.

This means that things like this:

```
:::{code-cell}
:tags: remove-input
!myst build -h
:::
```

Now show the output nicely in the docs, with the `--execute` flag on. Super cool.

cc @choldgraf