### PR TITLE
Lift plugin types to myst cli (refactoring) :arrow_heading_down: 

### DIFF
--- a/packages/myst-cli/src/build/utils/index.ts
+++ b/packages/myst-cli/src/build/utils/index.ts
@@ -5,3 +5,4 @@ export * from './getFileContent.js';
 export * from './localArticleExport.js';
 export * from './resolveAndLogErrors.js';
 export * from './bibtex.js';
+export * from './projectManifest.js';

--- a/packages/myst-cli/src/index.ts
+++ b/packages/myst-cli/src/index.ts
@@ -3,7 +3,7 @@ export * from './cli/index.js';
 export * from './config.js';
 export * from './init/index.js';
 export * from './frontmatter.js';
-export * from './plugins.js';
+export * from './plugins/index.js';
 export * from './process/index.js';
 export * from './project/index.js';
 export * from './session/index.js';

--- a/packages/myst-cli/src/plugins/executable.ts
+++ b/packages/myst-cli/src/plugins/executable.ts
@@ -1,12 +1,7 @@
-import type { ISession } from './session/types.js';
-import {
-  type MystPlugin,
-  type DirectiveSpec,
-  type RoleSpec,
-  type TransformSpec,
-  type GenericNode,
-} from 'myst-common';
 import { spawn, spawnSync } from 'node:child_process';
+import type { ISession } from '../session/types.js';
+import type { DirectiveSpec, RoleSpec, GenericNode, } from 'myst-common';
+import type {MystPlugin, TransformSpec } from './types.js';
 
 type DirectiveJSONSpec = Omit<DirectiveSpec, 'run' | 'validate'>;
 type RoleJSONSpec = Omit<RoleSpec, 'run' | 'validate'>;

--- a/packages/myst-cli/src/plugins/index.ts
+++ b/packages/myst-cli/src/plugins/index.ts
@@ -1,0 +1,3 @@
+export * from './load.js';
+export * from './executable.js';
+export * from './types.js';

--- a/packages/myst-cli/src/plugins/load.ts
+++ b/packages/myst-cli/src/plugins/load.ts
@@ -1,10 +1,11 @@
 import fs from 'node:fs';
 import { pathToFileURL } from 'node:url';
-import type { ISession } from './session/types.js';
-import { RuleId, plural, type MystPlugin, type ValidatedMystPlugin } from 'myst-common';
+import { RuleId, plural } from 'myst-common';
 import type { PluginInfo } from 'myst-config';
-import { addWarningForFile } from './utils/addWarningForFile.js';
-import { loadExecutablePlugin } from './executablePlugin.js';
+import type { ISession } from '../session/index.js';
+import { addWarningForFile } from '../utils/addWarningForFile.js';
+import { loadExecutablePlugin } from './executable.js';
+import type { MystPlugin, ValidatedMystPlugin } from './types.js';
 
 /**
  * Load user-defined plugin modules declared in the project frontmatter

--- a/packages/myst-cli/src/plugins/types.ts
+++ b/packages/myst-cli/src/plugins/types.ts
@@ -1,0 +1,40 @@
+import type { Plugin } from 'unified';
+import type { GenericNode, GenericParent, DirectiveSpec, RoleSpec } from 'myst-common';
+
+type Select = (selector: string, tree?: GenericParent) => GenericNode | null;
+type SelectAll = (selector: string, tree?: GenericParent) => GenericNode[] | null;
+
+export type PluginUtils = { select: Select; selectAll: SelectAll };
+export type PluginOptions = Record<string, any>;
+
+export type TransformSpec = {
+  name: string;
+  doc?: string;
+  stage: 'document' | 'project';
+  // context?: 'tex' | 'docx' | 'jats' | 'typst' | 'site';
+  plugin: Plugin<
+    [PluginOptions | undefined, PluginUtils],
+    GenericParent,
+    GenericParent | Promise<GenericParent>
+  >;
+};
+
+/**
+ * Create MyST plugins that export this from a file,
+ * or combine multiple plugins to a single object.
+ */
+export type MystPlugin = {
+  name?: string;
+  author?: string;
+  license?: string;
+  directives?: DirectiveSpec[];
+  roles?: RoleSpec[];
+  transforms?: TransformSpec[];
+};
+
+export type ValidatedMystPlugin = Required<
+  Pick<MystPlugin, 'directives' | 'roles' | 'transforms'>
+> & {
+  paths: string[];
+};
+

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { tic } from 'myst-cli-utils';
-import type { GenericParent, IExpressionResult, PluginUtils, References } from 'myst-common';
+import type { GenericParent, IExpressionResult, References } from 'myst-common';
 import { fileError, fileWarn, RuleId, slugToUrl } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import { SourceFileKind } from 'myst-spec-ext';
