### PR TITLE
🔧 fix exports when anywidgets are in containers

### DIFF
--- a/.changeset/anywidget-figure-meca.md
+++ b/.changeset/anywidget-figure-meca.md
@@ -1,0 +1,6 @@
+---
+'myst-transforms': patch
+---
+
+Recognize `anywidget` as valid figure container content so figures wrapping the `{anywidget}` directive no longer error during transforms and exports such as MECA. Fixes #2809
+.

--- a/packages/myst-cli/src/transforms/anywidgets.ts
+++ b/packages/myst-cli/src/transforms/anywidgets.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import { access, readdir } from 'node:fs/promises';
 import type { GenericParent } from 'myst-common';
 import { RuleId } from 'myst-common';
 import { computeHash, hashAndCopyStaticFile, isUrl } from 'myst-cli-utils';
@@ -50,9 +50,15 @@ export async function transformWidgetStaticAssetsToDisk(
         const stem = computeHash(attrPath);
 
         // Check whether file with stem exists (but unknown extension)
-        const exists = fs.existsSync(writeFolder);
-        const existingName = fs.readdirSync(writeFolder).find((f) => path.parse(f).name === stem);
-        if (exists && existingName !== undefined) {
+        let existingName: string | undefined;
+        try {
+          const entries = await readdir(writeFolder);
+          existingName = entries.find((f) => path.parse(f).name === stem);
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code !== 'ENOENT') throw err;
+        }
+        if (existingName !== undefined) {
           session.log.debug(`Cached asset found for '${attr}' (${attrPath})...`);
           fileName = existingName;
         } else {
@@ -76,8 +82,18 @@ export async function transformWidgetStaticAssetsToDisk(
             continue;
           }
         }
-      } else if (fs.existsSync(attrLocalPath)) {
-        // Non-oxa, non-url local image paths relative to the config.section.path
+      } else {
+        try {
+          await access(attrLocalPath);
+        } catch {
+          const message = `Cannot find asset for '${attr}' "${attrPath}" in ${attrSourceFolder}`;
+          addWarningForFile(session, filePath, message, 'error', {
+            position: widgetNode.position,
+            // TODO: add "asset exists" rule?
+          });
+          continue;
+        }
+        // non-url local image paths relative to the config.section.path
         if (path.resolve(path.dirname(attrLocalPath)) === path.resolve(writeFolder)) {
           // If file is already in write folder, don't hash/copy
           fileName = path.basename(attrLocalPath);
@@ -87,13 +103,6 @@ export async function transformWidgetStaticAssetsToDisk(
           });
         }
         if (!fileName) continue;
-      } else {
-        const message = `Cannot find asset for '${attr}' "${attrPath}" in ${attrSourceFolder}`;
-        addWarningForFile(session, filePath, message, 'error', {
-          position: widgetNode.position,
-          // TODO: add "asset exists" rule?
-        });
-        continue;
       }
       // Update mdast with new file name
       if (fileName !== undefined) {

--- a/packages/myst-transforms/src/containers.spec.ts
+++ b/packages/myst-transforms/src/containers.spec.ts
@@ -12,6 +12,10 @@ function image(placeholder = false) {
   return u('image', { url: 'my-image.png', placeholder });
 }
 
+function anywidget() {
+  return u('anywidget', { esm: './widget.mjs', id: 'w1', model: {} });
+}
+
 function container(children: GenericNode[], kind = 'figure'): GenericParent {
   children.forEach((child) => {
     if (child.type === 'container') child.subcontainer = true;
@@ -33,6 +37,13 @@ describe('Test containerChildrenTransform', () => {
     const mdast = rootContainer([image(), caption()]);
     containerChildrenTransform(mdast, new VFile());
     expect(mdast).toEqual(rootContainer([image(), caption()]));
+  });
+  test('figure with anywidget and caption is unchanged', async () => {
+    const mdast = rootContainer([anywidget(), caption()]);
+    const file = new VFile();
+    containerChildrenTransform(mdast, file);
+    expect(mdast).toEqual(rootContainer([anywidget(), caption()]));
+    expect(file.messages.filter((m) => m.fatal)).toHaveLength(0);
   });
   test('figure with caption and one image is reordered', async () => {
     const mdast = rootContainer([caption(), image()]);

--- a/packages/myst-transforms/src/containers.ts
+++ b/packages/myst-transforms/src/containers.ts
@@ -23,6 +23,7 @@ const SUBFIGURE_TYPES = [
   'table',
   'code',
   'output',
+  'anywidget',
 ];
 
 /** Raise a warning if caption includes content that is expected to be directly on the figure */
@@ -113,7 +114,7 @@ function hoistContentOutOfParagraphs(tree: GenericParent) {
  * Update container children and add sub-figures
  *
  * - Valid container nodes are ensured to be first children.
- *   These include image/iframe/table/code/embed/block/container nodes.
+ *   These include image/iframe/table/code/embed/block/container/anywidget nodes.
  * - If multiple of these are present, they are nested as sub-figures.
  *   (This does not include placeholder images, which are left unchanged)
  * - A warning is raised if these node types are found in caption or legend
@@ -197,7 +198,7 @@ export function containerChildrenTransform(tree: GenericParent, vfile: VFile) {
         {
           node: container,
           ruleId: RuleId.containerChildrenValid,
-          note: 'Valid content types include image, referenced notebook cell, table, code, iframe, subfigure',
+          note: 'Valid content types include image, referenced notebook cell, table, code, iframe, subfigure, anywidget',
         },
       );
     }


### PR DESCRIPTION
- 🔧 no longer reading dir that may not exist
- 🏎️ moved to non-blocking fs calls, as any sync call blocks the whole of node
- 🖼️ add anywidget as a subfigure type, while here because they could be
