### PR TITLE
Document folder and landing page behavior

### DIFF
--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -311,76 +311,8 @@ If there are duplicates, these will be enumerated with a trailing number (e.g. `
 
 ### Preserve folders in URLs
 
-By default, MyST will _remove folder information_ when creating URLs, as illustrated in the example above.
-
-To make your URL match your folder structure (so that `myfolder/myfile.md` becomes `myfolder/myfile/`), set `site.options.folders` to `true` in `myst.yml`. For example:
-
-```{code} yml
-:filename: myst.yml
-:caption: Example of setting folders to true to show nested file structure in the URL
-:linenos:
-:lineno-start: 78
-:emphasize-lines: 82
-...
-site:
-  template: book-theme
-  options:
-    folders: true
-...
-```
-
-### Slug examples
-
-The following examples show how filenames are converted to slugs:
-
-:::{list-table}
-:header-rows: 1
-:align: center
-:label: toc-slugs
-
-* - file path
-  - slug
-* - `simple-page.md`
-  - `simple-page`
-* - `multiple---dashes.md`
-  - `multiple-dashes`
-* - `12-01-remove_digits.md`
-  - `remove-digits`
-* - `approx-π-suite.md`
-  - `approx-suite`
-* - `notes-élémentaires.md`
-  - `notes-l-mentaires`
-* - `2025_12_01-dates.md`
-  - `2025-12-01-dates`
-* - `2025_12_01.md`
-  - `2025-12-01`
-* - `2025_12.md`
-  - `2025-12-1`
-* - `2025-12-01-minutes.md`
-  - `2025-12-01-minutes`
-* - `2025.md`
-  - `2025`
-* - `01.md`
-  - `01`
-:::
-
-Here is the effect of setting `site.options.folders` to `true` or `false`:
-
-:::{list-table}
-:header-rows: 1
-:align: center
-:label: toc-folders
-
-* - file path
-  - default
-  - folders=true
-* - `simple-page.md`
-  - `simple-page`
-  - `simple-page`
-* - `f1/f2/nested-file.md`
-  - `nested-file`
-  - `f1/f2/nested-file`
-:::
+By default, MyST will _remove folder information_ when creating URLs.
+To make your URL match your folder structure (so that `myfolder/myfile.md` becomes `myfolder/myfile/`), see [](#site-url-folders).
 
 (implicit-toc)=
 

--- a/docs/website-templates.md
+++ b/docs/website-templates.md
@@ -82,18 +82,38 @@ Below is a table of options for each theme bundled with MyST.
 ```
 
 (site-url-folders)=
-### Make site URLs respect folder structure
+### Folder-based URL structures
 
-By default, MyST URLs only contain the file name for each page; folder structure is respected in the table of contents but is not reflected in URLs. If you would like to maintain nested folder structure in the URLs, you may set the site option `folders` to `true`. This causes each folder in your MyST directory to become a path segment. For this feature to work correctly, your chosen theme must also support `folders` as an option. Both `book-theme` and `article-theme` bundled with MyST support this.
+By default, MyST URLs only contain the file name for each page, not folder names. To maintain nested folder structure in the URLs (e.g., `folder/page.md` -> `/folder/page/`), use `site.options.folders` like so:
 
-```{code-block} yaml
+
+```{code} yml
 :filename: myst.yml
+:caption: Example of setting folders to true to show nested file structure in the URL
 :linenos:
-:emphasize-lines: 3
+...
 site:
+  template: book-theme
   options:
     folders: true
+...
 ```
+
+#### Use index files as folder landing pages
+
+With `folders: true`, you can use `index.md` (or `readme.md`) inside a folder as a landing page for that folder.
+This lets you organize all of a section's content in a single folder:
+
+```
+getting-started/
+  ├── index.md           # Landing page at /getting-started/
+  ├── install.md         # /getting-started/install/
+  └── configuration.md   # /getting-started/configuration/
+```
+
+:::{warning}
+If both `getting-started.md` and `getting-started/index.md` exist, the sibling file takes the slug `getting-started` first, and the folder's index file gets a deduplicated slug like `getting-started-1`.
+:::
 
 ### Page Options
 


### PR DESCRIPTION
This documents behavior that we've already got but didn't mention: if a page is at `folder/index.md`, then the URL that's rendered becomes `/folder/`

It also de-duplicates some folder config instructions and points to a source of truth.

---

- closes https://github.com/jupyter-book/mystmd/issues/2372