### PR TITLE
🧮 Allow `math` in numbering as an alias for `equation`

### DIFF
--- a/.changeset/silent-terms-invite.md
+++ b/.changeset/silent-terms-invite.md
@@ -1,0 +1,5 @@
+---
+"myst-frontmatter": patch
+---
+
+Allow math as an alias for equation in numbering.

--- a/docs/cross-references.md
+++ b/docs/cross-references.md
@@ -338,7 +338,7 @@ The `numbering` object allows you to be much more granular with enabling and dis
 ```yaml
 numbering:
   code: false
-  math: false
+  equations: false
   headings: true
 ```
 

--- a/packages/myst-frontmatter/src/numbering/validators.ts
+++ b/packages/myst-frontmatter/src/numbering/validators.ts
@@ -45,6 +45,7 @@ export const NUMBERING_ALIAS = {
   figures: 'figure',
   subfigures: 'subfigure',
   equations: 'equation',
+  math: 'equation',
   subequations: 'subequation',
   tables: 'table',
   titles: 'title',


### PR DESCRIPTION
There is currently a typo in the docs, for numbering equations this should be `equation: false`, not `math: false`.

This PR fixes the docs and adds math as an alias for the numbering object.