### PR TITLE
🧪 Add `mhchem` extension

### DIFF
--- a/.changeset/fifty-chairs-draw.md
+++ b/.changeset/fifty-chairs-draw.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Add mhchem extension

--- a/packages/myst-transforms/src/math.ts
+++ b/packages/myst-transforms/src/math.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from 'unified';
 import type { VFile } from 'vfile';
 import katex from 'katex';
+import 'katex/contrib/mhchem/mhchem.js';
 import type { InlineMath, Node } from 'myst-spec';
 import type { Math } from 'myst-spec-ext';
 import { selectAll } from 'unist-util-select';


### PR DESCRIPTION
Fixes jupyter-book/jupyter-book#2460


The extension when loaded can turn:

```
$\ce{t-BuBr + H2O -> t-BuOH + HBr}$
```

into:

<img width="722" height="110" alt="image" src="https://github.com/user-attachments/assets/b629b86c-6346-4aa8-88b2-82dbfdfc9db4" />
