### PR TITLE
🪟 Windows paths on upgrade, resolve paths correctly

### DIFF
--- a/.changeset/fancy-tables-fly.md
+++ b/.changeset/fancy-tables-fly.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Upgrade windows should have the correct path

--- a/packages/myst-cli/src/init/jupyter-book/toc.ts
+++ b/packages/myst-cli/src/init/jupyter-book/toc.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { resolveExtension } from '../../utils/resolveExtension.js';
-import { join, relative } from 'node:path';
+import path, { join, relative } from 'node:path';
 import { cwd } from 'node:process';
 import type { ISession } from '../../session/types.js';
 import type { Entry as MySTEntry, ParentEntry as MySTParentEntry } from 'myst-toc';
@@ -201,8 +201,8 @@ function assertNever(): never {
 function maybeResolveDocument(dir: string, name: string, session: ISession): string {
   const resolved = resolveExtension(join(dir, name));
   if (resolved) {
-    // Use forward slashes for cross-platform compatibility (Windows path.relative uses backslashes)
-    return relative(dir, resolved).replace(/\\/g, '/');
+    // Use POSIX slashes for cross-platform compatibility (Windows path.relative uses backslashes)
+    return relative(dir, resolved).replaceAll(path.sep, path.posix.sep);
   }
   session.log.error(`Could not find a file named ${name} (declared in table of contents)`);
 

--- a/packages/myst-cli/src/init/jupyter-book/toc.ts
+++ b/packages/myst-cli/src/init/jupyter-book/toc.ts
@@ -201,7 +201,8 @@ function assertNever(): never {
 function maybeResolveDocument(dir: string, name: string, session: ISession): string {
   const resolved = resolveExtension(join(dir, name));
   if (resolved) {
-    return relative(dir, resolved);
+    // Use forward slashes for cross-platform compatibility (Windows path.relative uses backslashes)
+    return relative(dir, resolved).replace(/\\/g, '/');
   }
   session.log.error(`Could not find a file named ${name} (declared in table of contents)`);
 

--- a/packages/myst-cli/src/utils/resolveExtension.ts
+++ b/packages/myst-cli/src/utils/resolveExtension.ts
@@ -91,7 +91,13 @@ export function resolveExtension(
       }
     });
     if (normalizedMatches.length === 0 && path.extname(file)) {
-      warnFn(`Table of contents entry does not exist: ${file}`, 'error');
+      warnFn(
+        `Table of contents entry does not exist: ${file}`,
+        'error',
+        file.includes('\\')
+          ? 'Always use UNIX-style path separators (forward slashes) in the table of contents.'
+          : undefined,
+      );
     } else if (normalizedMatches.length === 0) {
       // Need a different warning if this is a folder
       warnFn(


### PR DESCRIPTION
This replaces the backslashes with unix-style paths. There is also a warning now that has a note for users who do this on their own.

Fixes jupyter-book/jupyter-book#2599