### PR TITLE
🖼️ Ensure `favicon` is under `site.options`

### DIFF
--- a/.changeset/sixty-actors-love.md
+++ b/.changeset/sixty-actors-love.md
@@ -1,0 +1,6 @@
+---
+'myst-config': patch
+'myst-cli': patch
+---
+
+Favicon on site option is under options.

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -375,9 +375,6 @@ async function resolveSiteConfigPaths(
       }),
     );
   }
-  if (siteConfig.favicon) {
-    resolvedFields.favicon = await resolutionFn(session, path, siteConfig.favicon);
-  }
   if (siteConfig.parts) {
     resolvedFields.parts = await loadFrontmatterParts(
       session,

--- a/packages/myst-config/src/site/site.spec.ts
+++ b/packages/myst-config/src/site/site.spec.ts
@@ -116,9 +116,19 @@ describe('validateSiteConfig', () => {
       nav: [{ title: 'cool folder', children: [{ title: 'cool page', url: '/test/cool-page' }] }],
       actions: [{ title: 'Go To Example', url: 'https://example.com', static: false }],
       domains: ['test.curve.space'],
-      favicon: 'curvenote.png',
+      options: { favicon: 'curvenote.png' },
     };
     expect(validateSiteConfig(siteConfig, opts)).toEqual(siteConfig);
+  });
+  it('valid favicon is moved to options', async () => {
+    const siteConfig = {
+      projects: [{ path: 'my-proj', slug: 'test' }],
+      favicon: 'curvenote.png',
+    };
+    expect(validateSiteConfig(siteConfig, opts)).toEqual({
+      projects: [{ path: 'my-proj', slug: 'test' }],
+      options: { favicon: 'curvenote.png' },
+    });
   });
   it('invalid list values are filtered', async () => {
     expect(

--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -29,7 +29,6 @@ export type SiteConfig = SiteFrontmatter & {
   nav?: SiteNavItem[];
   actions?: SiteAction[];
   domains?: string[];
-  favicon?: string;
   template?: string;
 };
 

--- a/packages/myst-config/src/site/validators.ts
+++ b/packages/myst-config/src/site/validators.ts
@@ -20,15 +20,7 @@ import {
 import type { SiteAction, SiteConfig, SiteNavItem, SiteProject } from './types.js';
 
 export const SITE_CONFIG_KEYS = {
-  optional: [
-    ...SITE_FRONTMATTER_KEYS,
-    'projects',
-    'nav',
-    'actions',
-    'domains',
-    'favicon',
-    'template',
-  ],
+  optional: [...SITE_FRONTMATTER_KEYS, 'projects', 'nav', 'actions', 'domains', 'template'],
   alias: FRONTMATTER_ALIASES,
 };
 
@@ -149,9 +141,6 @@ export function validateSiteConfigKeys(
       },
     );
     if (domains) output.domains = [...new Set(domains)];
-  }
-  if (defined(value.favicon)) {
-    output.favicon = validateString(value.favicon, incrementOptions('favicon', opts));
   }
   if (defined(value.template)) {
     output.template = validateString(value.template, incrementOptions('template', opts));


### PR DESCRIPTION
The favicon is only valid if it is under the `site.options` (that is where the theme looks for it), however, currently if you put it in `site.favicon` there is (a) no warning, and (b) the file isn't copied properly.

This now raises a warning and also works, by using the standard template options.