### PR TITLE
⚫️ Ignore `dot` top level domain

### DIFF
--- a/.changeset/dry-grapes-smash.md
+++ b/.changeset/dry-grapes-smash.md
@@ -1,0 +1,5 @@
+---
+"myst-parser": patch
+---
+
+Ignore 'dot' top level domain.

--- a/packages/myst-parser/src/config.ts
+++ b/packages/myst-parser/src/config.ts
@@ -69,4 +69,4 @@ export const MARKDOWN_IT_CONFIG = {
 };
 
 // List of valid TLDs to exclude from linkify
-export const EXCLUDE_TLDS = ['py', 'md'];
+export const EXCLUDE_TLDS = ['py', 'md', 'dot'];


### PR DESCRIPTION
Have come across this in a few scipy proceedings and our linker is turning `numpy.dot` for example into a link.