@@ -35,10 +35,10 @@ import { unified } from 'unified';
 import { select, selectAll } from 'unist-util-select';
 import { VFile } from 'vfile';
 import { processPageFrontmatter, updateFileInfoFromFrontmatter } from '../frontmatter.js';
+import { PluginUtils } from '../plugins/index.js';
 import { selectors } from '../store/index.js';
-import type { ISession } from '../session/types.js';
-import { castSession } from '../session/cache.js';
-import type { RendererData } from '../transforms/types.js';
+import { type ISession, castSession } from '../session/index.js';
+import { type RendererData, rawDirectiveTransform } from '../transforms/index.js';
 
 import {
   checkLinksTransform,
@@ -68,20 +68,17 @@ import {
   transformLiftCodeBlocksInJupytext,
   transformMystXRefs,
 } from '../transforms/index.js';
-import type { ImageExtensions } from '../utils/resolveExtension.js';
-import { logMessagesFromVFile } from '../utils/logging.js';
+import { type ImageExtensions, logMessagesFromVFile, addEditUrl } from '../utils/index.js';
 import { combineCitationRenderers } from './citations.js';
 import { bibFilesInDir, selectFile } from './file.js';
 import { parseMyst } from './myst.js';
 import { kernelExecutionTransform, LocalDiskCache } from 'myst-execute';
 import type { IOutput } from '@jupyterlab/nbformat';
-import { rawDirectiveTransform } from '../transforms/raw.js';
-import { addEditUrl } from '../utils/addEditUrl.js';
 import {
   indexFrontmatterFromProject,
   manifestPagesFromProject,
   manifestTitleFromProject,
-} from '../build/utils/projectManifest.js';
+} from '../build/index.js';
 
 const LINKS_SELECTOR = 'link,card,linkBlock';
 

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -3,7 +3,7 @@ import type { Store } from 'redux';
 import { createStore } from 'redux';
 import type { Logger } from 'myst-cli-utils';
 import { chalkLogger, LogLevel } from 'myst-cli-utils';
-import type { RuleId, ValidatedMystPlugin } from 'myst-common';
+import type { RuleId } from 'myst-common';
 import latestVersion from 'latest-version';
 import boxen from 'boxen';
 import chalk from 'chalk';
@@ -15,7 +15,7 @@ import {
   findCurrentSiteAndLoad,
   reloadAllConfigsForCurrentSite,
 } from '../config.js';
-import { loadPlugins } from '../plugins.js';
+import { type ValidatedMystPlugin, loadPlugins } from '../plugins/index.js';
 import type { BuildWarning } from '../store/index.js';
 import { selectors } from '../store/index.js';
 import type { RootState } from '../store/reducers.js';

--- a/packages/myst-cli/src/session/types.ts
+++ b/packages/myst-cli/src/session/types.ts
@@ -1,6 +1,6 @@
 import type { CitationRenderer } from 'citation-js-utils';
 import type { Logger } from 'myst-cli-utils';
-import type { MystPlugin, RuleId, ValidatedMystPlugin } from 'myst-common';
+import type { RuleId } from 'myst-common';
 import type { ResolvedExternalReference } from 'myst-transforms';
 import type { MinifiedContentCache } from 'nbtx';
 import type { Store } from 'redux';
@@ -11,6 +11,7 @@ import type { PreRendererData, RendererData, SingleCitationRenderer } from '../t
 import type { SessionManager } from '@jupyterlab/services';
 import type MystTemplate from 'myst-templates';
 import type { PluginInfo } from 'myst-config';
