### PR TITLE
:sparkle: Read configuration for execution from `myst.yml`

### DIFF
--- a/.changeset/long-jobs-listen.md
+++ b/.changeset/long-jobs-listen.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": minor
+---
+
+Read execution config from myst.yml

--- a/docs/integrating-jupyter.md
+++ b/docs/integrating-jupyter.md
@@ -287,7 +287,7 @@ Add the specific list options for custom wheel paths, etc.
 In addition to how you might normally start a JupyterLab session, it's necessary to provide two additional command line options, as follows.
 
 ```{code} bash
-jupyter lab --NotebookApp.token=<your-secret-token> --NotebookApp.allow_origin='http://localhost:3000'
+jupyter lab --IdentityProvider.token=<your-secret-token> --ServerApp.allow_origin='http://localhost:3000'
 ```
 
 The command above is fine for local development. The `token` used should align with that provided in the `project.thebe.token` key and `allow_origin` should allow connections from your myst site preview, usually running on `http://localhost:3000`.

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -204,10 +204,16 @@ export class Session implements ISession {
   }
 
   private async createJupyterSessionManager(): Promise<SessionManager | undefined> {
+    const projectConfig = selectors.selectCurrentProjectConfig(this.store.getState());
     try {
       let partialServerSettings: JupyterServerSettings | undefined;
-      // Load from environment
-      if (process.env.JUPYTER_BASE_URL !== undefined) {
+      const configServer = projectConfig?.thebe?.server;
+      if (configServer !== undefined) {
+        partialServerSettings = {
+          baseUrl: configServer.url,
+          token: configServer.token,
+        };
+      } else if (process.env.JUPYTER_BASE_URL !== undefined) {
         partialServerSettings = {
           baseUrl: process.env.JUPYTER_BASE_URL,
           token: process.env.JUPYTER_TOKEN,


### PR DESCRIPTION
Fixes #1214