### PR TITLE
Add citation markdown formatting info to simple referencing with DOI Link

### DIFF
--- a/docs/citations.md
+++ b/docs/citations.md
@@ -15,22 +15,6 @@ There are two different ways to add citations to your documents:
 ## Simple Referencing with a DOI Link
 
 Link to any DOI in your Markdown files or Jupyter Notebooks by including a link to the DOI.
-Provided the `DOI` is formatted correctly, this will be transformed during the build process to a citation with a pop-up panel on hover like this: [Cockett, 2022](https://doi.org/10.5281/zenodo.6476040), and the reference information will be automatically added to the reference section at the bottom of your notebook (see below 👇).
-
-```md
-This is a link in Markdown: [Cockett, 2022](https://doi.org/10.5281/zenodo.6476040).
-```
-
-It is also possible to drop the link text, that is:\
-`<doi:10.5281/zenodo.6476040>` or `[](doi:10.5281/zenodo.6476040)`,\
-which will insert the citation text in the correct format (e.g. adding an italic "_et al._", etc.).
-If the DOI is present on a citation from a BibTeX file in your project, that citation will be used.
-Otherwise, the citation data for these DOIs will be downloaded from `https://doi.org` once and cached to a local file in the `_build` directory.
-This cache may be cleared with `myst clean --cache`.
-
-Providing your DOIs as full links has the advantage that on other rendering platforms (e.g. GitHub), your citation will still be shown as a link.
-If you have many citations, however, this will slow down the build process as the citation information is fetched dynamically.
-Link to any DOI in your Markdown files or Jupyter Notebooks by including a link to the DOI.
 This will be transformed to a citation with a pop-up panel on hover like this: [Cockett, 2022](https://doi.org/10.5281/zenodo.6476040), and the reference information will be added to the reference section at the bottom of the page. Here's some example syntax:
 
 ```md


### PR DESCRIPTION
This week, I have been trying to work through using MyST for the first time to write a manuscript. 

I found the ease of use of [full doi links ](https://mystmd.org/guide/citations#doi-links) to be highly appealing, especially because I would not need to export BibTeX files and these links would be clickable through plain markdown. 

However, the proposed formatting in that section is either:
1. locked to a user defined format. i.e. `[Cockett, 2022](https://doi.org/10.5281/zenodo.6476040).`
2. or represents an easy to use, but not modifiable narrative syntax. i.e. `[](https://doi.org/10.5281/zenodo.6476040)`

I spent quite a while before I finally just tried to do what I really wanted, which was to combine the markdown formatting found in the [pandoc table](https://mystmd.org/guide/citations#table-pandoc-citations) with the magic of a full doi link, such as:

1. parenthetical with `[@https://doi.org/10.5281/zenodo.18089604]`
2. narrative with `@https://doi.org/10.5281/zenodo.18089604`

This is great, because now depending on the citation format I can output without a BibTeX file with the appropriate citation style.

To hopefully save others (and probably myself too) time in the future, I added a minimal mention that non-BibTeX markdown formatting is supported. 

Alternatively, this full doi style could be added to the table, but I think that it goes better (somewhere) in the DOI section because of clarity that a BibTeX file is not needed.