### PR TITLE
✨ Add `extends` field to myst.yml for composing multiple yamls

### DIFF
--- a/.changeset/green-brooms-applaud.md
+++ b/.changeset/green-brooms-applaud.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Support circular deps and live reloading for extending config

--- a/.changeset/large-peas-melt.md
+++ b/.changeset/large-peas-melt.md
@@ -1,0 +1,6 @@
+---
+'myst-frontmatter': patch
+'myst-cli': patch
+---
+
+Load and fill frontmatter from extend config key

--- a/.changeset/many-worms-know.md
+++ b/.changeset/many-worms-know.md
@@ -1,0 +1,6 @@
+---
+'myst-config': patch
+'myst-cli': patch
+---
+
+Add extend key to top-level config

--- a/.changeset/stupid-experts-pull.md
+++ b/.changeset/stupid-experts-pull.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Refactor config loading to separate validation from saving

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -55,7 +55,7 @@ project:
 ```
 
 (composing-myst-yml)=
-:::{note} Composing multiple `.yml` files
+#### Composing multiple `.yml` files
 
 You may separate your frontmatter into multiple, composable files. To reference other files from your main `myst.yml` file, use the `extends` key with relative path(s) to the other configuration files:
 
@@ -71,7 +71,6 @@ extends:
 Each of these files listed under `extends` must contain valid `myst.yml` structure with `version: 1` and `site` or `project` keys. They may also have additional files listed under `extends`.
 
 Composing files together this way allows you to have a single source of truth for project frontmatter that may be reused across multiple projects, for example math macros or funding information.
-:::
 
 +++
 

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -54,6 +54,25 @@ project:
   open_access: true
 ```
 
+(composing-myst-yml)=
+:::{note} Composing multiple `.yml` files
+
+You may separate your frontmatter into multiple, composable files. To reference other files from your main `myst.yml` file, use the `extends` key with relative path(s) to the other configuration files:
+
+```yaml
+version: 1
+site: ...
+project: ...
+extends:
+  - ../macros.yml
+  - ../funding.yml
+```
+
+Each of these files listed under `extends` must contain valid `myst.yml` structure with `version: 1` and `site` or `project` keys. They may also have additional files listed under `extends`.
+
+Composing files together this way allows you to have a single source of truth for project frontmatter that may be reused across multiple projects, for example math macros or funding information.
+:::
+
 +++
 
 ## Available frontmatter fields

