### PR TITLE
🥌 Remove curly braces around properties in verbatim latex handler

### DIFF
--- a/.changeset/tidy-parrots-boil.md
+++ b/.changeset/tidy-parrots-boil.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Remove curly braces around properties in verbatim latex handler

--- a/packages/tex-to-myst/src/verbatim.ts
+++ b/packages/tex-to-myst/src/verbatim.ts
@@ -17,9 +17,9 @@ function getListingProperty(line?: string): ListingsProps | false {
   if (!line || !line.match(/^\s*\[(.*)\]\s*$/)) return false;
   const props: ListingsProps = {};
   ['language', 'caption', 'label', 'numbers', 'firstnumber'].forEach((key) => {
-    props[key as keyof typeof props] = line
-      .match(new RegExp(`${key}(?:[\\s]*)?=([^,\\]]*)`))?.[1]
-      .trim();
+    let prop = line.match(new RegExp(`${key}(?:[\\s]*)?=([^,\\]]*)`))?.[1].trim();
+    if (prop?.match(/^{.*}$/)) prop = prop.slice(1, prop.length - 1);
+    props[key as keyof typeof props] = prop;
   });
   return props;
 }

--- a/packages/tex-to-myst/tests/verbatim.yml
+++ b/packages/tex-to-myst/tests/verbatim.yml
@@ -62,6 +62,47 @@ cases:
                   children:
                     - type: text
                       value: Hello world
+  - title: lstlisting with caption in brackets
+    tex: |
+      \begin{lstlisting}[language=Python, caption={RGB Image Tiles}, label= lst:save_rgb_tiles]
+      from rasterio import Window
+      from tifffile import imwrite
+      \end{lstlisting}
+    tree:
+      type: root
+      children:
+        - type: container
+          kind: code
+          label: lst:save_rgb_tiles
+          identifier: lst:save_rgb_tiles
+          children:
+            - type: code
+              lang: Python
+              value: |-
+                from rasterio import Window
+                from tifffile import imwrite
+            - type: caption
+              children:
+                - type: paragraph
+                  children:
+                    - type: text
+                      value: RGB Image Tiles
+  - title: lstlisting with caption that is only brackets
+    tex: |
+      \begin{lstlisting}[language=Python, caption={}, label= lst:save_rgb_tiles]
+      from rasterio import Window
+      from tifffile import imwrite
+      \end{lstlisting}
+    tree:
+      type: root
+      children:
+        - type: code
+          lang: Python
+          label: lst:save_rgb_tiles
+          identifier: lst:save_rgb_tiles
+          value: |-
+            from rasterio import Window
+            from tifffile import imwrite
   - title: lstlisting and line numbers
     tex: |
       \begin{lstlisting}[language=c,numbers=left,firstnumber=2,label=lst:loop]


### PR DESCRIPTION
This PR addresses a very specific issue encountered here, where `code` captions were inheriting `{}` from the source tex: https://github.com/scipy-conference/scipy_proceedings/pull/916

Possibly a more general solution would be worth considering (Do these brackets show up elsewhere? Do they imply we should run tex-to-myst on the contents or something?). But for now, this quick fix improves the simplest cases where latex has `caption={My Caption}`.