### PR TITLE
📖 Install NodeJS guide: Removed unnecessary verb on a sentence

### DIFF
--- a/docs/install-node.md
+++ b/docs/install-node.md
@@ -35,7 +35,7 @@ Download the installer package, and follow instructions to execute the installer
 
 `nodejs` is available as a package on `conda-forge`, although a limited number of versions are available on that channel. If you are a `conda` user, installation is straightforward but please note that MyST requires even-numbered node versions, and odd-numbered releases can be found on `conda-forge`.
 
-🛠️ Use the following command can be used to lock down the version you are installing, adjust as necessary for the even-numbered version you are targeting:
+🛠️ The following command can be used to lock down the version you are installing, adjust as necessary for the even-numbered version you are targeting:
 
 ```shell
 (my-conda-env)% conda install -c conda-forge 'nodejs>=20,<21'


### PR DESCRIPTION
Good day team, [in this guide about installing NodeJS](https://mystmd.org/guide/install-node#node-via-conda-mamba-all-platforms), there is a small grammatical error:

    Use the following command can be used to lock down the version you are installing

**Grammatical reasoning**

In the English language, each simple sentence contains 1 main verb. The quoted text contains 2 main verbs: `Use` and `can`. It seems that the author wanted to use `can`, and later forgot to delete the other verb.

**Resulting text**

    The following command can be used to lock down the version you are installing

This reads like a proper guide, indicating to the reader that the following command locks down the NodeJS version.

Thank you so much for your attention 🙏 