### PR TITLE
🐛 List elements with `citeGroup`s as children

### DIFF
--- a/.changeset/young-parrots-lick.md
+++ b/.changeset/young-parrots-lick.md
@@ -1,0 +1,5 @@
+---
+"myst-parser": patch
+---
+
+CiteGroup as another phrasing type

--- a/packages/myst-parser/src/transforms/listItemParagraphs.ts
+++ b/packages/myst-parser/src/transforms/listItemParagraphs.ts
@@ -24,6 +24,7 @@ export function listItemParagraphsTransform(tree: GenericParent) {
       'footnoteReference',
       'crossReference',
       'cite',
+      'citeGroup',
       'html',
     ]);
 


### PR DESCRIPTION
Similar to #2256.