### PR TITLE
📖 Add subsection about document titles in TOC

### DIFF
--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -154,7 +154,7 @@ The title of the document in the table of contents is drawn from the
 [`title` field](frontmatter#titles) in the
 [document frontmatter](frontmatter#in-a-myst-markdown-file) or the first heading
 in the document if `title` isn't specified.
-The [`short_title`](frontmatter#available-frontmatter-fields) field can be used
+The [`short_title`](frontmatter#all-available-frontmatter-fields) field can be used
 to specify a shorter title for navigation elements of the rendered site.
 For example:
 


### PR DESCRIPTION
Closes #2470 

The feature requested in #2470 is already available and controlled by the `short_title` key in the frontmatter, but I missed this while reading the docs. Hopefully direct mention of the `short_title` option in the TOC docs page will help with discoverability!