### PR TITLE
🙉 Update doi fetching to resolve 429 too many request errors

### DIFF
--- a/.changeset/polite-rings-divide.md
+++ b/.changeset/polite-rings-divide.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Update doi fetching to resolve 429 too many request errors

--- a/packages/myst-cli/src/transforms/dois.ts
+++ b/packages/myst-cli/src/transforms/dois.ts
@@ -1,3 +1,4 @@
+import pLimit from 'p-limit';
 import type { CitationRenderer, CSL } from 'citation-js-utils';
 import { getCitationRenderers, parseBibTeX, parseCSLJSON } from 'citation-js-utils';
 import { doi } from 'doi-utils';
@@ -246,12 +247,19 @@ export async function transformLinkedDOIs(
     citeDois.push(node as Cite);
   });
   if (linkedDois.length === 0 && citeDois.length === 0) return renderer;
+  const total = linkedDois.length + citeDois.length;
   session.log.debug(
-    `Found ${plural('%s DOI(s)', linkedDois.length + citeDois.length)} to auto link.`,
+    `Found ${plural('%s DOI(s)', total)} to auto link.`,
   );
+  const logData = { total, done: false };
+  setTimeout(() => {
+    if (!logData.done) session.log.info(`⏳ Waiting to resolve up to ${plural('%s DOI(s)', logData.total)} from doi.org...`);
+  }, 5000);
   let number = 0;
+  // Currently doi.org is strictly rate limiting their requests
+  const limit = pLimit(3);
   await Promise.all([
-    ...linkedDois.map(async (node) => {
+    ...linkedDois.map((node) => limit(async () => {
       const normalized = doi.normalize(node.url)?.toLowerCase();
       if (!normalized) return false;
       let cite: SingleCitationRenderer | null = doiRenderer[normalized];
@@ -274,8 +282,8 @@ export async function transformLinkedDOIs(
         citeNode.children = [];
       }
       return true;
-    }),
-    ...citeDois.map(async (node) => {
+    })),
+    ...citeDois.map((node) => limit(async () => {
       const normalized = doi.normalize(node.label)?.toLowerCase();
       if (!normalized) return false;
       let cite: SingleCitationRenderer | null = doiRenderer[normalized];
@@ -290,10 +298,11 @@ export async function transformLinkedDOIs(
       doiRenderer[normalized] = cite;
       node.label = cite.render.getLabel();
       return true;
-    }),
+    })),
   ]);
+  logData.done = true;
   if (number > 0) {
-    session.log.info(toc(`🪄  Linked ${number} DOI${number > 1 ? 's' : ''} in %s for ${path}`));
+    session.log.info(toc(`🪄  Linked ${plural('%s DOI(s)', number)} from doi.org in %s for ${path}`));
   }
   return renderer;
 }


### PR DESCRIPTION
We just released fixes for `403` errors from doi.org (#1285). Immediately, a bunch of `429 Too Many Requests` errors were encountered.

This PR attempts to address these new errors by limiting simultaneous requests to doi.org and improving messaging if DOI requests are slow (similar to messaging for slow requests in #1288).