### PR TITLE
🎆 Optimize project thumbnail/banner and fallback correctly

### DIFF
--- a/.changeset/chilly-flies-appear.md
+++ b/.changeset/chilly-flies-appear.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Optimize project thumbnail/banner and fallback correctly

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -178,7 +178,7 @@ export async function localToManifestProject(
     path.join(projectPath, 'myst.yml'),
     projFrontmatter,
     session.publicPath(),
-    { altOutputFolder: '/' },
+    { altOutputFolder: '/', webp: true },
   );
   const thumbnail = await transformThumbnail(
     session,
@@ -186,15 +186,22 @@ export async function localToManifestProject(
     path.join(projectPath, 'myst.yml'),
     projFrontmatter,
     session.publicPath(),
-    { altOutputFolder: '/' },
+    { altOutputFolder: '/', webp: true },
   );
   return {
     ...projFrontmatter,
     // TODO: a null in the project frontmatter should not fall back to index page
     thumbnail: thumbnail?.url || projectFileInfo.thumbnail,
-    thumbnailOptimized: thumbnail?.urlOptimized || projectFileInfo.thumbnailOptimized || undefined,
+    thumbnailOptimized:
+      thumbnail?.urlOptimized ||
+      // Do not fall back to optimized page thumbnail if unoptimized project thumbnail exists
+      (thumbnail?.url ? undefined : projectFileInfo.thumbnailOptimized) ||
+      undefined,
     banner: banner?.url || projectFileInfo.banner,
-    bannerOptimized: banner?.urlOptimized || projectFileInfo.bannerOptimized || undefined,
+    bannerOptimized:
+      banner?.urlOptimized ||
+      (banner?.url ? undefined : projectFileInfo.bannerOptimized) ||
+      undefined,
     exports,
     downloads,
     bibliography: projFrontmatter.bibliography || [],


### PR DESCRIPTION
This should address https://github.com/executablebooks/mystmd/issues/1315 by:
- enabling webp conversion on project thumbnail and banner
- in the case where project thumbnail exists but does not have an optimized version, leaving the optimized thumbnail `undefined` instead of falling back to the index page's optimized thumbnail