### PR TITLE
DOC: removing deprecated frontmatter from docs

### DIFF
--- a/docs/notebook-configuration.md
+++ b/docs/notebook-configuration.md
@@ -39,7 +39,8 @@ kernelspec:
   name: python3
   display_name: Python 3
 
-skip_execution: true
+execute:
+  skip: true
 ---
 ```
 


### PR DESCRIPTION
This should close #2595; however I'm not certain if we still have the cell level tag or not? Looking at the source code I think those are still valid, but if I misunderstood something then more cleanup will be needed.