+import type { MystPlugin, ValidatedMystPlugin } from '../plugins/index.js';
 
 export type ISession = {
   API_URL: string;

--- a/packages/myst-cli/src/transforms/index.ts
+++ b/packages/myst-cli/src/transforms/index.ts
@@ -2,6 +2,7 @@ export * from './citations.js';
 export * from './code.js';
 export * from './crossReferences.js';
 export * from './dois.js';
+export * from './raw.js';
 export * from './ror.js';
 export * from './embed.js';
 export * from './images.js';

--- a/packages/myst-cli/src/utils/index.ts
+++ b/packages/myst-cli/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './addEditUrl.js';
 export * from './addWarningForFile.js';
 export * from './check.js';
 export * from './createTempFolder.js';

--- a/packages/myst-common/src/index.ts
+++ b/packages/myst-common/src/index.ts
@@ -50,11 +50,6 @@ export type {
   DirectiveContext,
   RoleSpec,
   ParseTypes,
-  MystPlugin,
-  ValidatedMystPlugin,
-  PluginOptions,
-  PluginUtils,
-  TransformSpec,
   FrontmatterPart,
   FrontmatterParts,
 } from './types.js';

--- a/packages/myst-common/src/rule-severities.ts
+++ b/packages/myst-common/src/rule-severities.ts
@@ -119,7 +119,7 @@ export const RULE_DEFAULT_SEVERITY: Record<RuleId, 'error' | 'warn'> = {
   [RuleId.sourceFileCopied]: 'error', // addWarningForFile in packages/myst-cli/src/process/site.ts
   [RuleId.templateFileCopied]: 'error', // addWarningForFile in packages/myst-cli/src/build/site/manifest.ts
   [RuleId.staticActionFileCopied]: 'error', // addWarningForFile in packages/myst-cli/src/build/site/manifest.ts
-  [RuleId.pluginLoads]: 'error', // addWarningForFile in packages/myst-cli/src/plugins.ts
+  [RuleId.pluginLoads]: 'error', // addWarningForFile in packages/myst-cli/src/plugins/load.ts
   // Container rules
   [RuleId.containerChildrenValid]: 'error', // Uses both error (5×) and warn (1×); fileError, fileWarn in packages/myst-transforms/src/container...
   // File rules

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -1,4 +1,3 @@
-import type { Plugin } from 'unified';
 import type { Directive, Node, Role } from 'myst-spec';
 import type { VFile } from 'vfile';
 import type * as nbformat from '@jupyterlab/nbformat';
@@ -111,43 +110,6 @@ export type RoleSpec = {
   body?: BodyDefinition;
   validate?: (data: RoleData, vfile: VFile) => RoleData;
   run: (data: RoleData, vfile: VFile) => GenericNode[];
-};
-
-type Select = (selector: string, tree?: GenericParent) => GenericNode | null;
-type SelectAll = (selector: string, tree?: GenericParent) => GenericNode[] | null;
-
-export type PluginUtils = { select: Select; selectAll: SelectAll };
-export type PluginOptions = Record<string, any>;
-
-export type TransformSpec = {
-  name: string;
-  doc?: string;
-  stage: 'document' | 'project';
-  // context?: 'tex' | 'docx' | 'jats' | 'typst' | 'site';
-  plugin: Plugin<
-    [PluginOptions | undefined, PluginUtils],
-    GenericParent,
-    GenericParent | Promise<GenericParent>
-  >;
-};
-
-/**
- * Create MyST plugins that export this from a file,
- * or combine multiple plugins to a single object.
- */
-export type MystPlugin = {
-  name?: string;
-  author?: string;
-  license?: string;
-  directives?: DirectiveSpec[];
-  roles?: RoleSpec[];
-  transforms?: TransformSpec[];
-};
-
-export type ValidatedMystPlugin = Required<
-  Pick<MystPlugin, 'directives' | 'roles' | 'transforms'>
-> & {
-  paths: string[];
 };
 
 export enum TargetKind {


### PR DESCRIPTION
1) In the interest of being able to add a Session instance into the plugin utils that get passed to a plugin transform, move the following types from `myst-common` into `myst-cli`:
* `PluginUtils`
* `PluginOptions`
* `TransformSpec`
* `MystPlugin`
* `ValidatedMystPlugin`

2) Organize plugin stuff in `myst-cli` into a proper `plugins` sub-package.