### PR TITLE
:ballot_box: Add new table-of-contents validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1584,9 +1584,9 @@
       "dev": true
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -9761,6 +9761,10 @@
       "resolved": "packages/myst-to-typst",
       "link": true
     },
+    "node_modules/myst-toc": {
+      "resolved": "packages/myst-toc",
+      "link": true
+    },
     "node_modules/myst-transforms": {
       "resolved": "packages/myst-transforms",
       "link": true
@@ -12004,6 +12008,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -13129,6 +13142,88 @@
         "url": "https://github.com/sponsors/ts-graphviz"
       }
     },
+    "node_modules/ts-json-schema-generator": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-1.5.1.tgz",
+      "integrity": "sha512-apX5qG2+NA66j7b4AJm8q/DpdTeOsjfh7A3LpKsUiil0FepkNwtN28zYgjrsiiya2/OPhsr/PSjX5FUYg79rCg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "commander": "^12.0.0",
+        "glob": "^8.0.3",
+        "json5": "^2.2.3",
+        "normalize-path": "^3.0.0",
+        "safe-stable-stringify": "^2.4.3",
+        "typescript": "~5.4.2"
+      },
+      "bin": {
+        "ts-json-schema-generator": "bin/ts-json-schema-generator"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ts-json-schema-generator/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/ts-json-schema-generator/node_modules/commander": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ts-json-schema-generator/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ts-json-schema-generator/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ts-json-schema-generator/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tsconfig": {
       "resolved": "packages/tsconfig",
       "link": true
@@ -13457,9 +13552,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -15836,6 +15931,36 @@
         "unist-util-select": "^4.0.3",
         "vfile-reporter": "^7.0.4"
       }
+    },
+    "packages/myst-toc": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0"
+      },
+      "devDependencies": {
+        "ts-json-schema-generator": "^1.5.0"
+      }
+    },
+    "packages/myst-toc/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/myst-toc/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "packages/myst-transforms": {
       "version": "1.3.9",

--- a/packages/myst-toc/.eslintrc.cjs
+++ b/packages/myst-toc/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['curvenote'],
+};

--- a/packages/myst-toc/.gitignore
+++ b/packages/myst-toc/.gitignore
@@ -1,0 +1,1 @@
+/src/schema.json

--- a/packages/myst-toc/README.md
+++ b/packages/myst-toc/README.md
@@ -1,0 +1,3 @@
+# myst-toc
+
+Utilities to parse a MyST table of contents

--- a/packages/myst-toc/README.md
+++ b/packages/myst-toc/README.md
@@ -1,3 +1,31 @@
 # myst-toc
 
-Utilities to parse a MyST table of contents
+Utilities to parse a MyST table of contents.
+
+## Overview
+The MyST ToC format is defined in `types.ts`, from which a JSON schema definition is compiled. The high-level description is as follows:
+
+1. A TOC comprises of an array of TOC items
+2. Each TOC item can be 
+  - A file (document)
+  - A URL (document)
+  - A collection of child items
+3. TOC items containing children *must* have either a `title` or a document
+
+
+## Example
+Example `myst.yml`
+```yaml
+toc:
+  - title: Main
+    file: main.md
+  - title: Overview
+    children:
+      - file: overview-1.md
+      - file: overview-2.md
+  - url: https://google.com
+  - file: getting-started.md
+    children:
+      - file: getting-started-part-1.md
+      - file: getting-started-part-2.md
+```

--- a/packages/myst-toc/README.md
+++ b/packages/myst-toc/README.md
@@ -3,18 +3,22 @@
 Utilities to parse a MyST table of contents.
 
 ## Overview
+
 The MyST ToC format is defined in `types.ts`, from which a JSON schema definition is compiled. The high-level description is as follows:
 
 1. A TOC comprises of an array of TOC items
-2. Each TOC item can be 
-  - A file (document)
-  - A URL (document)
-  - A collection of child items
-3. TOC items containing children *must* have either a `title` or a document
+2. Each TOC item can be
 
+- A file (document)
+- A URL (document)
+- A collection of child items
+
+3. TOC items containing children _must_ have either a `title` or a document
 
 ## Example
