### PR TITLE
🧪 Add node 24 to ci testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['18', '20', '22.4.x']
+        node: ['18', '20', '22.4.x', '24']
     name: Testing on node ${{ matrix.node }}
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
@parmentelat pointed out that [we should probably be testing against node 24](https://github.com/jupyter-book/mystmd/pull/2344#issuecomment-3484749629). We can also probably boot 18, but that requires a slightly larger change of updating docs, etc.

<img width="516" height="391" alt="image" src="https://github.com/user-attachments/assets/2c112868-3ebc-4481-b887-442b9082902a" />
