### PR TITLE
🤝 Combine site options when using config extend

### DIFF
--- a/.changeset/cold-games-warn.md
+++ b/.changeset/cold-games-warn.md
@@ -1,0 +1,6 @@
+---
+'myst-frontmatter': patch
+'myst-cli': patch
+---
+
+Combine site options when using config extend

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import type { ValidationOptions } from 'simple-validators';
-import { fillPageFrontmatter } from './fillPageFrontmatter';
+import { fillPageFrontmatter, fillSiteFrontmatter } from './fillPageFrontmatter';
 import type { PageFrontmatter } from '../page/types';
 import type { ProjectFrontmatter } from '../project/types';
 
@@ -703,6 +703,23 @@ describe('fillPageFrontmatter', () => {
   it('page options override project options', async () => {
     expect(fillPageFrontmatter({ options: { a: 'b' } }, { options: { a: 'z' } }, opts)).toEqual({
       options: { a: 'b' },
+    });
+  });
+});
+
+describe('fillSiteFrontmatter', () => {
+  it('empty frontmatters return empty', async () => {
+    expect(fillSiteFrontmatter({}, {}, opts)).toEqual({});
+  });
+  it('site options are combined', async () => {
+    expect(
+      fillSiteFrontmatter(
+        { options: { logo: 'my-logo.png' } },
+        { options: { hide_outline: true } },
+        opts,
+      ),
+    ).toEqual({
+      options: { logo: 'my-logo.png', hide_outline: true },
     });
   });
 });

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
@@ -6,6 +6,7 @@ import { fillNumbering } from '../numbering/validators.js';
 import { USE_PROJECT_FALLBACK } from '../page/validators.js';
 import type { PageFrontmatter } from '../page/types.js';
 import type { ProjectFrontmatter } from '../project/types.js';
+import type { SiteFrontmatter } from '../site/types.js';
 import { normalizeJsonToString } from './normalizeString.js';
 import { isStashPlaceholder, stashPlaceholder } from './referenceStash.js';
 
@@ -23,44 +24,19 @@ export function fillPageFrontmatter(
   return fillProjectFrontmatter(pageFrontmatter, projectFrontmatter, opts, USE_PROJECT_FALLBACK);
 }
 
-export function fillProjectFrontmatter(
-  base: ProjectFrontmatter,
-  filler: ProjectFrontmatter,
+export function fillSiteFrontmatter(
+  base: SiteFrontmatter,
+  filler: SiteFrontmatter,
   opts: ValidationOptions,
   keys?: string[],
 ) {
   const frontmatter = fillMissingKeys(base, filler, keys ?? Object.keys(filler));
-
-  if (filler.numbering || base.numbering) {
-    frontmatter.numbering = fillNumbering(base.numbering, filler.numbering);
-  }
-
-  // Combine all math macros defined on page and project
-  if (filler.math || base.math) {
-    frontmatter.math = { ...(filler.math ?? {}), ...(base.math ?? {}) };
-  }
-
-  // Combine all abbreviation defined on page and project
-  if (filler.abbreviations || base.abbreviations) {
-    frontmatter.abbreviations = {
-      ...(filler.abbreviations ?? {}),
-      ...(base.abbreviations ?? {}),
-    };
-  }
 
   // Combine all options defined on page and project
   if (filler.options || base.options) {
     frontmatter.options = {
       ...(filler.options ?? {}),
       ...(base.options ?? {}),
-    };
-  }
-
-  // Combine all settings defined on page and project
-  if (filler.settings || base.settings) {
-    frontmatter.settings = {
-      ...(filler.settings ?? {}),
-      ...(base.settings ?? {}),
     };
   }
 
@@ -151,6 +127,47 @@ export function fillProjectFrontmatter(
     frontmatter.affiliations = [...affiliationIds].map((id) => {
       return affiliationLookup[id] ?? stashPlaceholder(id);
     });
+  }
+
+  return frontmatter;
+}
+
+export function fillProjectFrontmatter(
+  base: ProjectFrontmatter,
+  filler: ProjectFrontmatter,
+  opts: ValidationOptions,
+  keys?: string[],
+) {
+  const frontmatter: ProjectFrontmatter = fillSiteFrontmatter(
+    base,
+    filler,
+    opts,
+    keys ?? Object.keys(filler),
+  );
+
+  if (filler.numbering || base.numbering) {
+    frontmatter.numbering = fillNumbering(base.numbering, filler.numbering);
+  }
+
+  // Combine all math macros defined on page and project
+  if (filler.math || base.math) {
+    frontmatter.math = { ...(filler.math ?? {}), ...(base.math ?? {}) };
+  }
+
+  // Combine all abbreviation defined on page and project
+  if (filler.abbreviations || base.abbreviations) {
+    frontmatter.abbreviations = {
+      ...(filler.abbreviations ?? {}),
+      ...(base.abbreviations ?? {}),
+    };
+  }
+
+  // Combine all settings defined on page and project
+  if (filler.settings || base.settings) {
+    frontmatter.settings = {
+      ...(filler.settings ?? {}),
+      ...(base.settings ?? {}),
+    };
   }
 
   return frontmatter;


### PR DESCRIPTION
Previously, if `options` were defined in `myst.yml#site` and in an `extend` config file - the `extend` fields would be overridden. Now, they are combined, as we already do with project frontmatter. This is helpful as we are making site options more reusable: #1296 