### PR TITLE
FIX: formatting in developer.md for mermaid diagram

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -38,17 +38,17 @@ Here's a workflow for producing a rich web application:
 
 ```{mermaid}
 flowchart TB
-  subgraph "<tt>myst start --headless</tt>"
-    subgraph <b>Document conversion</b>
+  subgraph "myst start --headless"
+    subgraph "<b>Document conversion</b>"
     direction LR
     doc[folder_of/myfile.md] --> ast[AST]
     end
-    subgraph <b>Content server</b>
+    subgraph "<b>Content server</b>"
     ast --> content_server[serve AST on http://localhost:3100]
     end
   end
-  subgraph "<tt>npm run theme:book</tt>"
-    subgraph <b>Theme server</b>
+  subgraph "npm run theme:book"
+    subgraph "<b>Theme server</b>"
     direction LR
     theme_server[render themed content at http://localhost:3000] --> content_server
     user[User browser] --> theme_server


### PR DESCRIPTION
Currently the diagram is not rendered see: https://mystmd.org/guide/developer

```
Error parsing mermaid graph.

Parse error on line 3:
...</tt>"    subgraph <b>Document conversi
----------------------^
Expecting 'SPACE', 'GRAPH', 'DIR', 'subgraph', 'end', 'AMP', 'COLON', 'START_LINK', 'STR', 'MD_STR', 'STYLE', 'LINKSTYLE', 'CLASSDEF', 'CLASS', 'CLICK', 'DOWN', 'UP', 'NUM', 'NODE_STRING', 'BRKT', 'MINUS', 'MULT', 'UNICODE_TEXT', got 'TAGSTART'

```