+
 Example `myst.yml` under the `toc:` key:
+
 ```yaml
 toc:
   - title: Main

--- a/packages/myst-toc/README.md
+++ b/packages/myst-toc/README.md
@@ -14,7 +14,7 @@ The MyST ToC format is defined in `types.ts`, from which a JSON schema definitio
 
 
 ## Example
-Example `myst.yml`
+Example `myst.yml` under the `toc:` key:
 ```yaml
 toc:
   - title: Main

--- a/packages/myst-toc/package.json
+++ b/packages/myst-toc/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "myst-toc",
+  "version": "0.0.0",
+  "sideEffects": false,
+  "license": "MIT",
+  "description": "MyST Table of Contents types and validation",
+  "author": "Angus Hollands <goosey15@gmail.com>",
+  "homepage": "https://github.com/executablebooks/mystmd/tree/main/packages/myst-toc",
+  "type": "module",
+  "exports": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/executablebooks/mystmd.git"
+  },
+  "scripts": {
+    "clean": "rimraf dist ./src/schema.json",
+    "lint": "eslint \"src/**/!(*.spec).ts\" -c ./.eslintrc.cjs",
+    "lint:format": "npx prettier --check \"src/**/*.ts\"",
+    "test": "npm-run-all build:schema && vitest run",
+    "test:watch": "vitest watch",
+    "build:esm": "tsc",
+    "build:schema": "npx ts-json-schema-generator --path src/types.ts --type TOC -o ./src/schema.json",
+    "build": "npm-run-all -s -l clean build:schema build:esm"
+  },
+  "bugs": {
+    "url": "https://github.com/executablebooks/mystmd/issues"
+  },
+  "dependencies": {
+    "ajv": "^8.12.0"
+  },
+  "devDependencies": {
+    "ts-json-schema-generator": "^1.5.0"
+  }
+}

--- a/packages/myst-toc/src/guards.ts
+++ b/packages/myst-toc/src/guards.ts
@@ -1,15 +1,12 @@
 import type { Entry, FileEntry, URLEntry, PatternEntry } from './types.js';
 
-
 export function isFile(entry: Entry): entry is FileEntry {
   return (entry as any).file !== undefined;
 }
 
-
 export function isURL(entry: Entry): entry is URLEntry {
   return (entry as any).url !== undefined;
 }
