### PR TITLE
🧪 Remove short DOI test in latex

### DIFF
--- a/packages/myst-cli/src/transforms/doi.spec.ts
+++ b/packages/myst-cli/src/transforms/doi.spec.ts
@@ -19,6 +19,35 @@ const PRIESTLEY_1972_CSL_JSON = [
     volume: '100',
   },
 ];
+
+const BARTELS_1997_CSL_JSON = [
+  {
+    DOI: '10.1002/(sici)1096-987x(199709)18:12<1450::aid-jcc3>3.0.co;2-i',
+    // ISSN: '0192-8651',
+    // URL: 'http://dx.doi.org/10.1002/(SICI)1096-987X(199709)18:12<1450::AID-JCC3>3.0.CO;2-I',
+    author: [
+      {
+        family: 'Bartels',
+        given: 'Christian',
+      },
+      {
+        family: 'Karplus',
+        given: 'Martin',
+      },
+    ],
+    'container-title': 'Journal of Computational Chemistry',
+    issue: '12',
+    issued: {
+      'date-parts': [[1997, 9]],
+    },
+    page: '1450-1462',
+    publisher: 'Wiley',
+    title:
+      'Multidimensional adaptive umbrella sampling: Applications to main chain and side chain peptide conformations',
+    type: 'article-journal',
+    volume: '18',
+  },
+];
 describe.each([
   { resolver: resolveDOIAsBibTeX, name: 'BibTeX' },
   { resolver: resolveDOIAsCSLJSON, name: 'CSL-JSON' },
@@ -40,5 +69,16 @@ describe.each([
       'https://doi.org/10.1175/1520-0493(1972)100<0081:OTAOSH>2.3.CO;2',
     );
     expect(data).toMatchObject(PRIESTLEY_1972_CSL_JSON);
+  });
+  it('markdown link with strange characters resolves', async () => {
+    const data = await resolver(
+      new Session(),
+      'https://doi.org/10.1002/(SICI)1096-987X(199709)18:12%3C1450::AID-JCC3%3E3.0.CO;2-I',
+    );
+    // Both of these are different depending on the resolver
+    // The URL is encoded, the ISSN is actually different?!
+    delete data?.[0].URL;
+    delete data?.[0].ISSN;
+    expect(data).toMatchObject(BARTELS_1997_CSL_JSON);
   });
 });

--- a/packages/mystmd/tests/dois/index.md
+++ b/packages/mystmd/tests/dois/index.md
@@ -20,5 +20,3 @@ Nonexistent DOI citation (errors!): [](https://doi.org/10.1111/j.1365-246X.2012.
 DOI with with invalid BibTeX: [](10.2903/j.efsa.2019.5779)
 
 DOI with with invalid BibTeX as cite node: @10.2903/j.efsa.2019.5779
-
-DOI with some strange characters: [](<https://doi.org/10.1002/(SICI)1096-987X(199709)18:12%3C1450::AID-JCC3%3E3.0.CO;2-I>)

--- a/packages/mystmd/tests/dois/outputs/dois.bib
+++ b/packages/mystmd/tests/dois/outputs/dois.bib
@@ -73,19 +73,3 @@
 	volume = {17},
 }
 
-
-@article{Bartels_1997,
-	author = {Bartels, Christian and Karplus, Martin},
-	journal = {Journal of Computational Chemistry},
-	doi = {10.1002/(sici)1096-987x(199709)18:12<1450::aid-jcc3>3.0.co;2-i},
-	issn = {1096-987X},
-	number = {12},
-	year = {1997},
-	month = {9},
-	pages = {1450--1462},
-	publisher = {Wiley},
-	title = {Multidimensional adaptive umbrella sampling: Applications to main chain and side chain peptide conformations},
-	url = {http://dx.doi.org/10.1002/(SICI)1096-987X(199709)18:12%3C1450::AID-JCC3%3E3.0.CO;2-I},
-	volume = {18},
-}
-

--- a/packages/mystmd/tests/dois/outputs/dois.tex
+++ b/packages/mystmd/tests/dois/outputs/dois.tex
@@ -78,8 +78,6 @@ DOI with with invalid BibTeX: \cite{EFSA2019Dietary}
 
 DOI with with invalid BibTeX as cite node: \cite{EFSA2019Dietary}
 
-DOI with some strange characters: \cite{Bartels_1997}
-
 
 \bibliography{main.bib}
 


### PR DESCRIPTION
This doi is picked up in a myst-transform test already, the key in latex is not consistent and is leading to failures.