### PR TITLE
🔧 Fix broken term xrefs by no removing identifier on xref node

### DIFF
--- a/.changeset/silent-tools-stare.md
+++ b/.changeset/silent-tools-stare.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Fix broken term xrefs by no removing identifier on xref node

--- a/packages/myst-transforms/src/enumerate.ts
+++ b/packages/myst-transforms/src/enumerate.ts
@@ -514,8 +514,8 @@ export function addChildrenFromTargetNode(
   }
   node.resolved = true;
   // The identifier may have changed in the lookup, but unlikely
-  node.identifier = targetNode.identifier;
-  node.html_id = targetNode.html_id;
+  node.identifier = targetNode.identifier ?? node.identifier;
+  node.html_id = targetNode.html_id ?? node.html_id;
 }
 
 function warnNodeTargetNotFound(node: ResolvableCrossReference, vfile?: VFile) {


### PR DESCRIPTION
This PR makes sure we don't accidentally delete the `identifier` on cross reference resolution.

This happened because we now share the `nodesFromMystXRefData` function (which gets the target node from remote mdast) between xref resolution and embed rendering. The latter requires `definitionTerms` to be wrapped in `definitionList`, so that function returns a `definitionList` node for "term" xrefs (but `identifier` is still on the child `definitionTerm`). The xref resolution code looked to that top-level target node for `identifier`, and in this case when none was found, removed it from the xref node...

Now, we just make sure `identifier` is never entirely removed.