### PR TITLE
🏷 Add tags to project frontmatter

### DIFF
--- a/.changeset/seven-kangaroos-matter.md
+++ b/.changeset/seven-kangaroos-matter.md
@@ -1,0 +1,5 @@
+---
+"myst-frontmatter": patch
+---
+
+Add tags to project frontmatter

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -108,7 +108,7 @@ The following table lists the available frontmatter fields, a brief description 
   - a string (max 500 chars) to identify the page in cross-references
   - page only
 * - `tags`
-  - a list of strings
+  - a list of strings. Use to categorize posts/articles or the project to make it easier for readers to find related content within your site.
   - page & project
 * - `thumbnail`
   - a link to a local or remote image
@@ -118,6 +118,9 @@ The following table lists the available frontmatter fields, a brief description 
   - page & project
 * - `date`
   - a valid date formatted string
+  - page can override project
+* - `keywords`
+  - a list of strings. Use in articles to highlight key concepts and facilitate indexing in scientific databases.
   - page can override project
 * - `authors`
   - a list of author objects, see [](#frontmatter:authors)

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -55,6 +55,7 @@ project:
 ```
 
 (composing-myst-yml)=
+
 #### Composing multiple `.yml` files
 
 You may separate your frontmatter into multiple, composable files. To reference other files from your main `myst.yml` file, use the `extends` key with relative path(s) to the other configuration files:
@@ -88,6 +89,9 @@ The following table lists the available frontmatter fields, a brief description 
 * - `title`
   - a string (max 500 chars, see [](#titles))
   - page & project
+* - `subtitle`
+  - a string (max 500 chars, see [](#titles))
+  - page & project
 * - `short_title`
   - a string (max 40 chars, see [](#titles))
   - page & project
@@ -105,13 +109,13 @@ The following table lists the available frontmatter fields, a brief description 
   - page only
 * - `tags`
   - a list of strings
-  - page only
+  - page & project
 * - `thumbnail`
   - a link to a local or remote image
-  - page only
-* - `subtitle`
-  - a string (max 500 chars, see [](#titles))
-  - page only
+  - page & project
+* - `banner`
+  - a link to a local or remote image
+  - page & project
 * - `date`
   - a valid date formatted string
   - page can override project

--- a/packages/myst-frontmatter/src/page/validators.ts
+++ b/packages/myst-frontmatter/src/page/validators.ts
@@ -47,15 +47,6 @@ export function validatePageFrontmatterKeys(value: Record<string, any>, opts: Va
   if (defined(value.jupytext)) {
     output.jupytext = validateJupytext(value.jupytext, incrementOptions('jupytext', opts));
   }
-  if (defined(value.tags)) {
-    output.tags = validateList(
-      value.tags,
-      incrementOptions('tags', opts),
-      (file, index: number) => {
-        return validateString(file, incrementOptions(`tags.${index}`, opts));
-      },
-    );
-  }
   const partsOptions = incrementOptions('parts', opts);
   let parts: Record<string, any> | undefined;
   if (defined(value.parts)) {

--- a/packages/myst-frontmatter/src/site/types.ts
+++ b/packages/myst-frontmatter/src/site/types.ts
@@ -12,6 +12,7 @@ export const SITE_FRONTMATTER_KEYS = [
   'thumbnailOptimized',
   'banner',
   'bannerOptimized',
+  'tags',
   'authors',
   'reviewers',
   'editors',
@@ -64,6 +65,7 @@ export type SiteFrontmatter = {
   banner?: string | null;
   bannerOptimized?: string;
   authors?: Contributor[];
+  tags?: string[];
 
   /**
    * Reviewers and editors are author/contributor ids.

--- a/packages/myst-frontmatter/src/site/validators.ts
+++ b/packages/myst-frontmatter/src/site/validators.ts
@@ -42,6 +42,15 @@ export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: Va
     // No validation, this is expected to be set programmatically
     output.bannerOptimized = value.bannerOptimized;
   }
+  if (defined(value.tags)) {
+    output.tags = validateList(
+      value.tags,
+      incrementOptions('tags', opts),
+      (file, index: number) => {
+        return validateString(file, incrementOptions(`tags.${index}`, opts));
+      },
+    );
+  }
   const stash: ReferenceStash = {};
   if (defined(value.affiliations)) {
     const affiliationsOpts = incrementOptions('affiliations', opts);


### PR DESCRIPTION
@agoose77 @jmunroe as we were talking through this today in the pythia meetup, this brings tags up to the top level to support some of the work in Pythia, especially around galleries. This is necessary to support some of the work in collecting centralized resources.

Previously we could add tags to pages, but not projects. This opens up the possibility to tag a project and is more in line with how pythia, scipy-proceedings, and curvenote are dealing with projects that have this metadata at the project level.