### PR TITLE
Document link option with card

### DIFF
--- a/docs/dropdowns-cards-and-tabs.md
+++ b/docs/dropdowns-cards-and-tabs.md
@@ -41,7 +41,7 @@ Card content
 ```
 ````
 
-You can also add a `link` argument to the card, which will allow you to make the entire card clickable:
+You can also add a `link` option to the card, which will allow you to make the entire card clickable:
 
 ````{myst}
 

--- a/docs/dropdowns-cards-and-tabs.md
+++ b/docs/dropdowns-cards-and-tabs.md
@@ -41,13 +41,16 @@ Card content
 ```
 ````
 
-You can also add a `link` argument to the card, which will allow you to make the entire card clickable.
+You can also add a `link` argument to the card, which will allow you to make the entire card clickable:
+
+````{myst}
 
 :::{card} Clickable Card
 :link: https://mystmd.org
 
 The entire card can be clicked to navigate to `mystmd.org`.
 :::
+````
 
 ````{note} Compatibility with Sphinx design
 :class: dropdown
@@ -87,6 +90,9 @@ Note that, card headers and footers are optional. If you don’t include ^^^ or 
 
     footer _(optional, markdown)_
     : Styled content at the bottom of the card
+
+    link _(optional, string)_
+    : If given, clicking the card will direct you to the URL given here.
 
 ### Grids
 


### PR DESCRIPTION
This documents the `:link:` option for cards and adds it to the short reference below.

I tried to use a reference to the card directive like `` {myst:directive}`card` ``, but that didn't resolve for some reason. Maybe that's why the reference is manually included in the page?

Either way:

- closes #1184 