### PR TITLE
🤖 Stop over-eager documentation labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,7 +3,7 @@ release:
 documentation:
   - head-branch: '^docs\b'
   - changed-files:
-      - any-glob-to-any-file: 'docs/*'
+      - any-glob-to-all-files: 'docs/*'
 maintenance:
   - head-branch: '^maint\b'
 enhancement:


### PR DESCRIPTION
`enhancement` PRs with docs (as they should have 🚀) are over-eagerly labeled as `documentation` (and if you try to remove the label, github actions will put it back). (e.g. #2413)

This PR changes the auto-label functionality to only label as `documentation` if _all_ files are in `docs/` rather than _any_.