### PR TITLE
🧮 Frontmatter in `include` files removed, math/abbreviations maintained

### DIFF
--- a/.changeset/red-wolves-nail.md
+++ b/.changeset/red-wolves-nail.md
@@ -1,0 +1,6 @@
+---
+'myst-transforms': patch
+'myst-cli': patch
+---
+
+Included files remove frontmatter and update math/abbr

--- a/docs/embed.md
+++ b/docs/embed.md
@@ -56,7 +56,6 @@ For example, the following references the admonitions list in [](admonitions.md)
 
 ```
 
-
 ### The `![](#embed)` short-hand
 
 The embedding markdown shorthand lets you quickly embed content using the Markdown image syntax (see more about [images](./figures.md)).
@@ -152,6 +151,13 @@ By default the file will be parsed using MyST, you can also set the file to be {
 :class: dropdown
 If you are working with the auto-reload (e.g. `myst start`), the file dependencies are auto-reloaded.
 Circular dependencies are not allowed and MyST will issue a warning and not render the recursion.
+:::
+
+:::{tip} Math and abbreviation frontmatter from included files
+:class: dropdown
+When including a file that has frontmatter, only some of that frontmatter is used. For example, the `math` macros and `abbreviations` are brought up to the top level and will overwrite any macros or abbreviations that already exist.
+
+For LaTeX, the commands like `\newcommand` and `\renewcommand` are shared in the same way that math macros are shared for markdown files.
 :::
 
 ## `{embed}` vs. `{include}`

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -38,16 +38,19 @@ export function frontmatterValidationOpts(
  * @param tree - mdast tree already loaded
  * @param vfile - vfile used for logging
  * @param preFrontmatter - incoming frontmatter for the page that is not from the project or in the tree
+ * @param keepTitleNode - do not remove leading H1 even if it is lifted as title
  */
 export function getPageFrontmatter(
   session: ISession,
   tree: GenericParent,
   vfile: VFile,
   preFrontmatter?: Record<string, any>,
+  keepTitleNode?: boolean,
 ): { frontmatter: PageFrontmatter; identifiers: string[] } {
   const { frontmatter: rawPageFrontmatter, identifiers } = getFrontmatter(vfile, tree, {
     propagateTargets: true,
     preFrontmatter,
+    keepTitleNode,
   });
   unnestKernelSpec(rawPageFrontmatter);
   const pageFrontmatter = validatePageFrontmatter(

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -32,13 +32,12 @@ export function frontmatterValidationOpts(
   };
 }
 /**
- * Get page frontmatter from mdast tree and fill in missing info from project frontmatter
+ * Get page frontmatter from mdast tree
  *
  * @param session
- * @param path - project path for loading project config/frontmatter
- * @param tree - mdast tree already loaded from 'file'
- * @param file - file source for mdast 'tree' - this is only used for logging; tree is not reloaded
- * @param removeNode - if true, mdast tree will be mutated to remove frontmatter once read
+ * @param tree - mdast tree already loaded
+ * @param vfile - vfile used for logging
+ * @param preFrontmatter - incoming frontmatter for the page that is not from the project or in the tree
  */
 export function getPageFrontmatter(
   session: ISession,

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -21,7 +21,7 @@ import { parseMyst } from './myst.js';
 import { processNotebook } from './notebook.js';
 import { selectors } from '../store/index.js';
 
-type LoadFileOptions = { preFrontmatter?: Record<string, any> };
+type LoadFileOptions = { preFrontmatter?: Record<string, any>; keepTitleNode?: boolean };
 
 export type LoadFileResult = {
   kind: SourceFileKind;
@@ -52,6 +52,7 @@ export function loadMdFile(
     mdast,
     vfile,
     opts?.preFrontmatter,
+    opts?.keepTitleNode,
   );
   return { kind: SourceFileKind.Article, mdast, frontmatter, identifiers };
 }
@@ -70,6 +71,7 @@ export async function loadNotebookFile(
     mdast,
     vfile,
     opts?.preFrontmatter,
+    opts?.keepTitleNode,
   );
   return { kind: SourceFileKind.Notebook, mdast, frontmatter, identifiers };
 }

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -163,7 +163,7 @@ export async function transformMdast(
   // Import additional content from mdast or other files
   frontmatterPartsTransform(session, file, mdast, frontmatter);
   importMdastFromJson(session, file, mdast);
-  await includeFilesTransform(session, file, mdast, vfile);
+  await includeFilesTransform(session, file, mdast, frontmatter, vfile);
   rawDirectiveTransform(mdast, vfile);
   // This needs to come before basic transformations since it may add labels to blocks
   liftCodeMetadataToBlock(session, vfile, mdast);

--- a/packages/myst-cli/src/transforms/include.ts
+++ b/packages/myst-cli/src/transforms/include.ts
@@ -64,13 +64,14 @@ export const makeContentParser =
       const mdast = { type: 'root', children: [{ type: 'html', value: content }] };
       return { mdast, kind: SourceFileKind.Article };
     }
+    const opts = { keepTitleNode: true };
     if (filename.toLowerCase().endsWith('.tex')) {
-      return loadTexFile(session, content, file);
+      return loadTexFile(session, content, file, opts);
     }
     if (filename.toLowerCase().endsWith('.ipynb')) {
-      return loadNotebookFile(session, content, file);
+      return loadNotebookFile(session, content, file, opts);
     }
-    return loadMdFile(session, content, file);
+    return loadMdFile(session, content, file, opts);
   };
 
 export async function includeFilesTransform(

--- a/packages/myst-transforms/src/frontmatter.ts
+++ b/packages/myst-transforms/src/frontmatter.ts
@@ -20,6 +20,13 @@ type Options = {
    * is defined.
    */
   preFrontmatter?: Record<string, any>;
+  /**
+   * By default, if the page starts with an H1 heading and has no title in the
+   * frontmatter, the heading will become the title and be removed.
+   * If `keepTitleNode` is true, the heading will still become the title
+   * but the node will not be removed.
+   */
+  keepTitleNode?: boolean;
 };
 
 export function getFrontmatter(
@@ -70,7 +77,7 @@ export function getFrontmatter(
   if (nextNodeIsH1 && !titleNull) {
     const title = toText(nextNode.children);
     // Only remove the title if it is the same
-    if (frontmatter.title && frontmatter.title === title) {
+    if (frontmatter.title && frontmatter.title === title && !opts.keepTitleNode) {
       (nextNode as any).type = '__delete__';
       frontmatter.content_includes_title = false;
       // If this has a label add it to the page identifiers for reference resolution


### PR DESCRIPTION
Files loaded in the `include` directive previously retained their frontmatter in the `mdast` tree, resulting in an unwanted `yaml` code block. Additionally, everything in the `include` frontmatter was ignored (mostly we do want to ignore it, but for `.tex` source files, `include`s may have math macros, etc, that we need to inherit).

Now, we reuse the file loading functions from `loadFile` in the `include` directive. These functions remove and give access to file frontmatter. That means no more yaml blocks and we can inherit `math` and `abbreviations` into the parent file's frontmatter.