### PR TITLE
👩‍🎓 Add wrapfigure latex environment

### DIFF
--- a/.changeset/lovely-beans-rescue.md
+++ b/.changeset/lovely-beans-rescue.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Support wrapfigure environment

--- a/packages/tex-to-myst/src/figures.ts
+++ b/packages/tex-to-myst/src/figures.ts
@@ -24,21 +24,18 @@ function centering(node: GenericNode, state: ITexParser) {
   }
 }
 
+function renderFigure(node: GenericNode, state: ITexParser) {
+  state.closeParagraph();
+  state.openNode('container', { kind: 'figure' });
+  state.renderChildren(node);
+  state.closeParagraph();
+  state.closeNode();
+}
+
 const FIGURE_HANDLERS: Record<string, Handler> = {
-  env_figure(node, state) {
-    state.closeParagraph();
-    state.openNode('container', { kind: 'figure' });
-    state.renderChildren(node);
-    state.closeParagraph();
-    state.closeNode();
-  },
-  env_subfigure(node, state) {
-    state.closeParagraph();
-    state.openNode('container', { kind: 'figure' });
-    state.renderChildren(node);
-    state.closeParagraph();
-    state.closeNode();
-  },
+  env_figure: renderFigure,
+  env_subfigure: renderFigure,
+  env_wrapfigure: renderFigure,
   env_centering(node, state) {
     centering(node, state);
     state.renderChildren(node);

--- a/packages/tex-to-myst/src/tex.ts
+++ b/packages/tex-to-myst/src/tex.ts
@@ -79,6 +79,7 @@ const macros: Record<string, number> = {
   multirow: 5,
   multicolumn: 3,
   subfigure: 2,
+  wrapfigure: 3,
   tabularx: 2,
   longtable: 2,
   ['longtable*']: 2,

--- a/packages/tex-to-myst/tests/figures.yml
+++ b/packages/tex-to-myst/tests/figures.yml
@@ -188,3 +188,35 @@ cases:
                   children:
                     - type: text
                       value: Simulation Two
+  - title: Wrapfigure environment
+    tex: |-
+      \begin{wrapfigure}[23]{r}{0.5\textwidth}
+        \centering
+        \includegraphics[width=1.0\textwidth]{figures/my_pic.png}
+        \caption{ This is the caption, \href{computations.ipynb}{link to notebook}.}
+        \label{fig:picture}
+      \end{wrapfigure}
+    tree:
+      type: root
+      children:
+        - type: container
+          kind: figure
+          identifier: fig:picture
+          label: fig:picture
+          align: center
+          children:
+            - type: image
+              url: figures/my_pic.png
+            - type: caption
+              children:
+                - type: paragraph
+                  children:
+                    - type: text
+                      value: 'This is the caption, '
+                    - type: link
+                      url: computations.ipynb
+                      children:
+                        - type: text
+                          value: link to notebook
+                    - type: text
+                      value: '.'


### PR DESCRIPTION
The `wrapfigure` latex environment is now supported by myst. It just creates a figure, exactly the same as the `figure` environment would, no consideration to wrapping at this point.