### PR TITLE
🔧 Error if toc index file has children

### DIFF
--- a/.changeset/clean-chicken-own.md
+++ b/.changeset/clean-chicken-own.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Error if toc index file has children

--- a/packages/myst-cli/src/project/fromTOC.ts
+++ b/packages/myst-cli/src/project/fromTOC.ts
@@ -345,8 +345,12 @@ export function projectFromTOC(
   if (!root) {
     throw new Error('Project TOC must have at least one item');
   }
+  // TODO: Relax project structure so these index file constraints may be lifted
   if (!isFile(root)) {
     throw new Error(`First TOC item must be a file`);
+  }
+  if ((root as ParentEntry).children?.length) {
+    throw new Error(`First TOC item cannot have children`);
   }
   const indexFile = resolveExtension(resolve(path, root.file), (message, errorLevel, note) => {
     addWarningForFile(session, warnFile, message, errorLevel, {


### PR DESCRIPTION
Currently there is a constraint that the first toc entry must be a file; this becomes the project's `index` file. However, if this entry has a `file` and `children`, the children were previously just ignored. This PR adds an error if children are present on the index file.