### PR TITLE
🚨Better error messages for broken xrefs

### DIFF
--- a/.changeset/brown-ducks-speak.md
+++ b/.changeset/brown-ducks-speak.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+More specific error for invalid xref embed

--- a/.changeset/ten-countries-live.md
+++ b/.changeset/ten-countries-live.md
@@ -1,0 +1,6 @@
+---
+'myst-transforms': patch
+'myst-cli': patch
+---
+
+Better error messages for empty link text

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -294,6 +294,7 @@ export async function postProcessMdast(
   const state = pageReferenceStates
     ? new MultiPageReferenceResolver(pageReferenceStates, file, vfile)
     : fileState;
+  const externalReferences = Object.values(cache.$externalReferences);
   // NOTE: This is doing things in place, we should potentially make this a different state?
   const transformers = [
     ...(extraLinkTransformers || []),
@@ -302,8 +303,8 @@ export async function postProcessMdast(
     new RRIDTransformer(),
     new RORTransformer(),
     new DOITransformer(), // This also is picked up in the next transform
-    new MystTransformer(Object.values(cache.$externalReferences)),
-    new SphinxTransformer(Object.values(cache.$externalReferences)),
+    new MystTransformer(externalReferences),
+    new SphinxTransformer(externalReferences),
     new StaticFileTransformer(session, file), // Links static files and internally linked files
   ];
   resolveLinksAndCitationsTransform(mdast, { state, transformers });
@@ -324,7 +325,7 @@ export async function postProcessMdast(
 
   // Ensure there are keys on every node after post processing
   keysTransform(mdast);
-  checkLinkTextTransform(mdast, vfile);
+  checkLinkTextTransform(mdast, externalReferences, vfile);
   logMessagesFromVFile(session, fileState.vfile);
   logMessagesFromVFile(session, vfile);
   log.debug(toc(`Transformed mdast cross references and links for "${file}" in %s`));

--- a/packages/myst-transforms/src/links/check.ts
+++ b/packages/myst-transforms/src/links/check.ts
@@ -1,12 +1,35 @@
-import { RuleId, fileWarn, toText, type GenericNode, type GenericParent } from 'myst-common';
+import {
+  RuleId,
+  fileError,
+  fileWarn,
+  toText,
+  type GenericNode,
+  type GenericParent,
+} from 'myst-common';
 import { select, selectAll } from 'unist-util-select';
 import type { VFile } from 'vfile';
+import type { ResolvedExternalReference } from './types.js';
 
-export function checkLinkTextTransform(mdast: GenericParent, vfile: VFile) {
-  const linkNodes = selectAll('link,linkBlock,card,crossReference', mdast) as GenericNode[];
-  if (linkNodes.length === 0) return;
+export function checkLinkTextTransform(
+  mdast: GenericParent,
+  externalReferences: ResolvedExternalReference[],
+  vfile: VFile,
+) {
+  const linkNodes = selectAll('link,linkBlock,card', mdast) as GenericNode[];
+  const xrefNodes = selectAll('crossReference', mdast) as GenericNode[];
   linkNodes.forEach((node) => {
-    if (!toText(node.children) && !select('image', node)) {
+    if (node.url.startsWith('xref:') || node.url.startsWith('myst:')) {
+      const key = node.url.slice(5).split('/')[0].split('#')[0];
+      if (externalReferences.map((ref) => ref.key).includes(key)) {
+        // If this link has an existing reference key but did not resolve, another error was already raised
+      } else {
+        fileError(vfile, `Link did not resolve to valid cross-reference: ${node.url}`, {
+          node,
+          ruleId: RuleId.linkTextExists,
+          note: key ? `You need an entry in your project references with key "${key}"` : undefined,
+        });
+      }
+    } else if (!toText(node.children) && !select('image', node)) {
       fileWarn(
         vfile,
         `Link text is empty for <${node.urlSource ?? node.url}${node.identifier ? `#${node.identifier}` : ''}>`,
@@ -15,6 +38,14 @@ export function checkLinkTextTransform(mdast: GenericParent, vfile: VFile) {
           ruleId: RuleId.linkTextExists,
         },
       );
+    }
+  });
+  xrefNodes.forEach((node) => {
+    if (!toText(node.children) && !select('image', node)) {
+      fileWarn(vfile, `Cross reference text is empty for <${node.urlSource}>`, {
+        node,
+        ruleId: RuleId.linkTextExists,
+      });
     }
   });
 }


### PR DESCRIPTION
- On embed, the error message for non-existent reference vs. existing intersphinx reference is different
- On empty link text, error if this was caused by a non-existent reference, otherwise warn that text is empty