### PR TITLE
📖 Developer Guide: Fixed typo on a sentence

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -101,7 +101,7 @@ MyST has multiple renderers, themes, and templates that allow it to transform My
   - The [MyST React Renderer](https://github.com/jupyter-book/myst-theme/tree/main/packages/myst-to-react) generates React components out of MyST AST for use by the default MyST Themes. It provides a `<MyST />` component which can render MyST AST into a React tree.
   - The source code of the [default MyST Themes](https://github.com/jupyter-book/myst-theme/tree/main/themes), each of which use the React renderer. These themes are built and then published at the [`myst-templates` GitHub organization](https://github.com/myst-templates/book-theme) for consumption by users.
   - A React [context](https://react.dev/reference/react/useContext), named `ThemeContext` (defined [here in the `myst-theme` repository](https://github.com/jupyter-book/myst-theme/blob/main/packages/providers/src/theme.tsx)), is used to push state deeply into the tree, without having to pass it via props.
-- [`myst-templates`](https://github.com/myst-templates): An index of templates that convert rendered components into final outputs. These are similar to _MyST Themes_, but follow a more standard "template" structure to product static outputs.
+- [`myst-templates`](https://github.com/myst-templates): An index of templates that convert rendered components into final outputs. These are similar to _MyST Themes_, but follow a more standard "template" structure to produce static outputs.
 
 :::{error} to do — explain rendering
 


### PR DESCRIPTION
Good day team, [in the Developer Guide document](https://mystmd.org/guide/developer#where-to-find-renderers-themes-and-templates), there is seemingly a typo that is being addressed by this PR. Pay particular attention to the ending: 'to product static outputs'.

    These are similar to MyST Themes, but follow a more standard “template” structure to product static outputs.

Grammatical reasoning

The structure of that sentence expects a verb after the 'to' preposition, as in 'to verb'. Reading that sentence, it seems that the expected verb is 'to produce', so where it says 'to product', it seems to be a typo.

Resulting text

    These are similar to MyST Themes, but follow a more standard “template” structure to produce static outputs.

This reads correctly, and it is accurate to the guide, because the MyST templates can be used to produce static output such as LaTeX, PDF, etc.

Please let me know if this is correct. Thank you.