### PR TITLE
:bug: Fix CSV-table caption

### DIFF
--- a/.changeset/short-deers-explain.md
+++ b/.changeset/short-deers-explain.md
@@ -1,0 +1,5 @@
+---
+"myst-directives": patch
+---
+
+Fix caption for CSV table

--- a/packages/myst-directives/src/table.ts
+++ b/packages/myst-directives/src/table.ts
@@ -335,7 +335,6 @@ export const csvTableDirective: DirectiveSpec = {
       children: rows,
     };
 
-
     const container = {
       type: 'container',
       kind: 'table',

--- a/packages/myst-directives/src/table.ts
+++ b/packages/myst-directives/src/table.ts
@@ -271,6 +271,14 @@ export const csvTableDirective: DirectiveSpec = {
   run(data: DirectiveData, vfile: VFile, ctx: DirectiveContext): GenericNode[] {
     const { label, identifier } = normalizeLabel(data.options?.label as string | undefined) || {};
 
+    const captions: GenericParent[] = [];
+    if (data.arg) {
+      captions.push({
+        type: 'caption',
+        children: [{ type: 'paragraph', children: data.arg as GenericNode[] }],
+      });
+    }
+
     const rows: GenericParent[] = [];
 
     if (data.options?.header !== undefined) {
@@ -326,13 +334,15 @@ export const csvTableDirective: DirectiveSpec = {
       align: data.options?.align,
       children: rows,
     };
+
+
     const container = {
       type: 'container',
       kind: 'table',
       identifier: identifier,
       label: label,
       class: data.options?.class,
-      children: [...((data.arg ?? []) as GenericNode[]), table],
+      children: [...captions, table],
     };
 
     return [container];


### PR DESCRIPTION
This PR ensures that we wrap captions in CSV-table nodes with the `caption` node.

Fixes #1273 