### PR TITLE
⚠️ Improve `{doc}` role warning with node position

### DIFF
--- a/.changeset/pink-memes-draw.md
+++ b/.changeset/pink-memes-draw.md
@@ -1,0 +1,5 @@
+---
+'myst-roles': patch
+---
+
+Add node information to doc-role warning

--- a/packages/myst-roles/src/doc.ts
+++ b/packages/myst-roles/src/doc.ts
@@ -19,6 +19,7 @@ export const docRole: RoleSpec = {
       'Usage of the {doc} role is not recommended, use a markdown link to the file instead.',
       {
         source: 'role:doc',
+        node: data.node,
         note: `For {doc}\`${body}\` use [${modified || ''}](${url})`,
         ruleId: RuleId.roleBodyCorrect,
       },


### PR DESCRIPTION
Adds position information to more easily find the node.

<img width="1434" height="274" alt="image" src="https://github.com/user-attachments/assets/bc90dec4-6c5a-4687-a3e0-bef65164805c" />


See #2374

cc @mfisher87 