### PR TITLE
:chair: Update `table` docs

### DIFF
--- a/docs/table-from-file.html
+++ b/docs/table-from-file.html
@@ -1,0 +1,38 @@
+<table>
+    <tr>
+       <th rowspan="2">Projection</th>
+       <th colspan="3" align="center">Area in square miles</th>
+    </tr>
+    <tr>
+       <th align="right">Large Horizontal Area</th>
+       <th align="right" style="background: -webkit-linear-gradient(20deg, #09009f, #E743D9); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">Large Vertical Area</th>
+       <th align="right">Smaller Square Area
+       <th>
+    </tr>
+    <tr>
+       <td>Albers Equal Area</td>
+       <td align="right">7,498.7</td>
+       <td align="right">10,847.3</td>
+       <td align="right">35.8</td>
+    </tr>
+    <tr>
+       <td>Web Mercator</td>
+       <td align="right">13,410.0</td>
+       <td align="right">18,271.4</td>
+       <td align="right">63.0</td>
+    </tr>
+    <tr>
+       <td>Difference</td>
+       <td align="right" style="background-color: red;color: white">5,911.3</td>
+       <td align="right">7,424.1</td>
+       <td align="right">27.2</td>
+    </tr>
+    <tr>
+       <td>
+          <bold>Percent Difference</bold>
+       </td>
+       <td align="right" style="background-color: green;color: white">44%</td>
+       <td align="right">41%</td>
+       <td align="right">43%</td>
+    </tr>
+ </table>

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -132,7 +132,7 @@ CSS styles are currently only used for HTML outputs and are not carried through 
 
 ## Include tables from file
 
-If you have tables in a file (e.g. output from your data analysis elsewhere), you can use the [`{include}` directive](directives.md/#include). This works both for HTML and TeX tables.
+If you have tables in a file (e.g. output from your data analysis elsewhere), you can use the {myst:directive}`include` directive. This works both for HTML and LaTeX tables.
 
 ```{myst}
 ::::{table} Area Comparisons (imported HTML file)

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -22,9 +22,9 @@ Cells in a column can be aligned using the `:` character:
 
 % TODO: The centering isn't working!?
 
-## Adding a Caption
+## Table directive
 
-You can use the {myst:directive}`table` directive to add a caption to a markdown table.
+To add more features to your table, you can use the {myst:directive}`table` directive. Here you can add a caption and label. Adding a label enables [cross-referencing](cross-references.md) .
 
 ```{myst}
 :::{table} Table caption
@@ -129,6 +129,20 @@ It is also possible to write tables in raw HTML with `rowspan` and `colspan`, as
 :::{note} Styles are Only for HTML
 CSS styles are currently only used for HTML outputs and are not carried through to all export targets (e.g. LaTeX) and are primarily used for web.
 :::
+
+## Include tables from file
+
+If you have tables in a file (e.g. output from your data analysis elsewhere), you can use the [`{include}` directive](directives.md/#include). This works both for HTML and TeX tables.
+
+```{myst}
+::::{table} Area Comparisons (imported HTML file)
+:label: tbl:areas-html-file
+
+:::{include} table-from-file.html
+:::
+
+::::
+```
 
 ## Notebook outputs as tables
 


### PR DESCRIPTION
This PR does two small things: 

1. Documents that `:label:` is needed for table numbering.
2. Introduces import table from file via `{include}`.

I've added an HTML table file too.
Closes #1241.