### PR TITLE
📺 Prefer video in web build if available

### DIFF
--- a/.changeset/weak-bugs-press.md
+++ b/.changeset/weak-bugs-press.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Change priority of mp4 to prefer video over images if both are available

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -31,13 +31,13 @@ import type { TransformFn } from './mdast.js';
 import { finalizeMdast, postProcessMdast, transformMdast } from './mdast.js';
 
 const WEB_IMAGE_EXTENSIONS = [
+  ImageExtensions.mp4,
   ImageExtensions.webp,
   ImageExtensions.svg,
   ImageExtensions.gif,
   ImageExtensions.png,
   ImageExtensions.jpg,
   ImageExtensions.jpeg,
-  ImageExtensions.mp4,
 ];
 
 export type ProcessFileOptions = {


### PR DESCRIPTION
This is possible to use the `image.*` as the src, if that is the case, an mp4 will be used by default for the web, but png for the static exports.