### PR TITLE
Provide explicit debug command in error rules documentation

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -100,7 +100,7 @@ project:
         - 'https://*.example.com/**'
 ```
 
-The `severity` of each rule can be set to `ignore`, `warn`, or `error`. If the rule is triggered, then the severity listed will be adopted rather than the default log message severity. The default severity for rules included in the list is `ignore`, which means that simply listing the rule IDs as strings will ignore those rules. To discover the rule ID, run myst in debug mode to get the error (and optional key) printed to the console. For example, the above configuration updates will no longer warn on `math-eqnarray-replaced` and will also ignore the two links when running `myst build --check-links --strict` in continuous integration.
+The `severity` of each rule can be set to `ignore`, `warn`, or `error`. If the rule is triggered, then the severity listed will be adopted rather than the default log message severity. The default severity for rules included in the list is `ignore`, which means that simply listing the rule IDs as strings will ignore those rules. To discover the rule ID, run myst in debug mode (i.e. `myst --debug build`) to get the error (and optional key) printed to the console. For example, the above configuration updates will no longer warn on `math-eqnarray-replaced` and will also ignore the two links when running `myst build --check-links --strict` in continuous integration.
 
 :::{seealso .dropdown} List of Error Rules
 


### PR DESCRIPTION
My first time reading this doc, I struggled a bit because I assumed `--debug` would be e.g. an argument to `myst build`, and it didn't show up in `myst build --help`. I figured it out soon after, but I figure for folks less used to CLIs it would be good to explicitly provide an example.