### PR TITLE
🚦 Share doi request limiter across session

### DIFF
--- a/.changeset/hot-pillows-refuse.md
+++ b/.changeset/hot-pillows-refuse.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Share doi request limiter across session

--- a/packages/myst-cli/src/session/types.ts
+++ b/packages/myst-cli/src/session/types.ts
@@ -5,6 +5,7 @@ import type { ResolvedExternalReference, ReferenceState } from 'myst-transforms'
 import type { MinifiedContentCache } from 'nbtx';
 import type { Store } from 'redux';
 import type { RequestInfo, RequestInit, Response } from 'node-fetch';
+import type { Limit } from 'p-limit';
 import type { BuildWarning, RootState } from '../store/index.js';
 import type { PreRendererData, RendererData, SingleCitationRenderer } from '../transforms/types.js';
 import type { SessionManager } from '@jupyterlab/services';
@@ -14,6 +15,7 @@ export type ISession = {
   configFiles: string[];
   store: Store<RootState>;
   log: Logger;
+  doiLimiter: Limit;
   reload(): Promise<ISession>;
   clone(): Promise<ISession>;
   sourcePath(): string;

--- a/packages/myst-cli/src/transforms/dois.ts
+++ b/packages/myst-cli/src/transforms/dois.ts
@@ -1,4 +1,3 @@
-import pLimit from 'p-limit';
 import type { CitationRenderer, CSL } from 'citation-js-utils';
 import { getCitationRenderers, parseBibTeX, parseCSLJSON } from 'citation-js-utils';
 import { doi } from 'doi-utils';
@@ -259,10 +258,9 @@ export async function transformLinkedDOIs(
   }, 5000);
   let number = 0;
   // Currently doi.org is strictly rate limiting their requests
-  const limit = pLimit(3);
   await Promise.all([
     ...linkedDois.map((node) =>
-      limit(async () => {
+      session.doiLimiter(async () => {
         const normalized = doi.normalize(node.url)?.toLowerCase();
         if (!normalized) return false;
         let cite: SingleCitationRenderer | null = doiRenderer[normalized];
@@ -289,7 +287,7 @@ export async function transformLinkedDOIs(
       }),
     ),
     ...citeDois.map((node) =>
-      limit(async () => {
+      session.doiLimiter(async () => {
         const normalized = doi.normalize(node.label)?.toLowerCase();
         if (!normalized) return false;
         let cite: SingleCitationRenderer | null = doiRenderer[normalized];


### PR DESCRIPTION
This partially addresses https://github.com/executablebooks/mystmd/issues/1335 - now, the rate limiting previously implemented at a page level (and therefore easily exceeded during a build with multiple pages) is shared across the entire session.