### PR TITLE
🌎 Fetch config extensions from URL

### DIFF
--- a/.changeset/hot-actors-destroy.md
+++ b/.changeset/hot-actors-destroy.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'mystmd': patch
+---
+
+Fetch config files from url

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -126,7 +126,10 @@ export async function collectAllBuildExportOptions(
     throw new Error(`When specifying output, you can only request one format`);
   }
   let exportOptionsList: ExportWithInputOutput[];
-  const projectPath = findCurrentProjectAndLoad(session, files[0] ? path.dirname(files[0]) : '.');
+  const projectPath = await findCurrentProjectAndLoad(
+    session,
+    files[0] ? path.dirname(files[0]) : '.',
+  );
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   if (output) {
     session.log.debug(`Exporting formats: "${requestedFormats.join('", "')}"`);

--- a/packages/myst-cli/src/build/init.ts
+++ b/packages/myst-cli/src/build/init.ts
@@ -69,7 +69,7 @@ export async function init(session: ISession, opts: InitOptions) {
   if (!project && !site && !writeTOC) {
     session.log.info(WELCOME());
   }
-  loadConfig(session, '.');
+  await loadConfig(session, '.');
   const state = session.store.getState();
   const existingRawConfig = selectors.selectLocalRawConfig(state, '.');
   const existingProjectConfig = selectors.selectLocalProjectConfig(state, '.');
@@ -96,7 +96,7 @@ export async function init(session: ISession, opts: InitOptions) {
     }
     if (siteConfig || projectConfig) {
       session.log.info(`💾 Updating config file: ${existingConfigFile}`);
-      writeConfigs(session, '.', { siteConfig, projectConfig });
+      await writeConfigs(session, '.', { siteConfig, projectConfig });
     }
   } else {
     // If no config is present, write it explicitly to include comments.
@@ -119,7 +119,7 @@ export async function init(session: ISession, opts: InitOptions) {
     fs.writeFileSync(configFile, configData);
   }
   if (writeTOC) {
-    loadConfig(session, '.');
+    await loadConfig(session, '.');
     await loadProjectFromDisk(session, '.', { writeTOC });
   }
   // If we have any options, this command is complete!

--- a/packages/myst-cli/src/build/legacy.ts
+++ b/packages/myst-cli/src/build/legacy.ts
@@ -47,7 +47,7 @@ export async function localArticleToWord(
   extraLinkTransformers?: LinkTransformer[],
 ): Promise<ExportResults> {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
     await legacyCollectExportOptions(session, file, 'docx', [ExportFormats.docx], projectPath, opts)
@@ -81,7 +81,7 @@ export async function localArticleToJats(
   extraLinkTransformers?: LinkTransformer[],
 ) {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
     await legacyCollectExportOptions(session, file, 'xml', [ExportFormats.xml], projectPath, opts)
@@ -115,7 +115,7 @@ export async function localArticleToMd(
   extraLinkTransformers?: LinkTransformer[],
 ) {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
     await legacyCollectExportOptions(session, file, 'md', [ExportFormats.md], projectPath, opts)
@@ -146,7 +146,7 @@ export async function localProjectToMeca(
   extraLinkTransformers?: LinkTransformer[],
 ) {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
     await legacyCollectExportOptions(session, file, 'zip', [ExportFormats.meca], projectPath, opts)
@@ -179,7 +179,7 @@ export async function localArticleToPdf(
   templateOptions?: Record<string, any>,
 ): Promise<ExportResults> {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const pdfExportOptionsList = (
     await legacyCollectExportOptions(
@@ -249,7 +249,7 @@ export async function localArticleToTex(
   extraLinkTransformers?: LinkTransformer[],
 ): Promise<ExportResults> {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
     await legacyCollectExportOptions(session, file, 'tex', [ExportFormats.tex], projectPath, opts)
@@ -323,7 +323,7 @@ export async function localArticleToTypst(
   extraLinkTransformers?: LinkTransformer[],
 ): Promise<ExportResults> {
   let { projectPath } = opts;
-  if (!projectPath) projectPath = findCurrentProjectAndLoad(session, path.dirname(file));
+  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
     await legacyCollectExportOptions(session, file, 'typ', [ExportFormats.typst], projectPath, opts)

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -120,7 +120,7 @@ export async function startServer(
   opts: StartOptions,
 ): Promise<AppServer | undefined> {
   // Ensure we are on the latest version of the configs
-  session.reload();
+  await session.reload();
   warnOnHostEnvironmentVariable(session, opts);
   const mystTemplate = await getMystTemplate(session, opts);
   if (!opts.headless) await installSiteTemplate(session, mystTemplate);

--- a/packages/myst-cli/src/build/utils/collectExportOptions.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.ts
@@ -471,7 +471,7 @@ export async function collectExportOptions(
     sourceFiles.map(async (file) => {
       let fileProjectPath: string | undefined;
       if (!projectPath) {
-        fileProjectPath = findCurrentProjectAndLoad(session, path.dirname(file));
+        fileProjectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
         if (fileProjectPath) await loadProjectFromDisk(session, fileProjectPath);
       } else {
         fileProjectPath = projectPath;

--- a/packages/myst-cli/src/build/utils/localArticleExport.ts
+++ b/packages/myst-cli/src/build/utils/localArticleExport.ts
@@ -82,9 +82,11 @@ async function _localArticleExport(
     exportOptionsList.map(async (exportOptionsWithFile) => {
       const { $file, $project, ...exportOptions } = exportOptionsWithFile;
       const { format, output } = exportOptions;
-      const sessionClone = session.clone();
+      const sessionClone = await session.clone();
       const fileProjectPath =
-        projectPath ?? $project ?? findCurrentProjectAndLoad(sessionClone, path.dirname($file));
+        projectPath ??
+        $project ??
+        (await findCurrentProjectAndLoad(sessionClone, path.dirname($file)));
 
       if (fileProjectPath) {
         await loadProjectFromDisk(sessionClone, fileProjectPath);

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -385,7 +385,7 @@ async function resolveProjectConfigPaths(
   if (projectConfig.exclude) {
     resolvedFields.exclude = await Promise.all(
       projectConfig.exclude.map(async (file) => {
-        const resolved = await resolutionFn(session, path, file, false);
+        const resolved = await resolutionFn(session, path, file, { allowNotExist: true });
         return resolved;
       }),
     );

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -286,7 +286,7 @@ export async function resolveToAbsolute(
     relativePath = cachePath(session, cacheFilename);
   }
   try {
-    const absPath = resolve(join(basePath, relativePath));
+    const absPath = resolve(basePath, relativePath);
     if (!checkExists || fs.existsSync(absPath)) {
       return absPath;
     }

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -466,7 +466,7 @@ export async function processProject(
 
 export async function processSite(session: ISession, opts?: ProcessSiteOptions): Promise<boolean> {
   try {
-    reloadAllConfigsForCurrentSite(session);
+    await reloadAllConfigsForCurrentSite(session);
   } catch (error) {
     session.log.debug(`\n\n${(error as Error)?.stack}\n\n`);
     const prefix = (error as Error)?.message

--- a/packages/myst-cli/src/project/toTOC.ts
+++ b/packages/myst-cli/src/project/toTOC.ts
@@ -49,7 +49,7 @@ function tocFromPages(pages: (LocalProjectFolder | LocalProjectPage)[], path: st
 }
 
 export function tocFromProject(
-  project: Omit<LocalProject, 'bibliography'>,
+  project: Pick<LocalProject, 'file' | 'pages'>,
   dir: string = '.',
 ): any {
   return [

--- a/packages/myst-cli/src/project/toc.spec.ts
+++ b/packages/myst-cli/src/project/toc.spec.ts
@@ -576,7 +576,7 @@ describe('findProjectPaths', () => {
       'folder/newproj/page.md': '',
       'folder/newproj/myst.yml': SITE_CONFIG,
     });
-    expect(findProjectsOnPath(session, '.')).toEqual([]);
+    expect(await findProjectsOnPath(session, '.')).toEqual([]);
   });
   it('project myst.ymls', async () => {
     memfs.vol.fromJSON({
@@ -587,7 +587,7 @@ describe('findProjectPaths', () => {
       'folder/newproj/page.md': '',
       'folder/newproj/myst.yml': PROJECT_CONFIG,
     });
-    expect(findProjectsOnPath(session, '.')).toEqual(['.', 'folder/newproj']);
+    expect(await findProjectsOnPath(session, '.')).toEqual(['.', 'folder/newproj']);
   });
 });
 

--- a/packages/myst-cli/src/session/session.spec.ts
+++ b/packages/myst-cli/src/session/session.spec.ts
@@ -25,7 +25,7 @@ describe('session warnings', () => {
   });
   it('getAllWarnings returns clone warnings', async () => {
     const session = new Session();
-    const clone = session.clone();
+    const clone = await session.clone();
     addWarningForFile(session, 'my-file-0', 'my message', 'error', {
       ruleId: RuleId.bibFileExists,
     });
@@ -55,7 +55,7 @@ describe('session warnings', () => {
   });
   it('getAllWarnings deduplicates clone warnings', async () => {
     const session = new Session();
-    const clone = session.clone();
+    const clone = await session.clone();
     addWarningForFile(session, 'my-file', 'my message', 'error', { ruleId: RuleId.bibFileExists });
     addWarningForFile(clone, 'my-file', 'my message', 'error', { ruleId: RuleId.bibFileExists });
     expect(session.getAllWarnings(RuleId.bibFileExists)).toEqual([

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -91,7 +91,6 @@ export class Session implements ISession {
     const proxyUrl = process.env.HTTPS_PROXY;
     if (proxyUrl) this.proxyAgent = new HttpsProxyAgent(proxyUrl);
     this.store = createStore(rootReducer);
-    this.reload();
     // Allow the latest version to be loaded
     latestVersion('mystmd')
       .then((latest) => {
@@ -113,11 +112,11 @@ export class Session implements ISession {
     this._shownUpgrade = true;
   }
 
-  reload() {
-    findCurrentProjectAndLoad(this, '.');
-    findCurrentSiteAndLoad(this, '.');
+  async reload() {
+    await findCurrentProjectAndLoad(this, '.');
+    await findCurrentSiteAndLoad(this, '.');
     if (selectors.selectCurrentSitePath(this.store.getState())) {
-      reloadAllConfigsForCurrentSite(this);
+      await reloadAllConfigsForCurrentSite(this);
     }
     return this;
   }
@@ -172,8 +171,9 @@ export class Session implements ISession {
 
   _clones: ISession[] = [];
 
-  clone(): Session {
+  async clone() {
     const cloneSession = new Session({ logger: this.log });
+    await cloneSession.reload();
     // TODO: clean this up through better state handling
     cloneSession._jupyterSessionManagerPromise = this._jupyterSessionManagerPromise;
     this._clones.push(cloneSession);

--- a/packages/myst-cli/src/session/types.ts
+++ b/packages/myst-cli/src/session/types.ts
@@ -14,8 +14,8 @@ export type ISession = {
   configFiles: string[];
   store: Store<RootState>;
   log: Logger;
-  reload(): ISession;
-  clone(): ISession;
+  reload(): Promise<ISession>;
+  clone(): Promise<ISession>;
   sourcePath(): string;
   buildPath(): string;
   sitePath(): string;

--- a/packages/mystmd/src/clirun.ts
+++ b/packages/mystmd/src/clirun.ts
@@ -19,6 +19,7 @@ export function clirun(
     const opts = program.opts() as SessionOpts;
     const logger = chalkLogger(opts?.debug ? LogLevel.debug : LogLevel.info, process.cwd());
     const session = new sessionClass({ logger });
+    await session.reload();
     const versions = await getNodeVersion(session);
     logVersions(session, versions);
     const versionsInstalled = await checkNodeVersion(session);


### PR DESCRIPTION
`extends` pr was added here to allow one myst.yml to extend another: https://github.com/executablebooks/mystmd/pull/1215

In that PR and in this issue https://github.com/executablebooks/mystmd/issues/336 the next step was allowing remote urls for the extend content so centralized data may be reused across users/projects. This PR adds that remote resolution step!

Biggest thing about this pr is going from sync to async at the config loading level; this means many functions are newly awaited... big diff minor impact.