### PR TITLE
📖 Adding xref error rules in cli docs

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -79,6 +79,8 @@ beamer
     - `true`: Add `\begin{frame}` environment for each block, delimited by `+++`, and enable presentation outline with block metadata `+++ {"outline":true}`
     - `false` (default): No extra `\begin{frame}` environment will be used
 
+(setting:error_rules)=
+
 ## Error Rules
 
 The `error_rules` list in the project configuration can be used to disable or modify logging rules in the CLI:

--- a/packages/myst-cli/docs/reference.md
+++ b/packages/myst-cli/docs/reference.md
@@ -79,7 +79,7 @@ MyST can check for broken links when building a site. To report bad links:
 myst build --check-links
 ```
 
-And to fail the build if there are bad links:
+And use `--strict` to fail the build if there are errors, such as bad links, or other [rules](#setting:error_rules) set to error severity:
 
 ```
 myst build --strict


### PR DESCRIPTION
Cross ref for the error-rules page from the cli page