### PR TITLE
🐛 Fix bug where intersphinx xrefs do not resolve on first load

### DIFF
--- a/.changeset/lucky-shoes-search.md
+++ b/.changeset/lucky-shoes-search.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fix bug where intersphinx xrefs do not resolve on first load

--- a/packages/myst-cli/src/process/loadReferences.ts
+++ b/packages/myst-cli/src/process/loadReferences.ts
@@ -129,6 +129,8 @@ async function loadReference(
       }
       return;
     }
+    reference.kind = 'intersphinx';
+    reference.value = inventory;
     if (inventory.id && inventory.path && isUrl(inventory.path)) {
       const intersphinxPath = cachePath(
         session,


### PR DESCRIPTION
Intersphinx xrefs did not resolve on first load (subsequent loads from disk are fine). This was particularly a problem for CI where it is always a first load.