### PR TITLE
👩‍🎓 Differentiate behavior of newcommand, renewcommand, providecommand

### DIFF
--- a/.changeset/sour-jeans-happen.md
+++ b/.changeset/sour-jeans-happen.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Differentiate behavior of newcommand, renewcommand, providecommand

--- a/packages/tex-to-myst/src/frontmatter.ts
+++ b/packages/tex-to-myst/src/frontmatter.ts
@@ -145,8 +145,12 @@ const FRONTMATTER_HANDLERS: Record<string, Handler> = {
       state.warn(`Multiple packages imported with the same name: "${p}"`, node);
     });
   },
+  /** `newcommand` defines a new command, and makes an error if it is already defined. */
   macro_newcommand: newCommand(true),
+  /** `renewcommand` redefines a predefined command, and makes an error if it is not yet defined. */
   macro_renewcommand: newCommand(false),
+  /** `providecommand` defines a new command if it isn't already defined. */
+  macro_providecommand: newCommand(false),
   macro_date(node, state) {
     state.closeParagraph();
     // No action for now

--- a/packages/tex-to-myst/src/frontmatter.ts
+++ b/packages/tex-to-myst/src/frontmatter.ts
@@ -112,15 +112,24 @@ function cleanMacro(macro: string) {
   return macro.trim().replace(/(^\$)|(\$$)/g, '');
 }
 
-function newCommand(showWarning: boolean) {
+function newCommand(opts?: { override?: boolean; warn?: 'defined' | 'undefined' }) {
   return (node: GenericNode, state: ITexParser) => {
     state.closeParagraph();
     const [nameNode, macroNode] = getArguments(node, 'group');
     getPositionExtents(macroNode);
     const name = originalValue(state.tex, { position: getPositionExtents(nameNode) });
     const macro = originalValue(state.tex, { position: getPositionExtents(macroNode) });
-    if (state.data.macros[name] && showWarning) {
-      state.warn(`Multiple macros defined with the same value: "${name}": "${macro}"`, node);
+    if (state.data.macros[name]) {
+      if (opts?.warn === 'defined') {
+        state.warn(
+          `Multiple macros defined with the same value${opts?.override ? '; overriding' : ''}: "${name}": "${macro}"`,
+          node,
+        );
+      }
+      if (!opts?.override) return;
+    }
+    if (!state.data.macros[name] && opts?.warn === 'undefined') {
+      state.warn(`Attempting to redefine a currently undefined macro: "${name}": "${macro}"`, node);
     }
     state.data.macros[name] = cleanMacro(macro);
     const macroName = name.replace(/^\\/, '');
@@ -146,11 +155,11 @@ const FRONTMATTER_HANDLERS: Record<string, Handler> = {
     });
   },
   /** `newcommand` defines a new command, and makes an error if it is already defined. */
-  macro_newcommand: newCommand(true),
+  macro_newcommand: newCommand({ warn: 'defined', override: true }),
   /** `renewcommand` redefines a predefined command, and makes an error if it is not yet defined. */
-  macro_renewcommand: newCommand(false),
+  macro_renewcommand: newCommand({ warn: 'undefined', override: true }),
   /** `providecommand` defines a new command if it isn't already defined. */
-  macro_providecommand: newCommand(false),
+  macro_providecommand: newCommand({ override: false }),
   macro_date(node, state) {
     state.closeParagraph();
     // No action for now

--- a/packages/tex-to-myst/src/utils.ts
+++ b/packages/tex-to-myst/src/utils.ts
@@ -187,7 +187,7 @@ function lastNode(node: GenericNode): GenericNode {
     const lastArg = node.args?.[node.args.length - 1];
     const last = lastNode(lastArg);
     // This is a bit of a hack, we need to put the positions around the arguments
-    if (node.type === 'macro' && last.position?.end.offset && lastArg.closeMark.match(/^\}|\]$/)) {
+    if (node.type === 'macro' && last?.position?.end.offset && lastArg.closeMark.match(/^\}|\]$/)) {
       lastArg.position = {
         ...lastArg.content[0].position,
         end: { ...last.position.end, offset: last.position.end.offset + 1 },

--- a/packages/tex-to-myst/tests/commands.yml
+++ b/packages/tex-to-myst/tests/commands.yml
@@ -13,6 +13,46 @@ cases:
         '\ii': '{i\mkern1mu}'
         '\f': '\mathcal{F}_{#1}\left[#2\right]'
         '\FFT': '\mathcal{F}_{\mathbf{r}\to\mathbf{k}}'
+  - title: reusing newcommand for same macro warns
+    tex: |-
+      \newcommand{\angstroms}{\text{\normalfont\ZZ }}
+      \newcommand{\angstroms}{\text{\normalfont\AA }}
+    text: ''
+    data:
+      macros:
+        '\angstroms': '\text{\normalfont\AA }'
+    warnings: 1
+  - title: newcommand then renewcommand does not warn
+    tex: |-
+      \newcommand{\angstroms}{\text{\normalfont\ZZ }}
+      \renewcommand{\angstroms}{\text{\normalfont\AA }}
+    text: ''
+    data:
+      macros:
+        '\angstroms': '\text{\normalfont\AA }'
+  - title: renewcommand without new command warns
+    tex: |-
+      \renewcommand{\angstroms}{\text{\normalfont\AA }}
+    text: ''
+    data:
+      macros:
+        '\angstroms': '\text{\normalfont\AA }'
+    warnings: 1
+  - title: providecommand with new macro adds macro
+    tex: |-
+      \providecommand{\angstroms}{\text{\normalfont\AA }}
+    text: ''
+    data:
+      macros:
+        '\angstroms': '\text{\normalfont\AA }'
+  - title: providecommand after newcommand does nothing
+    tex: |-
+      \newcommand{\angstroms}{\text{\normalfont\AA }}
+      \providecommand{\angstroms}{\text{\normalfont\ZZ }}
+    text: ''
+    data:
+      macros:
+        '\angstroms': '\text{\normalfont\AA }'
   - title: newtheorem
     tex: |-
       \newtheorem{proposition}{Proposition}


### PR DESCRIPTION
Previously, `providecommand` was not supported and `renewcommand` did not care if the macro was already defined. Now: 

- `newcommand`: warns if macro is already defined (still overrides the previous command, to maintain previous behavior with MyST)
- `renewcommand`: warns if macro is _not_ already defined (either way, it sets the new command)
- `providecommand`: never warns - if macro is not defined, it sets the new command; if macro is defined, it does nothing