--- a/docs/quickstart-myst-websites.md
+++ b/docs/quickstart-myst-websites.md
@@ -246,7 +246,7 @@ site:
   ...
 ```
 
-Doing this will keep the `_build` directory at the root level, but everything else outside of the `content` folder will be ignored. If you have a project in the same configuration file it can be accessed with `path: .`. Projects are "mounted" at the `slug:` (i.e. `/my-content/`) above.
+Doing this will keep the `_build` directory at the root level, but everything else outside of the `content` folder will be ignored. If you have a project in the same configuration file it can be accessed with `path: .`. Projects are "mounted" at the `slug:` (e.g. `/my-content/` above).
 :::
 
 ## Additional options

--- a/packages/myst-cli/src/project/load.ts
+++ b/packages/myst-cli/src/project/load.ts
@@ -38,6 +38,7 @@ export async function loadProjectFromDisk(
     const cachedProject = selectors.selectLocalProject(session.store.getState(), path);
     if (cachedProject) return cachedProject;
   }
+  loadConfig(session, path, opts);
   const projectConfig = selectors.selectLocalProjectConfig(session.store.getState(), path);
   const file = join(path, session.configFiles[0]);
   if (!projectConfig && opts?.warnOnNoConfig) {

--- a/packages/myst-cli/src/store/reducers.ts
+++ b/packages/myst-cli/src/store/reducers.ts
@@ -3,7 +3,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import type { ProjectConfig, SiteConfig } from 'myst-config';
 import { combineReducers } from 'redux';
-import type { BuildWarning, ExternalLinkResult } from './types.js';
+import type { BuildWarning, ExternalLinkResult, ValidatedRawConfig } from './types.js';
 import type { LocalProject } from '../project/types.js';
 
 export const projects = createSlice({
@@ -38,10 +38,11 @@ export const config = createSlice({
   } as {
     currentProjectPath: string | undefined;
     currentSitePath: string | undefined;
-    rawConfigs: Record<string, { raw: Record<string, any>; validated: Record<string, any> }>;
+    rawConfigs: Record<string, { raw: Record<string, any>; validated: ValidatedRawConfig }>;
     projects: Record<string, ProjectConfig>;
     sites: Record<string, Record<string, any>>;
     filenames: Record<string, string>;
+    configExtensions?: string[];
   },
   reducers: {
     receiveCurrentProjectPath(state, action: PayloadAction<{ path: string }>) {
@@ -54,7 +55,7 @@ export const config = createSlice({
       state,
       action: PayloadAction<{
         raw: Record<string, any>;
-        validated: Record<string, any>;
+        validated: ValidatedRawConfig;
         path: string;
         file: string;
       }>,
@@ -70,6 +71,10 @@ export const config = createSlice({
     receiveProjectConfig(state, action: PayloadAction<ProjectConfig & { path: string }>) {
       const { path, ...payload } = action.payload;
       state.projects[resolve(path)] = payload;
+    },
+    receiveConfigExtension(state, action: PayloadAction<{ file: string }>) {
+      state.configExtensions ??= [];
+      state.configExtensions.push(action.payload.file);
     },
   },
 });

--- a/packages/myst-cli/src/store/selectors.ts
+++ b/packages/myst-cli/src/store/selectors.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path';
 import type { ProjectConfig, SiteConfig } from 'myst-config';
 import type { LocalProject, LocalProjectPage } from '../project/types.js';
 import type { RootState } from './reducers.js';
-import type { BuildWarning, ExternalLinkResult } from './types.js';
+import type { BuildWarning, ExternalLinkResult, ValidatedRawConfig } from './types.js';
 
 function mutableCopy(obj?: Record<string, any>) {
   if (!obj) return;
@@ -65,8 +65,12 @@ export function selectLocalConfigFile(state: RootState, path: string): string | 
 export function selectLocalRawConfig(
   state: RootState,
   path: string,
-): { raw: Record<string, any>; validated: Record<string, any> } | undefined {
+): { raw: Record<string, any>; validated: ValidatedRawConfig } | undefined {
   return mutableCopy(state.local.config.rawConfigs[resolve(path)]);
+}
+
+export function selectConfigExtensions(state: RootState): string[] {
+  return [...(state.local.config.configExtensions ?? [])];
 }
 
 export function selectReloadingState(state: RootState) {

--- a/packages/myst-cli/src/store/types.ts
+++ b/packages/myst-cli/src/store/types.ts
@@ -18,3 +18,9 @@ export type BuildWarning = {
   position?: VFileMessage['position'];
   ruleId?: string | null;
 };
+
+export type ValidatedRawConfig = {
+  site?: Record<string, any>;
+  project?: Record<string, any>;
+  extend?: string[];
+};

--- a/packages/myst-config/src/index.ts
+++ b/packages/myst-config/src/index.ts
@@ -6,6 +6,7 @@ export * from './site/index.js';
 
 export type Config = {
   version: 1;
+  extend?: string[];
   project?: ProjectConfig;
   site?: SiteConfig;
 };

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.spec.ts
@@ -17,7 +17,6 @@ const TEST_PAGE_FRONTMATTER: PageFrontmatter = {
     },
   ],
   affiliations: [{ id: 'univb', name: 'University B' }],
-  name: 'example.md',
   doi: '10.1000/abcd/efg012',
   arxiv: 'https://arxiv.org/example',
   open_access: true,
@@ -52,7 +51,6 @@ const TEST_PROJECT_FRONTMATTER: ProjectFrontmatter = {
   ],
   affiliations: [{ id: 'univa', name: 'University A' }],
   date: '14 Dec 2021',
-  name: 'example.md',
   doi: '10.1000/abcd/efg012',
   arxiv: 'https://arxiv.org/example',
   open_access: true,
@@ -100,7 +98,6 @@ describe('fillPageFrontmatter', () => {
     const result = { ...TEST_PROJECT_FRONTMATTER };
     delete result.title;
     delete result.description;
-    delete result.name;
     delete result.oxa;
     delete result.exports;
     delete result.requirements;

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
@@ -19,39 +19,48 @@ export function fillPageFrontmatter(
   pageFrontmatter: PageFrontmatter,
   projectFrontmatter: ProjectFrontmatter,
   opts: ValidationOptions,
-) {
-  const frontmatter = fillMissingKeys(pageFrontmatter, projectFrontmatter, USE_PROJECT_FALLBACK);
+): PageFrontmatter {
+  return fillProjectFrontmatter(pageFrontmatter, projectFrontmatter, opts, USE_PROJECT_FALLBACK);
+}
 
-  if (pageFrontmatter.numbering || projectFrontmatter.numbering) {
-    frontmatter.numbering = fillNumbering(pageFrontmatter.numbering, projectFrontmatter.numbering);
+export function fillProjectFrontmatter(
+  base: ProjectFrontmatter,
+  filler: ProjectFrontmatter,
+  opts: ValidationOptions,
+  keys?: string[],
+) {
+  const frontmatter = fillMissingKeys(base, filler, keys ?? Object.keys(filler));
+
+  if (filler.numbering || base.numbering) {
+    frontmatter.numbering = fillNumbering(base.numbering, filler.numbering);
   }
 
   // Combine all math macros defined on page and project
-  if (projectFrontmatter.math || pageFrontmatter.math) {
-    frontmatter.math = { ...(projectFrontmatter.math ?? {}), ...(pageFrontmatter.math ?? {}) };
+  if (filler.math || base.math) {
+    frontmatter.math = { ...(filler.math ?? {}), ...(base.math ?? {}) };
   }
 
   // Combine all abbreviation defined on page and project
-  if (projectFrontmatter.abbreviations || pageFrontmatter.abbreviations) {
+  if (filler.abbreviations || base.abbreviations) {
     frontmatter.abbreviations = {
-      ...(projectFrontmatter.abbreviations ?? {}),
-      ...(pageFrontmatter.abbreviations ?? {}),
+      ...(filler.abbreviations ?? {}),
+      ...(base.abbreviations ?? {}),
     };
   }
 
   // Combine all options defined on page and project
-  if (projectFrontmatter.options || pageFrontmatter.options) {
+  if (filler.options || base.options) {
     frontmatter.options = {
-      ...(projectFrontmatter.options ?? {}),
-      ...(pageFrontmatter.options ?? {}),
+      ...(filler.options ?? {}),
+      ...(base.options ?? {}),
     };
   }
 
   // Combine all settings defined on page and project
-  if (projectFrontmatter.settings || pageFrontmatter.settings) {
+  if (filler.settings || base.settings) {
     frontmatter.settings = {
-      ...(projectFrontmatter.settings ?? {}),
-      ...(pageFrontmatter.settings ?? {}),
+      ...(filler.settings ?? {}),
+      ...(base.settings ?? {}),
     };
   }
 
@@ -83,10 +92,10 @@ export function fillPageFrontmatter(
   if (frontmatter.authors?.length || contributorIds.size) {
     // Gather all people from page/project authors/contributors
     const people = [
-      ...(pageFrontmatter.authors ?? []),
-      ...(projectFrontmatter.authors ?? []),
-      ...(pageFrontmatter.contributors ?? []),
-      ...(projectFrontmatter.contributors ?? []),
+      ...(base.authors ?? []),
+      ...(filler.authors ?? []),
+      ...(base.contributors ?? []),
+      ...(filler.contributors ?? []),
     ];
     const peopleLookup: Record<string, Contributor> = {};
     people.forEach((auth) => {
@@ -126,10 +135,7 @@ export function fillPageFrontmatter(
   });
 
   if (affiliationIds.size) {
-    const affiliations = [
-      ...(pageFrontmatter.affiliations ?? []),
-      ...(projectFrontmatter.affiliations ?? []),
-    ];
+    const affiliations = [...(base.affiliations ?? []), ...(filler.affiliations ?? [])];
     const affiliationLookup: Record<string, Affiliation> = {};
     affiliations.forEach((aff) => {
       if (!aff.id || isStashPlaceholder(aff)) return;

--- a/packages/mystmd/tests/exports.yml
+++ b/packages/mystmd/tests/exports.yml
@@ -144,3 +144,11 @@ cases:
     outputs:
       - path: notebook-fig-embed/_build/site/content/index.json
         content: notebook-fig-embed/outputs/index.json
+  - title: Extend config test
+    cwd: extend-config/proj-a
+    command: myst build
+    outputs:
+      - path: extend-config/proj-a/_build/site/content/index.json
+        content: outputs/extend-config-index.json
+      - path: extend-config/proj-a/_build/site/config.json
+        content: outputs/extend-config-config.json

--- a/packages/mystmd/tests/extend-config/proj-a/index.md
+++ b/packages/mystmd/tests/extend-config/proj-a/index.md
@@ -1,0 +1,3 @@
+# Testing Config
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/packages/mystmd/tests/extend-config/proj-a/index.md
+++ b/packages/mystmd/tests/extend-config/proj-a/index.md
@@ -1,3 +1,8 @@
+---
+math:
+  b: defined-on-page
+---
+
 # Testing Config
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/packages/mystmd/tests/extend-config/proj-a/myst.yml
+++ b/packages/mystmd/tests/extend-config/proj-a/myst.yml
@@ -1,0 +1,15 @@
+version: 1
+project:
+  id: 7c806d98-0093-41ae-9889-dea2b9019064
+  title: MyST Config Extend Test
+  math:
+    a: defined-in-project-a
+    b: defined-in-project-a
+site:
+  template: ../../templates/site/myst/book-theme
+  nav: []
+  actions:
+    - title: Learn More
+      url: https://mystmd.org/guide
+  domains: []
+extends: ../proj-b/myst.yml

--- a/packages/mystmd/tests/extend-config/proj-b/myst.yml
+++ b/packages/mystmd/tests/extend-config/proj-b/myst.yml
@@ -1,0 +1,20 @@
+version: 1
+project:
+  id: 36470d68-33d2-4b16-b0cf-5c955396fe57
+  keywords:
+    - my-kw
+  authors:
+    - John Doe
+  license: CC-BY-4.0
+  math:
+    a: defined-in-project-b
+    c: defined-in-project-b
+site:
+  template: book-theme
+  nav: []
+  actions:
+    - title: Learn More
+      url: https://mystmd.org/guide
+  domains: []
+extends:
+  - ../proj-c/macros.yml

--- a/packages/mystmd/tests/extend-config/proj-c/macros.yml
+++ b/packages/mystmd/tests/extend-config/proj-c/macros.yml
@@ -1,0 +1,6 @@
+version: 1
+project:
+  math:
+    a: defined-in-project-c
+    c: defined-in-project-c
+    d: defined-in-project-c

--- a/packages/mystmd/tests/outputs/basic-site-config.json
+++ b/packages/mystmd/tests/outputs/basic-site-config.json
@@ -1,1 +1,19 @@
-{"options":{},"myst":"1.2.3","nav":[],"actions":[{"title":"Learn More","url":"https://mystmd.org/guide","internal":false,"static":false}],"projects":[{"github":"https://github.com/executablebooks/mystjs","keywords":[],"id":"22c218e1-66c6-428f-9df9-a7f2c6a3bd76","exports":[],"bibliography":[],"title":"Basic Test","index":"index","pages":[]}]}
+{
+  "options": {},
+  "nav": [],
+  "actions": [
+    { "title": "Learn More", "url": "https://mystmd.org/guide", "internal": false, "static": false }
+  ],
+  "projects": [
+    {
+      "github": "https://github.com/executablebooks/mystjs",
+      "keywords": [],
+      "id": "22c218e1-66c6-428f-9df9-a7f2c6a3bd76",
+      "exports": [],
+      "bibliography": [],
+      "title": "Basic Test",
+      "index": "index",
+      "pages": []
+    }
+  ]
+}

--- a/packages/mystmd/tests/outputs/extend-config-config.json
+++ b/packages/mystmd/tests/outputs/extend-config-config.json
@@ -1,0 +1,34 @@
+{
+  "options": {},
+  "nav": [],
+  "actions": [
+    { "title": "Learn More", "url": "https://mystmd.org/guide", "internal": false, "static": false }
+  ],
+  "projects": [
+    {
+      "license": {
+        "content": {
+          "id": "CC-BY-4.0",
+          "name": "Creative Commons Attribution 4.0 International",
+          "free": true,
+          "CC": true,
+          "url": "https://creativecommons.org/licenses/by/4.0/"
+        }
+      },
+      "math": {
+        "a": "defined-in-project-a",
+        "c": "defined-in-project-b",
+        "d": "defined-in-project-c",
+        "b": "defined-in-project-a"
+      },
+      "title": "MyST Config Extend Test",
+      "authors": [{ "id": "John Doe", "name": "John Doe" }],
+      "keywords": ["my-kw"],
+      "id": "7c806d98-0093-41ae-9889-dea2b9019064",
+      "exports": [],
+      "bibliography": [],
+      "index": "index",
+      "pages": []
+    }
+  ]
+}

--- a/packages/mystmd/tests/outputs/extend-config-index.json
+++ b/packages/mystmd/tests/outputs/extend-config-index.json
@@ -1,6 +1,6 @@
 {
   "kind": "Article",
-  "sha256": "b956ef955e38d755ee949dded619a8cbcd7dfbe7e33d368ab867a1aab49992ee",
+  "sha256": "1303d3b24843b9c9a7a3df04f2b8625a9e690eae98dee1f87ee870d6db6986af",
   "slug": "index",
   "location": "/index.md",
   "dependencies": [],
@@ -22,13 +22,12 @@
       "a": "defined-in-project-a",
       "c": "defined-in-project-b",
       "d": "defined-in-project-c",
-      "b": "defined-in-project-a"
+      "b": "defined-on-page"
     },
     "exports": [
       {
         "format": "md",
-        "filename": "index.md",
-        "url": "/index-552a182d983b86e4781eb9df6c156089.md"
+        "filename": "index.md"
       }
     ]
   },
@@ -40,14 +39,14 @@
         "children": [
           {
             "type": "paragraph",
-            "position": { "start": { "line": 3, "column": 1 }, "end": { "line": 3, "column": 1 } },
+            "position": { "start": { "line": 8, "column": 1 }, "end": { "line": 8, "column": 1 } },
             "children": [
               {
                 "type": "text",
                 "value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
                 "position": {
-                  "start": { "line": 3, "column": 1 },
-                  "end": { "line": 3, "column": 1 }
+                  "start": { "line": 8, "column": 1 },
+                  "end": { "line": 8, "column": 1 }
                 }
               }
             ]

--- a/packages/mystmd/tests/outputs/extend-config-index.json
+++ b/packages/mystmd/tests/outputs/extend-config-index.json
@@ -1,0 +1,60 @@
+{
+  "kind": "Article",
+  "sha256": "b956ef955e38d755ee949dded619a8cbcd7dfbe7e33d368ab867a1aab49992ee",
+  "slug": "index",
+  "location": "/index.md",
+  "dependencies": [],
+  "frontmatter": {
+    "title": "Testing Config",
+    "content_includes_title": false,
+    "authors": [{ "id": "John Doe", "name": "John Doe" }],
+    "license": {
+      "content": {
+        "id": "CC-BY-4.0",
+        "name": "Creative Commons Attribution 4.0 International",
+        "free": true,
+        "CC": true,
+        "url": "https://creativecommons.org/licenses/by/4.0/"
+      }
+    },
+    "keywords": ["my-kw"],
+    "math": {
+      "a": "defined-in-project-a",
+      "c": "defined-in-project-b",
+      "d": "defined-in-project-c",
+      "b": "defined-in-project-a"
+    },
+    "exports": [
+      {
+        "format": "md",
+        "filename": "index.md",
+        "url": "/index-552a182d983b86e4781eb9df6c156089.md"
+      }
+    ]
+  },
+  "mdast": {
+    "type": "root",
+    "children": [
+      {
+        "type": "block",
+        "children": [
+          {
+            "type": "paragraph",
+            "position": { "start": { "line": 3, "column": 1 }, "end": { "line": 3, "column": 1 } },
+            "children": [
+              {
+                "type": "text",
+                "value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+                "position": {
+                  "start": { "line": 3, "column": 1 },
+                  "end": { "line": 3, "column": 1 }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "references": { "cite": { "order": [], "data": {} } }
+}

--- a/packages/mystmd/tests/outputs/site-xrefs-config.json
+++ b/packages/mystmd/tests/outputs/site-xrefs-config.json
@@ -1,6 +1,5 @@
 {
   "options": {},
-  "myst": "1.2.3",
   "nav": [],
   "actions": [
     { "title": "Learn More", "url": "https://mystmd.org/guide", "internal": false, "static": false }


### PR DESCRIPTION
This PR allows users to have project frontmatter defined in multiple files (all of the same `myst.yml` format), then the main `myst.yml` can bring in those other files under the top level `extends` key. A small example has been added to the docs.