-
 
 export function isPattern(entry: Entry): entry is PatternEntry {
   return (entry as any).pattern !== undefined;

--- a/packages/myst-toc/src/guards.ts
+++ b/packages/myst-toc/src/guards.ts
@@ -1,0 +1,16 @@
+import type { Entry, FileEntry, URLEntry, PatternEntry } from './types.js';
+
+
+export function isFile(entry: Entry): entry is FileEntry {
+  return (entry as any).file !== undefined;
+}
+
+
+export function isURL(entry: Entry): entry is URLEntry {
+  return (entry as any).url !== undefined;
+}
+
+
+export function isPattern(entry: Entry): entry is PatternEntry {
+  return (entry as any).pattern !== undefined;
+}

--- a/packages/myst-toc/src/index.ts
+++ b/packages/myst-toc/src/index.ts
@@ -1,0 +1,2 @@
+export * from './toc.js';
+export * from './types.js';

--- a/packages/myst-toc/src/index.ts
+++ b/packages/myst-toc/src/index.ts
@@ -1,2 +1,3 @@
 export * from './toc.js';
 export * from './types.js';
+export * from './guards.js';

--- a/packages/myst-toc/src/toc.ts
+++ b/packages/myst-toc/src/toc.ts
@@ -15,11 +15,8 @@ export function parseTOC(toc: Record<string, unknown>): TOC {
   const ajv = new Ajv.default();
   const validate = ajv.compile(schema);
   if (!validate(toc)) {
-    throw new Error(
-      `The given contents do not form a valid TOC.`,
-    );
+    throw new Error(`The given contents do not form a valid TOC.`);
   }
 
   return toc as unknown as TOC;
 }
-

--- a/packages/myst-toc/src/toc.ts
+++ b/packages/myst-toc/src/toc.ts
@@ -1,0 +1,25 @@
+import type { TOC } from './types.js';
+import schema from './schema.json';
+import _Ajv from 'ajv';
+
+// Adjust types for ES module
+// @ts-ignore
+const Ajv = _Ajv as unknown as typeof _Ajv.default;
+
+/**
+ * Parse a sphinx-external-toc table of contents
+ *
+ * @param contents: raw TOC yaml
+ */
+export function parseTOC(toc: Record<string, unknown>): TOC {
+  const ajv = new Ajv.default();
+  const validate = ajv.compile(schema);
+  if (!validate(toc)) {
+    throw new Error(
+      `The given contents do not form a valid TOC.`,
+    );
+  }
+
+  return toc as unknown as TOC;
+}
+

--- a/packages/myst-toc/src/toc.ts
+++ b/packages/myst-toc/src/toc.ts
@@ -3,11 +3,11 @@ import schema from './schema.json';
 import _Ajv from 'ajv';
 
 /**
- * Parse a sphinx-external-toc table of contents
+ * validate a MyST table of contents
  *
- * @param contents: raw TOC yaml
+ * @param toc: structured TOC data
  */
-export function parseTOC(toc: Record<string, unknown>): TOC {
+export function validateTOC(toc: Record<string, unknown>): TOC {
   // eslint-disable-next-line
   // @ts-ignore
   const Ajv = _Ajv.default;

--- a/packages/myst-toc/src/toc.ts
+++ b/packages/myst-toc/src/toc.ts
@@ -8,6 +8,7 @@ import _Ajv from 'ajv';
  * @param contents: raw TOC yaml
  */
 export function parseTOC(toc: Record<string, unknown>): TOC {
+  // eslint-disable-next-line
   // @ts-ignore
   const Ajv = _Ajv.default;
   const ajv = new Ajv();

--- a/packages/myst-toc/src/toc.ts
+++ b/packages/myst-toc/src/toc.ts
@@ -2,17 +2,15 @@ import type { TOC } from './types.js';
 import schema from './schema.json';
 import _Ajv from 'ajv';
 
-// Adjust types for ES module
-// @ts-ignore
-const Ajv = _Ajv as unknown as typeof _Ajv.default;
-
 /**
  * Parse a sphinx-external-toc table of contents
  *
  * @param contents: raw TOC yaml
  */
 export function parseTOC(toc: Record<string, unknown>): TOC {
-  const ajv = new Ajv.default();
+  // @ts-ignore
+  const Ajv = _Ajv.default;
+  const ajv = new Ajv();
   const validate = ajv.compile(schema);
   if (!validate(toc)) {
     throw new Error(`The given contents do not form a valid TOC.`);

--- a/packages/myst-toc/src/types.ts
+++ b/packages/myst-toc/src/types.ts
@@ -8,6 +8,7 @@ export type CommonEntry = {
   numbering?: string;
   id?: string;
   part?: string;
+  class?: string;
 };
 
 /**
@@ -16,7 +17,6 @@ export type CommonEntry = {
 export type ParentEntry = {
   children: Entry[];
   title: string;
-  class?: string;
 } & CommonEntry;
 
 /**

--- a/packages/myst-toc/src/types.ts
+++ b/packages/myst-toc/src/types.ts
@@ -1,0 +1,31 @@
+export type ParentEntry = {
+  children: Entry[];
+  title: string;
+  class?: string;
+}
+
+/**
+ * Entry with a path to a single document with or without the file extension
+ */
+export type FileEntry = {
+  file: string;
+  title?: string;
+} & Partial<ParentEntry>;
+
+/**
+ * Entry with a URL to an external URL
+ */
+export type URLEntry = {
+  url: string;
+  title?: string;
+} & Partial<ParentEntry>;
+
+
+
+/**
+ * Single TOC entry
+ */
+export type Entry = FileEntry | URLEntry | ParentEntry;
+
+
+export type TOC = Entry[];

--- a/packages/myst-toc/src/types.ts
+++ b/packages/myst-toc/src/types.ts
@@ -48,6 +48,10 @@ export type DocumentEntry = FileEntry | URLEntry;
 /**
  * All possible types of Entry
  */
-export type Entry = DocumentEntry | (DocumentEntry & Omit<ParentEntry, 'title'>) | PatternEntry | ParentEntry;
+export type Entry =
+  | DocumentEntry
+  | (DocumentEntry & Omit<ParentEntry, 'title'>)
+  | PatternEntry
+  | ParentEntry;
 
 export type TOC = Entry[];

--- a/packages/myst-toc/src/types.ts
+++ b/packages/myst-toc/src/types.ts
@@ -3,11 +3,11 @@
  * Should be taken as a Partial<>
  */
 export type CommonEntry = {
-  title: string;
-  hidden: boolean;
-  numbering: string;
-  id: string;
-  part: string;
+  title?: string;
+  hidden?: boolean;
+  numbering?: string;
+  id?: string;
+  part?: string;
 };
 
 /**
@@ -17,32 +17,37 @@ export type ParentEntry = {
   children: Entry[];
   title: string;
   class?: string;
-} & Partial<Omit<CommonEntry, 'title'>>;
+} & CommonEntry;
 
 /**
  * Entry with a path to a single document with or without the file extension
  */
 export type FileEntry = {
   file: string;
-} & Partial<ParentEntry>;
+} & CommonEntry;
 
 /**
  * Entry with a URL to an external URL
  */
 export type URLEntry = {
   url: string;
-} & Partial<ParentEntry>;
+} & CommonEntry;
 
 /**
  * Entry representing several documents through a glob
  */
 export type PatternEntry = {
   pattern: string;
-} & Partial<CommonEntry>;
+} & CommonEntry;
 
 /**
- * Single TOC entry
+ * Entry representing a single document
  */
-export type Entry = FileEntry | URLEntry | PatternEntry | ParentEntry;
+export type DocumentEntry = FileEntry | URLEntry;
+
+/**
+ * All possible types of Entry
+ */
+export type Entry = DocumentEntry | (DocumentEntry & Omit<ParentEntry, 'title'>) | PatternEntry | ParentEntry;
 
 export type TOC = Entry[];

--- a/packages/myst-toc/src/types.ts
+++ b/packages/myst-toc/src/types.ts
@@ -2,7 +2,7 @@ export type ParentEntry = {
   children: Entry[];
   title: string;
   class?: string;
-}
+};
 
 /**
  * Entry with a path to a single document with or without the file extension
@@ -20,12 +20,9 @@ export type URLEntry = {
   title?: string;
 } & Partial<ParentEntry>;
 
-
-
 /**
  * Single TOC entry
  */
 export type Entry = FileEntry | URLEntry | ParentEntry;
-
 
 export type TOC = Entry[];

--- a/packages/myst-toc/src/types.ts
+++ b/packages/myst-toc/src/types.ts
@@ -1,15 +1,29 @@
+/**
+ * Common attributes for all TOC items
+ * Should be taken as a Partial<>
+ */
+export type CommonEntry = {
+  title: string;
+  hidden: boolean;
+  numbering: string;
+  id: string;
+  part: string;
+};
+
+/**
+ * Entry that groups children, with no associated document
+ */
 export type ParentEntry = {
   children: Entry[];
   title: string;
   class?: string;
-};
+} & Partial<Omit<CommonEntry, 'title'>>;
 
 /**
  * Entry with a path to a single document with or without the file extension
  */
 export type FileEntry = {
   file: string;
-  title?: string;
 } & Partial<ParentEntry>;
 
 /**
@@ -17,12 +31,18 @@ export type FileEntry = {
  */
 export type URLEntry = {
   url: string;
-  title?: string;
 } & Partial<ParentEntry>;
+
+/**
+ * Entry representing several documents through a glob
+ */
+export type PatternEntry = {
+  pattern: string;
+} & Partial<CommonEntry>;
 
 /**
  * Single TOC entry
  */
-export type Entry = FileEntry | URLEntry | ParentEntry;
+export type Entry = FileEntry | URLEntry | PatternEntry | ParentEntry;
 
 export type TOC = Entry[];

--- a/packages/myst-toc/tests/examples.spec.ts
+++ b/packages/myst-toc/tests/examples.spec.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { parseTOC } from '../src';
+
+type TestCase = {
+  title: string;
+  content: object;
+  throws?: string; // RegExp pattern
+  output?: object;
+  didUpgrade?: boolean;
+};
+
+type TestCases = {
+  title: string;
+  cases: TestCase[];
+};
+
+const only = '';
+
+const casesList: TestCases[] = fs
+  .readdirSync(__dirname)
+  .filter((file) => file.endsWith('.yml'))
+  .map((file) => {
+    const content = fs.readFileSync(path.join(__dirname, file), { encoding: 'utf-8' });
+    return yaml.load(content) as TestCases;
+  });
+
+casesList.forEach(({ title, cases }) => {
+  const filtered = cases.filter((c) => !only || c.title === only);
+  if (filtered.length === 0) return;
+  describe(title, () => {
+    test.each(filtered.map((c): [string, TestCase] => [c.title, c]))(
+      '%s',
+      (_, { content, throws, output }) => {
+        if (output) {
+
+          const toc = parseTOC(content);
+          expect(toc).toEqual(output);
+        } else if (throws) {
+          const pattern = new RegExp(throws);
+          expect(() => parseTOC(content)).toThrowError(pattern);
+        } else {
+          parseTOC(content);
+        }
+      },
+    );
+  });
+});

--- a/packages/myst-toc/tests/examples.spec.ts
+++ b/packages/myst-toc/tests/examples.spec.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
-import { parseTOC } from '../src';
+import { validateTOC } from '../src';
 
 type TestCase = {
   title: string;
@@ -35,13 +35,13 @@ casesList.forEach(({ title, cases }) => {
       '%s',
       (_, { content, throws, output }) => {
         if (output) {
-          const toc = parseTOC(content);
+          const toc = validateTOC(content);
           expect(toc).toEqual(output);
         } else if (throws) {
           const pattern = new RegExp(throws);
-          expect(() => parseTOC(content)).toThrowError(pattern);
+          expect(() => validateTOC(content)).toThrowError(pattern);
         } else {
-          parseTOC(content);
+          validateTOC(content);
         }
       },
     );

--- a/packages/myst-toc/tests/examples.spec.ts
+++ b/packages/myst-toc/tests/examples.spec.ts
@@ -35,7 +35,6 @@ casesList.forEach(({ title, cases }) => {
       '%s',
       (_, { content, throws, output }) => {
         if (output) {
-
           const toc = parseTOC(content);
           expect(toc).toEqual(output);
         } else if (throws) {

--- a/packages/myst-toc/tests/test.yml
+++ b/packages/myst-toc/tests/test.yml
@@ -7,36 +7,44 @@ cases:
     content:
       - file: foo.md 
         title: Foo!
+  - title: Single file with part passes
+    content:
+      - file: foo.md 
+        part: abstract
+  - title: Single file with hidden passes
+    content:
+      - file: foo.md 
+        hidden: true
+  - title: Single file with invalid hidden fails
+    content:
+      - file: foo.md 
+        hidden: "yes"
+    throws: 'The given contents do not form a valid TOC'
   - title: Single file with children passes
     content:
       - file: foo.md 
-        children:
-          - file: bar.md
-  - title: Single file with title and children passes
-    content:
-      - file: foo.md 
-        title: Foo
         children:
           - file: bar.md
 
   - title: Single URL passes
     content:
       - url: https://bar.com/foo.md 
-  - title: Single URL with title passes
-    content:
-      - url: https://bar.com/foo.md 
-        title: Foo!
   - title: Single URL with children passes
     content:
       - url: foo.md 
         children:
           - url: https://bar.com/foo.md
-  - title: Single URL with title and children passes
+
+  - title: Single pattern passes
     content:
-      - url: https://bar.com/foo.md 
-        title: Foo
+      - pattern: foo/*.md 
+  - title: Single pattern with children passes fails
+    content:
+      - pattern: foo/*.md 
         children:
-          - url: https://bar.com/bar.md
+          - url: https://bar.com/foo.md
+    throws: 'The given contents do not form a valid TOC'
+
 
   - title: Single parent passes
     content:

--- a/packages/myst-toc/tests/test.yml
+++ b/packages/myst-toc/tests/test.yml
@@ -1,0 +1,63 @@
+title: Table of Contents
+cases:
+  - title: Single file passes
+    content:
+      - file: foo.md 
+  - title: Single file with title passes
+    content:
+      - file: foo.md 
+        title: Foo!
+  - title: Single file with children passes
+    content:
+      - file: foo.md 
+        children:
+          - file: bar.md
+  - title: Single file with title and children passes
+    content:
+      - file: foo.md 
+        title: Foo
+        children:
+          - file: bar.md
+
+  - title: Single URL passes
+    content:
+      - url: https://bar.com/foo.md 
+  - title: Single URL with title passes
+    content:
+      - url: https://bar.com/foo.md 
+        title: Foo!
+  - title: Single URL with children passes
+    content:
+      - url: foo.md 
+        children:
+          - url: https://bar.com/foo.md
+  - title: Single URL with title and children passes
+    content:
+      - url: https://bar.com/foo.md 
+        title: Foo
+        children:
+          - url: https://bar.com/bar.md
+
+  - title: Single parent passes
+    content:
+      - title: Foo
+        children:
+          - url: https://bar.com/bar.md
+  - title: Single parent with class passes
+    content:
+      - title: Foo
+        class: dropdown
+        children:
+          - url: https://bar.com/bar.md
+  - title: Single parent without title fails
+    content:
+      - children:
+          - url: https://bar.com/bar.md
+    throws: 'The given contents do not form a valid TOC'
+
+
+  - title: Mix of URL and file types fails
+    content:
+      - file: foo.md
+        url: https://bar.com/foo.md
+    throws: 'The given contents do not form a valid TOC'

--- a/packages/myst-toc/tests/test.yml
+++ b/packages/myst-toc/tests/test.yml
@@ -11,6 +11,10 @@ cases:
     content:
       - file: foo.md 
         part: abstract
+  - title: Single file with class passes
+    content:
+      - file: foo.md 
+        class: beta
   - title: Single file with hidden passes
     content:
       - file: foo.md 
@@ -49,12 +53,6 @@ cases:
   - title: Single parent passes
     content:
       - title: Foo
-        children:
-          - url: https://bar.com/bar.md
-  - title: Single parent with class passes
-    content:
-      - title: Foo
-        class: dropdown
         children:
           - url: https://bar.com/bar.md
   - title: Single parent without title fails

--- a/packages/myst-toc/tsconfig.json
+++ b/packages/myst-toc/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "resolveJsonModule": true,
+  },
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules", "src/**/*.spec.ts", "tests"],
+}


### PR DESCRIPTION
In #1102, we identified the need for a new table of contents format.

This format must satisfy the following goals:
1. Easy to humanly read/write
2. Easy to programatically read/write
3. Expressive enough to represent complex trees

This PR is a WIP in that direction. The TOC schema can be build using 
```bash
npm run build:schema --workspace=packages/myst-toc
```
and then used with <https://www.jsonschemavalidator.net/> (or the CLI equivalent) to verify a TOC JSON blob.

Here's an example "complex" TOC:
```yaml
  - title: Main
    file: main.md
  - title: Overview
    children:
      - file: overview-1.md
      - file: overview-2.md
  - url: https://google.com
  - file: getting-started.md
    children:
      - file: getting-started-part-1.md
      - file: getting-started-part-2.md
```

There are notably two kinds of "subtrees" in MyST:
1. Non-hyperlink categories (grouping)
2. Categories with index pages (Sphinx-like)

This TOC supports both; a bare `children` entry requires a `title`, whereas a file/URL entry does not. 

@rowanc1 also mentioned the ability to choose between drop-downs and fixed-headings. This TOC format has a `class` string field that we could use to support that. 

We should iterate on this as necessary!

Closes #1102