### PR TITLE
📖 Document include for splitting a document across multiple parts

### DIFF
--- a/docs/documents-exports.md
+++ b/docs/documents-exports.md
@@ -56,3 +56,10 @@ The following table shows the available properties for each export. You must def
 ```{seealso} Exposing Exports as Downloads
 You can also include exported documents as downloads in your site, see [](./website-downloads.md).
 ```
+
+## Split your document across multiple content files
+
+When writing longer documents like manuscripts, it's common to write your document in multiple parts and then stitch them together into a single narrative.
+You can accomplish this in MyST with the {myst:directive}`include` directive.
+
+See [](#docs:include) for more information.

--- a/docs/embed.md
+++ b/docs/embed.md
@@ -146,8 +146,11 @@ The following content is embedded from `![](xref:spec#admonition)`:
 
 ## The {myst:directive}`include` directive
 
-If a portion of your content is in a separate file that is **not already included in your project** you can use the {myst:directive}`include` directive to parse and include that content.
-This directive is helpful for including content snippets, such as a table, equation, that you want to keep in a different file on disk, but present as if it were one document. In addition to Markdown, MyST will also parse `.ipynb`, `.tex`, and `.html`.
+You can include multiple files into your MyST document as if they were all written in the same file.
+This allows you to store content in separate files, and then weave them together at build time.
+To do so, use the {myst:directive}`include` directive.
+
+This is also helpful for including content snippets, such as a table or an equation, that you want to keep in a different file on disk, but present as if it were one document. In addition to Markdown, MyST will also parse `.ipynb`, `.tex`, and `.html`.
 
 See {myst:directive}`the {include} directive documentation <include>` for details about all the arguments you can give to `{include}`.
 


### PR DESCRIPTION
Inspired by this discussion:

- https://github.com/orgs/executablebooks/discussions/1182#discussioncomment-9540505

This adds a short description of how you can split a document across many parts. I figured it's worth documenting since this is a very common workflow. @matthewfeickert curious if you would have found this here?