### PR TITLE
:bug: Support `raises-exception` in cell execution

### DIFF
--- a/docs/execute-notebooks.md
+++ b/docs/execute-notebooks.md
@@ -28,6 +28,20 @@ The following computational content will be executed:
 In order to execute your MyST content, you must install a Jupyter Server and the kernel needed to execute your code (e.g., the [IPython kernel](https://ipython.readthedocs.io/en/stable/), the [Xeus Python kernel](https://github.com/jupyter-xeus/xeus-python), or the [IRKernel](https://irkernel.github.io/).)
 :::
 
+
+## Deadling with errors
+
+Sometimes, it is expected that a code-cell might fail (e.g. to demonstrate invalid code). Notebook environments like JupyterLab (and Jupyter Notebook, its predecessor) will stop notebook execution once a cell failure occurs. These applications can be instructed to continue execution of a notebook if a cell fails by setting the `raises-exception` tag. This is often used to execute code that is expected to fail, e.g. to demonstrate the traceback for invalid code.
+
+For example, setting the tag for a {myst:directive}`code-cell` directive:
+````markdown
+```{code-cell}
+:tags: raises-exception
+
+print("Hello" + 10001)
+````
+
+
 ## Cache execution outputs
 
 When MyST executes your notebook, it will store the outputs in a cache in a folder called `execute/` in your MyST build folder.

--- a/docs/execute-notebooks.md
+++ b/docs/execute-notebooks.md
@@ -29,16 +29,23 @@ In order to execute your MyST content, you must install a Jupyter Server and the
 :::
 
 
-## Dealing with errors
+## Expected errors
 
-Sometimes, it is expected that a code-cell might fail (e.g. to demonstrate invalid code). Notebook environments like JupyterLab (and Jupyter Notebook, its predecessor) will stop notebook execution once a cell failure occurs. These applications can be instructed to continue execution of a notebook if a cell fails by setting the `raises-exception` tag. This is often used to execute code that is expected to fail, e.g. to demonstrate the traceback for invalid code.
+By default, MyST will stop executing a notebook if a cell raises an error.
+If instead you'd like MyST to continue executing subsequent cells (e.g., in order to demonstrate an expected error message), add the {guilabel}`raises-exception` tag to the cell.
+If a cell with this tag raises an error, then the error is provided with the cell output, and MyST will continue executing the rest of the cells in a notebook.
 
-For example, setting the tag for a {myst:directive}`code-cell` directive:
+The easiest way to add cell tags is via [the JupyterLab interface](https://jupyterlab.readthedocs.io).
+Additionally, you can specify tags (and other cell metadata) with markdown using the {myst:directive}`code-cell` directive.
+
+Here's an example of adding this tag with a {myst:directive}`code-cell` directive:
+
 ````markdown
 ```{code-cell}
 :tags: raises-exception
 
 print("Hello" + 10001)
+```
 ````
 
 

--- a/docs/execute-notebooks.md
+++ b/docs/execute-notebooks.md
@@ -29,7 +29,7 @@ In order to execute your MyST content, you must install a Jupyter Server and the
 :::
 
 
-## Deadling with errors
+## Dealing with errors
 
 Sometimes, it is expected that a code-cell might fail (e.g. to demonstrate invalid code). Notebook environments like JupyterLab (and Jupyter Notebook, its predecessor) will stop notebook execution once a cell failure occurs. These applications can be instructed to continue execution of a notebook if a cell fails by setting the `raises-exception` tag. This is often used to execute code that is expected to fail, e.g. to demonstrate the traceback for invalid code.
 

--- a/packages/myst-execute/src/execute.ts
+++ b/packages/myst-execute/src/execute.ts
@@ -118,7 +118,7 @@ function buildCacheKey(nodes: (ICellBlock | InlineExpression)[]): string {
       hashableItems.push({
         kind: node.type,
         content: (select('code', node) as Code).value,
-        raisesException: !!node.data?.tags?.['raises-exception'],
+        raisesException: !!node.data?.tags?.includes?.('raises-exception'),
       });
     } else {
       assert(isInlineExpression(node));
@@ -188,8 +188,7 @@ async function computeExecutableNodes(
       results.push(outputs);
 
       // Check for errors
-      const metadata = matchedNode.data || {};
-      const allowErrors = !!metadata?.tags?.['raises-exception'];
+      const allowErrors = !!matchedNode.data?.tags?.includes?.('raises-exception');
       if (status === 'error' && !allowErrors) {
         fileWarn(
           opts.vfile,

--- a/packages/myst-execute/tests/execute.yml
+++ b/packages/myst-execute/tests/execute.yml
@@ -209,3 +209,62 @@ cases:
                   #   - "\e[0;31mValueError\e[0m: "
                   ename: ValueError
                   evalue: ''
+  - title: tree with bad executable code and `raises-exception` is evaluated and passes
+    before:
+      type: root
+      children:
+        - type: block
+          kind: notebook-code
+          data:
+            id: nb-cell-0
+            tags: raises-exception
+          identifier: nb-cell-0
+          label: nb-cell-0
+          html_id: nb-cell-0
+          children:
+            - type: code
+              lang: python
+              executable: true
+              value: raise ValueError
+              identifier: nb-cell-0-code
+              enumerator: 1
+              html_id: nb-cell-0-code
+            - type: output
+              id: T7FMDqDm8dM2bOT1tKeeM
+              identifier: nb-cell-0-output
+              html_id: nb-cell-0-output
+              data:  
+    after:
+      type: root
+      children:
+        - type: block
+          kind: notebook-code
+          data:
+            id: nb-cell-0
+            tags: raises-exception
+          identifier: nb-cell-0
+          label: nb-cell-0
+          html_id: nb-cell-0
+          children:
+            - type: code
+              lang: python
+              executable: true
+              value: raise ValueError
+              identifier: nb-cell-0-code
+              enumerator: 1
+              html_id: nb-cell-0-code
+            - type: output
+              id: T7FMDqDm8dM2bOT1tKeeM
+              identifier: nb-cell-0-output
+              html_id: nb-cell-0-output
+              data:
+                - output_type: error
+                  # Note this traceback can be different on various machines
+                  # Not including it means we still validate an error, just don't care about the traceback
+                  # traceback:
+                  #   - "\e[0;31m---------------------------------------------------------------------------\e[0m"
+                  #   - "\e[0;31mValueError\e[0m                                Traceback (most recent call last)"
+                  #   - "Cell \e[0;32mIn[2], line 1\e[0m\n\e[0;32m----> 1\e[0m \e[38;5;28;01mraise\e[39;00m \e[38;5;167;01mValueError\e[39;00m\n"
+                  #   - "\e[0;31mValueError\e[0m: "
+                  ename: ValueError
+                  evalue: ''


### PR DESCRIPTION
This was already supposed to be implemented, but a silly mistake prevented it from working.