### PR TITLE
🖊️ Separate references into paragraphs when exporting to docx

### DIFF
--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -77,12 +77,9 @@ function defaultWordRenderer(
   if (referenceNodes.length > 0) {
     serializer.render(createReferenceTitle());
 
-    const breakNode = {
-      type: 'break',
-    };
     const referencesRoot = {
       type: 'root',
-      children: referenceNodes.map((node) => [node, breakNode]).flat(),
+      children: referenceNodes,
     };
     serializer.renderChildren(referencesRoot);
     serializer.closeBlock();


### PR DESCRIPTION
Dear maintainers,
this pull request adds a line break to each html reference node, so the translation to docx keeps a hard return after every reference.
Fixes https://github.com/jupyter-book/mystmd/issues/2655 and closes #2711

This is the same as #2677 with the correct branch name so the label check is working.

A more aesthetic solution would probably have been to add one more level of nesting in the node structure before serializing... but this was above my code understanding.
Hope this can help anyway.

Thanks for considering this PR