### PR TITLE
⏳ Add a log message for slow web requests

### DIFF
--- a/.changeset/sixty-suns-serve.md
+++ b/.changeset/sixty-suns-serve.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Add a log message for slow web requests

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -129,7 +129,12 @@ export class Session implements ISession {
       init = { agent: this.proxyAgent, ...init };
       this.log.debug(`Using HTTPS proxy: ${this.proxyAgent.proxy}`);
     }
+    const logData = { url: urlOnly, done: false };
+    setTimeout(() => {
+      if (!logData.done) this.log.info(`⏳ Waiting for response from ${url}`);
+    }, 5000);
     const resp = await nodeFetch(url, init);
+    logData.done = true;
     return resp;
   }
 


### PR DESCRIPTION
Some of the DOI updates made slow requests very apparent - it feels like MyST is hanging when it's just waiting for a response.

This little PR adds a small log message to `session.fetch` that appears when a response takes more than 5s.