### PR TITLE
Add `ipynb` format option in validators

### DIFF
--- a/packages/myst-frontmatter/src/exports/validators.ts
+++ b/packages/myst-frontmatter/src/exports/validators.ts
@@ -61,6 +61,7 @@ export const EXT_TO_FORMAT: Record<string, ExportFormats> = {
   '.typ': ExportFormats.typst,
   '.typst': ExportFormats.typst,
   '.cff': ExportFormats.cff,
+  '.ipynb': ExportFormats.ipynb,
 };
 
 export const RESERVED_EXPORT_KEYS = [


### PR DESCRIPTION
Fixes the validation error when used `ipynb` format option while building.

cc @agoose77 @mmcky 