### PR TITLE
🆕 Emit Node20 for mystmd

### DIFF
--- a/packages/mystmd/package.json
+++ b/packages/mystmd/package.json
@@ -38,7 +38,7 @@
     "typecheck": "tsc --noEmit",
     "test": "npm run link; npm run copy:version; vitest run; bun run typecheck",
     "test:watch": "npm run link; npm run copy:version; vitest watch",
-    "build:cli": "esbuild src/index.ts --bundle --outfile=dist/myst.cjs --platform=node --external:fsevents --target=node18",
+    "build:cli": "esbuild src/index.ts --bundle --outfile=dist/myst.cjs --platform=node --external:fsevents --target=node20",
     "build": "npm-run-all -l clean copy:version -p build:cli"
   },
   "devDependencies": {


### PR DESCRIPTION
Now that our minimum version of Node.js is Node.js 20, and we have a policy of three trailing LTS versions (which I can't find the provenance for, but I remember discussing it with core team members), we should bump our esbuild target.