### PR TITLE
🪜 Unescape yaml for labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,16 +1,16 @@
 release:
   - head-branch: '^changeset-release/main$'
 documentation:
-  - head-branch: '^docs\\b'
+  - head-branch: '^docs\b'
   - changed-files:
       - any-glob-to-any-file: 'docs/*'
 maintenance:
-  - head-branch: '^maint\\b'
+  - head-branch: '^maint\b'
 enhancement:
   - head-branch:
-      - '^enh\\b'
-      - '^feat\\b'
+      - '^enh\b'
+      - '^feat\b'
 bug:
   - head-branch:
-      - '^fix\\b'
-      - '^bug\\b'
+      - '^fix\b'
+      - '^bug\b'


### PR DESCRIPTION
It's not working right now, because the YAML is already escaped.