### PR TITLE
Add support for iframe title for accessibility.

### DIFF
--- a/docs/figures.md
+++ b/docs/figures.md
@@ -226,7 +226,7 @@ Get up and running with MyST in Jupyter!
 :::
 ```
 
-You can find this URL when clicking share > embed on various platforms. You can also give the {myst:directive}`iframe` directive {myst:directive}`iframe.width` and a {myst:directive}`caption <iframe.body>`.
+You can find this URL when clicking share > embed on various platforms. You can also give the {myst:directive}`iframe` directive {myst:directive}`iframe.width`, {myst:directive}`iframe.title` (for accessibility), and a {myst:directive}`caption <iframe.body>`.
 
 ## Provide Light and Dark Mode images
 

--- a/packages/myst-directives/src/iframe.ts
+++ b/packages/myst-directives/src/iframe.ts
@@ -19,6 +19,10 @@ export const iframeDirective: DirectiveSpec = {
       type: String,
       doc: 'The alignment of the iframe in the page. Choose one of `left`, `center` or `right`',
     },
+    title: {
+      type: String,
+      doc: 'The title attribute for the iframe element, describing its content for accessibility.',
+    },
     placeholder: {
       type: String,
       doc: 'A placeholder image for the iframe in static exports.',
@@ -31,6 +35,7 @@ export const iframeDirective: DirectiveSpec = {
       src: data.arg as string,
       width: data.options?.width as string,
       align: data.options?.align as Iframe['align'],
+      title: data.options?.title as string,
     };
     if (data.options?.placeholder) {
       iframe.children = [

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -129,6 +129,7 @@ export type Iframe = Target & {
   width?: string;
   align?: Image['align'];
   class?: Image['class'];
+  title?: string;
   children?: Image[];
 };
 

--- a/packages/myst-transforms/src/html.spec.ts
+++ b/packages/myst-transforms/src/html.spec.ts
@@ -468,6 +468,29 @@ describe('Test reconstructHtmlTransform', () => {
       ],
     });
   });
+  test('iframe tags with title attribute', async () => {
+    const mdast = {
+      type: 'root',
+      children: [
+        {
+          type: 'html',
+          value: '<iframe src="https://example.com/video" title="Example Video" />',
+        },
+      ],
+    };
+    htmlTransform(mdast);
+    expect(mdast).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'iframe',
+          src: 'https://example.com/video',
+          title: 'Example Video',
+          width: '100%',
+        },
+      ],
+    });
+  });
   test('image tags in html', async () => {
     const mdast = {
       type: 'root',

--- a/packages/myst-transforms/src/html.ts
+++ b/packages/myst-transforms/src/html.ts
@@ -130,6 +130,7 @@ const defaultHtmlToMdastOptions: Record<keyof HtmlTransformOptions, any> = {
       const attrs = addClassAndIdentifier(node);
       attrs.src = String(node.properties.src || '');
       attrs.width = '100%';
+      if (node.properties.title) attrs.title = node.properties.title;
       return h(node, 'iframe', attrs);
     },
     figure(h: H, node: any) {


### PR DESCRIPTION
My institution uses Siteimprove to evaluate websites for accessibility compliance. It spotted that our iframes (for [embedded youtube videos](https://mystmd.org/guide/figures#youtube-videos)) were missing a "text alternative". `<iframe>` doesn't have an `alt` attribute, but it does use `title` for this purpose apparently.

 - https://help.siteimprove.com/support/solutions/articles/80001051799-accessibility-rule-inline-frame-without-a-text-alternative-explained
 - https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#accessibility

The content of the iframe directive is used as a caption. I'm not sure if it would be better to re-use the `caption.body` as the iframe title, re-use the iframe title for the caption, or let them be separate.