### PR TITLE
DOC: Adding yaml example as the page was a bit confusing

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -5,6 +5,8 @@ description: Project and page settings for MyST
 
 The `settings` field in the project or page frontmatter allows you to change how the parsing, transforms, plugins, or other behaviors of mystmd.
 
+Here's an example of settings specified in **project frontmatter**
+
 ```{code-block} yaml
 :filename: myst.yml
 project:
@@ -12,7 +14,14 @@ project:
     output_matplotlib_strings: remove
     output_stderr: remove-warn
 ```
+Here's an example of settings in **page frontmatter**
+```{code-block} yaml
+:filename: page.md
 
+settings:
+  output_matplotlib_strings: remove
+  output_stderr: remove-warn
+```
 (project-settings)=
 
 ## Available settings fields


### PR DESCRIPTION
I was trying to use `output_matplotlib_strings: remove` but the docs page wasn't super clear about how/where to add it.

(There are a bunch of level2 headings, some are for options under `settings` but the last one, which in fact had a yaml example as well was for one layer up.)