### PR TITLE
🧮 Ensure include file frontmatter takes priority

### DIFF
--- a/.changeset/small-zoos-watch.md
+++ b/.changeset/small-zoos-watch.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Ensure include file frontmatter takes priority

--- a/packages/myst-transforms/src/include.ts
+++ b/packages/myst-transforms/src/include.ts
@@ -22,18 +22,21 @@ export type Options = {
  *
  * For now, this only includes math macros and abbreviations; all other
  * include frontmatter is ignored.
+ *
+ * If values are defined on both the page and the include file,
+ * values from the include file will take priority.
  */
 function updateFrontmatterFromInclude(
   frontmatter: PageFrontmatter,
   includeFrontmatter?: PageFrontmatter,
 ) {
   if (frontmatter.math || includeFrontmatter?.math) {
-    frontmatter.math = { ...includeFrontmatter?.math, ...frontmatter.math };
+    frontmatter.math = { ...frontmatter.math, ...includeFrontmatter?.math };
   }
   if (frontmatter.abbreviations || includeFrontmatter?.abbreviations) {
     frontmatter.abbreviations = {
-      ...includeFrontmatter?.abbreviations,
       ...frontmatter.abbreviations,
+      ...includeFrontmatter?.abbreviations,
     };
   }
 }


### PR DESCRIPTION
This updates `include` frontmatter implementation to match the documentation: https://github.com/executablebooks/mystmd/pull/1156/commits/81d7490074ea72b3c3ba94b07c0323b3a5a7aa8e