### PR TITLE
[FIX] 🧊 don't overwrite `node.data`, append new fields

### DIFF
--- a/packages/myst-transforms/src/links/doi.ts
+++ b/packages/myst-transforms/src/links/doi.ts
@@ -30,7 +30,7 @@ export class DOITransformer implements LinkTransformer {
       return false;
     }
     link.url = doiUrl;
-    link.data = { doi: doi.normalize(doiUrl) };
+    link.data = { ...link.data, doi: doi.normalize(doiUrl) };
     link.internal = false;
     updateLinkTextIfEmpty(link, '');
     return true;

--- a/packages/myst-transforms/src/links/github.ts
+++ b/packages/myst-transforms/src/links/github.ts
@@ -113,7 +113,7 @@ export class GithubTransformer implements LinkTransformer {
       return false;
     }
     const [defaultText, data] = parsed;
-    link.data = data;
+    link.data = { ...link.data, ...data };
     link.internal = false;
     updateLinkTextIfEmpty(link, defaultText);
     return true;

--- a/packages/myst-transforms/src/links/rrid.ts
+++ b/packages/myst-transforms/src/links/rrid.ts
@@ -42,7 +42,7 @@ export class RRIDTransformer implements LinkTransformer {
       return false;
     }
     link.url = `${RESOLVER}${rrid}`;
-    link.data = { rrid };
+    link.data = { ...link.data, rrid };
     link.internal = false;
     updateLinkTextIfEmpty(link, rrid);
     return true;

--- a/packages/myst-transforms/src/links/wiki.ts
+++ b/packages/myst-transforms/src/links/wiki.ts
@@ -86,6 +86,7 @@ export class WikiTransformer implements LinkTransformer {
       .replace(/(?:^_)|(?:_$)/g, '');
     link.url = `${result.wiki}wiki/${page}`;
     link.data = {
+      ...link.data,
       page: page,
       wiki: result.wiki,
       lang: result.lang,


### PR DESCRIPTION
In certain transforms, the `node.data` object was being completely replaced. This behaviour prevents upstream plugins (e.g. user myst plugins in individual projects) from including additional data on a node.

My understanding of the role of the data field is to enable a "userdata" type store where arbitrary fields could be added, it's purpose mainly to enable meaningful storage of data that would otherwise be buried in a node's children, body or value, etc...

This PR fixes a specific issue in the `doi` transform that was overwriting user data. It also includes similar changes in other places to preserve any existing `node.data` where similar assignments were being made, although I don't have a failure case to test for those changes and they need review.