### PR TITLE
🔧 Fix exclude glob/path resolution

### DIFF
--- a/.changeset/famous-squids-hide.md
+++ b/.changeset/famous-squids-hide.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fix exclude glob/path resolution

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -382,14 +382,6 @@ async function resolveProjectConfigPaths(
   if (projectConfig.index) {
     resolvedFields.index = await resolutionFn(session, path, projectConfig.index);
   }
-  if (projectConfig.exclude) {
-    resolvedFields.exclude = await Promise.all(
-      projectConfig.exclude.map(async (file) => {
-        const resolved = await resolutionFn(session, path, file, { allowNotExist: true });
-        return resolved;
-      }),
-    );
-  }
   if (projectConfig.plugins) {
     resolvedFields.plugins = await Promise.all(
       projectConfig.plugins.map(async (file) => {

--- a/packages/myst-cli/src/project/fromTOC.ts
+++ b/packages/myst-cli/src/project/fromTOC.ts
@@ -311,7 +311,7 @@ export function getIgnoreFiles(session: ISession, path: string) {
   const excludePatterns = projectConfig?.exclude ?? [];
   const excludeFiles = excludePatterns
     .map((pattern) => {
-      const matches = globSync(pattern); //.split(sep).join('/'));
+      const matches = globSync(pattern, { cwd: path, absolute: true });
       return matches.map((match) => match.split('/').join(sep));
     })
     .flat();


### PR DESCRIPTION
Recent updates broke `exclude` resolution on windows:

- `exclude` entries are supposed to use `/` forward slashes since they are "glob" patterns, regardless of platform (`\` back slashes are reserved as the escape character)
- However, during config load, these entries were resolved to absolute paths. For posix paths, this was fine: given `exclude: my/pattern` it would give `/my/full/path/my/pattern`. However for windows, it was more like `C:\my\full\path\my/pattern`.
- We did another pass to normalize all slashes to forward slashes - this fixed the windows paths so glob pattern matching was happy with them. _However_ it also turned escape characters into path separators...
- I removed this last normalization step, optimistically to prevent issues with escaped symbols. Unfortunately, this resulted in all windows paths being invalid glob patterns, since they no longer had forward slash separators.

In this PR, I changed the approach slightly.

- `exclude` entries are no longer resolved to absolute paths; they are kept as original patterns
- This means we must `glob`/`watch` these exclude entries relative to the myst project directory - this matches closer to how we handle `glob` patterns in the `toc`.