### PR TITLE
🧹 Fix json type annotation in anywidget directive

### DIFF
--- a/packages/myst-directives/src/anywidget.ts
+++ b/packages/myst-directives/src/anywidget.ts
@@ -61,7 +61,7 @@ export const widgetDirective: DirectiveSpec = {
     return data;
   },
   run(data, _vfile, _opts) {
-    let model: ReturnType<typeof JSON5.parse>;
+    let model: Record<string, unknown>;
     if (data.body === undefined) {
       model = {};
     } else {


### PR DESCRIPTION
The `ReturnType<typeof JSON5.parse>` annotation was resolving to `unknown` and causing ts build errors downstream. This type annotation now matches the expected type of `AnyWidget.model`. Potentially we should add some guards against `JSON5.parse` resolving to [array, string, null, etc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#return_value), but for now I just wanted to ship this type change quickly without any code changes.