### PR TITLE
🐛 Include index page in `--strict` mode error checking

### DIFF
--- a/.changeset/solid-heads-jog.md
+++ b/.changeset/solid-heads-jog.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Throw errors including on the main page when strict.

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -674,7 +674,7 @@ export async function processSite(session: ISession, opts?: ProcessSiteOptions):
   if (opts?.strict) {
     const hasWarnings = projects
       .map((project) => {
-        return project.pages
+        return [{ file: project.file, slug: project.index }, ...project.pages]
           .map((page) => {
             if (!('slug' in page)) return [0, 0];
             const buildWarnings = selectors.selectFileWarnings(session.store.getState(), page.file);


### PR DESCRIPTION
Fixes a bug where `myst build --strict` was not checking build warnings/errors for the project index page, only for pages in the project.pages array.

## Problem

When running `myst build --strict`, the build warning/error check was only iterating over `project.pages`, which does not include the project's index file. This meant that errors in the index page (such as missing cross-references, broken citations, etc.) were not caught by strict mode and would **not** cause the build to fail, even when configured to be errors via error_rules.

For example, if index.md had a missing citation configured as an error:

```yaml
error_rules:
  - id: reference-target-resolves
    severity: error
```

cc @bsipocz 