### PR TITLE
✂️ Remove doi requests to handle.net

### DIFF
--- a/.changeset/chilled-ants-sin.md
+++ b/.changeset/chilled-ants-sin.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Remove doi requests to handle.net

--- a/packages/myst-cli/src/transforms/dois.ts
+++ b/packages/myst-cli/src/transforms/dois.ts
@@ -100,8 +100,7 @@ export async function resolveDoiOrg(
 ): Promise<CSL[] | undefined> {
   const normalizedDoi = doi.normalize(doiString);
   const url = doi.buildUrl(doiString); // This must be based on the incoming string, not the normalizedDoi. (e.g. short DOIs)
-  const handleUrl = url?.replace('doi.org', 'hdl.handle.net');
-  if (!doi.validate(doiString) || !normalizedDoi || !url || !handleUrl) return undefined;
+  if (!doi.validate(doiString) || !normalizedDoi || !url) return undefined;
   const filename = doiCSLJSONCacheFilename(normalizedDoi);
 
   // Cache DOI resolution as CSL JSON (parsed)
@@ -115,7 +114,6 @@ export async function resolveDoiOrg(
   let data: CSL[] | undefined;
   try {
     data = await resolveDOIAsBibTeX(session, url);
-    if (!data) data = await resolveDOIAsBibTeX(session, handleUrl);
     if (data) {
       session.log.debug(toc(`Fetched reference BibTeX for doi:${normalizedDoi} in %s`));
     } else {
@@ -131,7 +129,6 @@ export async function resolveDoiOrg(
   if (!data) {
     try {
       data = await resolveDOIAsCSLJSON(session, url);
-      if (!data) data = await resolveDOIAsCSLJSON(session, handleUrl);
       if (data) {
         session.log.debug(toc(`Fetched reference CSL-JSON for doi:${normalizedDoi} in %s`));
       } else {


### PR DESCRIPTION
Previously we encountered 403 responses when hitting doi.org. Adding a request to the separate handle.net service _seemed_ to help with that. Now, though, we are getting 429 responses instead and the requests to handle.net definitely _do not_ help.

This PR just takes out those requests, reducing the total number of requests required to resolve a doi and speeding up the build.