### PR TITLE
📦 Generalize the HTTP logger for the myst-cli

### DIFF
--- a/.changeset/sunny-comics-brake.md
+++ b/.changeset/sunny-comics-brake.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Generalize the http logger for myst-cli

--- a/packages/myst-cli/src/build/site/logger.ts
+++ b/packages/myst-cli/src/build/site/logger.ts
@@ -11,7 +11,7 @@ export function createServerLogger(
       const line = data.trim();
       if (!line || line.startsWith('>') || line.startsWith('Watching')) return;
       if (line.includes('File changed: app/content')) return; // This is shown elsewhere
-      if (line.includes('started at http://')) {
+      if (line.includes('http://')) {
         const [, ipAndPort] = line.split('http://');
         const port = ipAndPort.split(':')[1].replace(/[^0-9]/g, '');
         const local = `http://${opts.host}:${port}`;


### PR DESCRIPTION
We overwrite the logs for the remix and react-router, currently there is a difference in how they report that the port is ready. This works for both.