### PR TITLE
✅ Add helpful error information when image conversions fail

### DIFF
--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -449,10 +449,10 @@ export async function transformImageFormats(
       addWarningForFile(
         session,
         file,
-        `Cannot convert image "${path.basename(image.url)}" - may not correctly render.`,
+        `To convert image "${path.basename(image.url)}" you must install imagemagick.`,
         'error',
         {
-          note: 'To convert this image, you must install imagemagick',
+          note: `Image ${path.basename(image.url)} may not render correctly`,
           position: image.position,
           ruleId: RuleId.imageFormatConverts,
         },


### PR DESCRIPTION
Fixes #1376 by making `imagemagick` part of the main red error message.