### PR TITLE
Document how to use options with dashes in their names

### DIFF
--- a/packages/jtex/docs/create-a-latex-template.md
+++ b/packages/jtex/docs/create-a-latex-template.md
@@ -241,7 +241,16 @@ options:
       - Curvenote
 ```
 
-The options can be of `type:` `string`, `boolean` or `choice`. For all of your variable names, prefer `lowercase_underscores` for the naming convention. You can also provide a `title` for any `part` or `option`.
+The options can be of `type:` `string`, `boolean`, `choice`, or `file`. You can also provide a `title` for any `part` or `option`.
+
+If you use dashes in option names (i.e., `my-option` instead of `my_option`), you have to access them within brackets in your template:
+
+```
+[#- if options['my-option'] -#]
+#show: somefunction.with(
+  option: "[-options['my-option']-]"
+)
+```
 
 ## Content, Imports and Packages
 


### PR DESCRIPTION
Also add missing `file` type

I removed the recommendation to use underscores, because (a) that goes against what typst uses itself and (b) is also not a common pattern in YAML. So, I think we can let template authors decide for themselves if they want to deal with the dashes or not?