### PR TITLE
:bug: Always bundle static links

### DIFF
--- a/.changeset/early-insects-cross.md
+++ b/.changeset/early-insects-cross.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Bundle all static files

--- a/docs/notebooks-with-markdown.md
+++ b/docs/notebooks-with-markdown.md
@@ -77,7 +77,7 @@ and results in the following:
 > print("This will show output with no input!")
 > ```
 
-This can be particularly helpful for showing the output of a calculation or plot, which is reproducible in the source code, but not shown to the user.
+This can be particularly helpful for showing the output of a calculation or plot, which is reproducible in the {download}`source code <./notebooks-with-markdown.md>`, but not shown to the user like this `matplotlib` plot:
 
 ```{code-cell} python
 :tags: remove-input

--- a/packages/myst-cli/src/transforms/links.ts
+++ b/packages/myst-cli/src/transforms/links.ts
@@ -154,7 +154,8 @@ export class StaticFileTransformer implements LinkTransformer {
     const [linkFile, ...target] = linkFileWithTarget.split('#');
     const { url, title, dataUrl } =
       selectors.selectFileInfo(this.session.store.getState(), linkFile) || {};
-    if (url != null) {
+    // If the link is non-static, and can be resolved locally
+    if (url != null && !url.static) {
       // Replace relative file link with resolved site path
       // TODO: lookup the and resolve the hash as well
       link.url = [url, ...(target || [])].join('#');

--- a/packages/myst-cli/src/transforms/links.ts
+++ b/packages/myst-cli/src/transforms/links.ts
@@ -155,7 +155,7 @@ export class StaticFileTransformer implements LinkTransformer {
     const { url, title, dataUrl } =
       selectors.selectFileInfo(this.session.store.getState(), linkFile) || {};
     // If the link is non-static, and can be resolved locally
-    if (url != null && !url.static) {
+    if (url != null && link.static !== true) {
       // Replace relative file link with resolved site path
       // TODO: lookup the and resolve the hash as well
       link.url = [url, ...(target || [])].join('#');


### PR DESCRIPTION
This fixes #1135 by scoping the URL rewriting to non-static links.

I think what was happening was that the URL was being re-written as an internal link, but the `static` attribute was causing MyST to try and resolve that re-written link as a static item.

This change now prevents rewriting for static items (we'll always want those in the `static` endpoint).

I didn't add a test yet - not sure where that should go, would appreciate some pointers.