### PR TITLE
🚨 Surface warnings during toc file extension resolution

### DIFF
--- a/.changeset/large-ravens-shop.md
+++ b/.changeset/large-ravens-shop.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Surface warnings during tocfile extension resolution

--- a/packages/myst-cli/src/build/utils/collectExportOptions.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.ts
@@ -87,7 +87,7 @@ function resolveArticlesFromTOC(
   } else if (exp.top_level === 'chapters') {
     level = 0;
   }
-  const proj = projectFromTOC(session, projectPath, toc, level);
+  const proj = projectFromTOC(session, projectPath, toc, level, vfile.path);
   return resolveArticlesFromProject(exp, proj, vfile);
 }
 

--- a/packages/myst-cli/src/project/load.ts
+++ b/packages/myst-cli/src/project/load.ts
@@ -57,7 +57,7 @@ export async function loadProjectFromDisk(
   let legacyToc = false;
   const sphinxTOCFile = validateSphinxTOC(session, path) ? tocFile(path) : undefined;
   if (projectConfig?.toc !== undefined) {
-    newProject = projectFromTOC(session, path, projectConfig.toc);
+    newProject = projectFromTOC(session, path, projectConfig.toc, 1, projectConfigFile);
     if (sphinxTOCFile) {
       addWarningForFile(
         session,

--- a/packages/myst-cli/src/utils/resolveExtension.ts
+++ b/packages/myst-cli/src/utils/resolveExtension.ts
@@ -23,14 +23,45 @@ export function isValidFile(file: string): boolean {
   return VALID_FILE_EXTENSIONS.includes(path.extname(file).toLowerCase());
 }
 
-// export function isDirectory(file: string): boolean {
-//   return fs.lstatSync(file).isDirectory();
-// }
-
-export function resolveExtension(file: string): string | undefined {
+export function resolveExtension(
+  file: string,
+  warnFn?: (message: string, level: 'warn' | 'error', note?: string) => void,
+): string | undefined {
   if (fs.existsSync(file) && !isDirectory(file)) return file;
   const extensions = VALID_FILE_EXTENSIONS.concat(
     VALID_FILE_EXTENSIONS.map((ext) => ext.toUpperCase()),
   );
-  return extensions.map((ext) => `${file}${ext}`).find((fileExt) => fs.existsSync(fileExt));
+  const matches = extensions
+    .map((ext) => `${file}${ext}`)
+    .filter((fileExt) => fs.existsSync(fileExt));
+  if (warnFn) {
+    const normalizedMatches: string[] = [];
+    matches.forEach((match) => {
+      if (!normalizedMatches.map((m) => m.toLowerCase()).includes(match.toLowerCase())) {
+        normalizedMatches.push(match);
+      }
+    });
+    if (normalizedMatches.length === 0 && path.extname(file)) {
+      warnFn(`Table of contents entry does not exist: ${file}`, 'error');
+    } else if (normalizedMatches.length === 0) {
+      warnFn(
+        `Unable to resolve table of contents entry: ${file}`,
+        'error',
+        `Expected one of:\n     - ${VALID_FILE_EXTENSIONS.map((ext) => `${file}${ext}`).join('\n- ')}`,
+      );
+    } else if (normalizedMatches.length === 1) {
+      warnFn(
+        `Extension inferred for table of contents entry: ${file}`,
+        'warn',
+        `To ensure consistent behavior, update the toc entry to ${matches[0]}`,
+      );
+    } else {
+      warnFn(
+        `Multiple files match table of contents entry: ${file}`,
+        'error',
+        `Valid files include: ${normalizedMatches[0]} (currently used in the build), ${normalizedMatches.slice(1).join(', ')}\n   Update the toc entry to include the correct extension to ensure consistent behavior.`,
+      );
+    }
+  }
+  return matches[0];
 }


### PR DESCRIPTION
Old jupyterbook-style `_toc.yml` files allowed (required...?) filenames without extensions. We are hoping to encourage explicit filenames with extensions in the new `myst.yml` toc.

This PR raises warnings/errors during toc resolution; there are 4 distinct errors:
- toc entry has an extension but does not exist
- toc entry has no extension and cannot be resolved to a file that exists
- toc entry has no extension and resolves to a single file (this is just a warning, but still surfaced to the user)
- toc entry has no extension and resolves to multiple files

This PR addresses https://github.com/executablebooks/mystmd/issues/1248

Note - legacy jupyterbook toc behavior and warnings/errors are unchanged.