### PR TITLE
DOCX Add html line break in references when exporting to docx

### DIFF
--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -65,6 +65,9 @@ function defaultWordRenderer(
     });
   if (referencesDocStates.length > 0) {
     serializer.render(createReferenceTitle());
+    referencesDocStates.forEach((child) => {
+      child.value += "<br />";
+    });
     const referencesRoot = htmlTransform({ type: 'root', children: referencesDocStates as any });
     serializer.renderChildren(referencesRoot);
     serializer.closeBlock();


### PR DESCRIPTION
Dear maintainers,
this pull request adds a line break to each html reference node, so the translation to docx keeps a hard return after every reference.
Fixes #2655

A more aesthetic solution would probably have been to add one more level of nesting in the node structure  before serializing... but this was above my code understanding.
Hope this can help anyway.

Thanks for considering this PR