### PR TITLE
Don't check links with strict mode

### DIFF
--- a/.changeset/funny-wasps-reply.md
+++ b/.changeset/funny-wasps-reply.md
@@ -1,0 +1,6 @@
+---
+"myst-cli": patch
+"mystmd": patch
+---
+
+Don't check links with strict mode.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -125,7 +125,11 @@ project:
         - 'https://*.example.com/**'
 ```
 
-The `severity` of each rule can be set to `ignore`, `warn`, or `error`. If the rule is triggered, then the severity listed will be adopted rather than the default log message severity. The default severity for rules included in the list is `ignore`, which means that simply listing the rule IDs as strings will ignore those rules. To discover the rule ID, run myst in debug mode (i.e. `myst --debug build`) to get the error (and optional key) printed to the console. For example, the above configuration updates will no longer warn on `math-eqnarray-replaced` and will also ignore the two explicit links and the two link patterns listed in the configuration when running `myst build --check-links --strict`.
+The `severity` of each rule can be set to `ignore`, `warn`, or `error`. If the rule is triggered, then the severity listed will be adopted rather than the default log message severity. For example, the above configuration updates will no longer warn on `math-eqnarray-replaced` and will also ignore the two explicit links and the two link patterns listed in the configuration when running `myst build --check-links --strict`.
+
+**The default severity is `ignore`**. Simply listing the rule IDs as strings will ignore those rules.
+
+**To discover the rule ID**, run myst in debug mode (i.e. `myst --debug build`) to get the error (and optional key) printed to the console.
 
 Some error rules support a `key` field that identifies specific instances of the error. This allows you to target particular cases rather than all instances of a rule. For example, the `link-resolves` rule uses the URL as the key, allowing you to ignore specific broken links while still checking others. Similarly, the `doi-link-valid` rule uses the DOI value as the key, so you can ignore specific invalid DOIs while still validating others. When a rule supports keys, you can provide a list of keys (or key patterns) in the `keys` field to match multiple specific instances.
 
@@ -159,19 +163,39 @@ The following domains are automatically skipped by the link checker and do not n
 
 :::
 
-**Common use cases:**
+### Fail builds with broken links
 
-To fail CI when there are missing links, you can use `myst build --check-links --strict` with the following example `myst.yml` configuration.
+To fail CI when there are broken external links, combine `--check-links` with `--strict`:
+
+```shell
+$ myst build --check-links --strict
+```
+
+Both flags are needed:
+
+- `--check-links` checks every external link and reports broken ones in the build log, but on its own does not cause the build to fail.
+- `--strict` exits non-zero on any errors reported during the build.
+
+Together they will cause a build to fail if any links are broken.
+
+#### Ignore specific URLs
+
+To skip some URL patterns (e.g. if you know they are flaky), add those URLs as `keys` under the `link-resolves` rule in your `myst.yml` with `severity: ignore`.
 
 ```{code-block} yaml
 :filename: myst.yml
 project:
   error_rules:
-    # Match both HTTP and HTTPS for a domain
     - rule: link-resolves
+      severity: ignore
       keys:
         - '{http,https}://legacy-api.mysite.com/**'
         - '{http,https}://staging.mysite.com/**'
 ```
 
-This is particularly useful for ignoring groups of external links that may be blocked in CI environments or example URLs that don't need to be checked.
+The `keys` values support glob patterns - see [Pattern Matching in Keys](#pattern-matching-in-keys) above.
+
+:::{tip} Omitting `severity:` has the same effect as `severity: ignore`
+
+Entries listed under `error_rules` default to `severity: ignore` (see [the error rules section](#setting:error_rules)). Setting it explicitly makes the intent obvious at a glance.
+:::

--- a/packages/myst-cli/docs/reference.md
+++ b/packages/myst-cli/docs/reference.md
@@ -73,25 +73,26 @@ You may specify `--site` if you only wish to build the site content. The first t
 myst build --site
 ```
 
-MyST can check for broken links when building a site. To report bad links:
+**Broken links**: MyST can check for broken links when building a site. To report bad links in the build log:
 
 ```
 myst build --check-links
 ```
 
-And use `--strict` to fail the build if there are errors from [rules](#setting:error_rules) set to error severity:
+On its own, `--check-links` only _reports_ broken links - the build still exits successfully.
+If a link successfully resolves during `--check-links`, the status will be cached to disk and the link will not be rechecked. If you need to recheck for broken links, you may clear this cache with `myst clean --cache`.
+
+**Fail on errors**: To make the build exit non-zero on any errors, use `--strict`:
 
 ```
 myst build --strict
 ```
 
-Combine the two to check links and fail the build on broken links or other errors:
+**Fail on broken links**: Combine both check links and fail the build on broken links (the typical CI setup):
 
 ```
 myst build --check-links --strict
 ```
-
-If a link successfully resolves during `--check-links`, the status will be cached to disk and the link will not be rechecked. If you need to recheck for broken links, you may clear this cache with `myst clean --cache`.
 
 ## MyST Start
 

--- a/packages/myst-cli/docs/reference.md
+++ b/packages/myst-cli/docs/reference.md
@@ -79,10 +79,16 @@ MyST can check for broken links when building a site. To report bad links:
 myst build --check-links
 ```
 
-And use `--strict` to fail the build if there are errors, such as bad links, or other [rules](#setting:error_rules) set to error severity:
+And use `--strict` to fail the build if there are errors from [rules](#setting:error_rules) set to error severity:
 
 ```
 myst build --strict
+```
+
+Combine the two to check links and fail the build on broken links or other errors:
+
+```
+myst build --check-links --strict
 ```
 
 If a link successfully resolves during `--check-links`, the status will be cached to disk and the link will not be rechecked. If you need to recheck for broken links, you may clear this cache with `myst clean --cache`.

--- a/packages/myst-cli/src/cli/options.ts
+++ b/packages/myst-cli/src/cli/options.ts
@@ -96,7 +96,10 @@ export function makeNamedExportOption(description: string) {
 }
 
 export function makeStrictOption() {
-  return new Option('--strict', 'Summarize build warnings and stop on any errors.').default(false);
+  return new Option(
+    '--strict',
+    'Summarize build warnings and exit non-zero on any errors.',
+  ).default(false);
 }
 
 export function makeForceOption(description: string) {
@@ -104,7 +107,10 @@ export function makeForceOption(description: string) {
 }
 
 export function makeCheckLinksOption() {
-  return new Option('--check-links', 'Check all links to websites resolve.').default(false);
+  return new Option(
+    '--check-links',
+    'Check all external links resolve and report broken ones in the build log.',
+  ).default(false);
 }
 
 export function makeKeepHostOption() {

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -545,7 +545,6 @@ export async function processProject(
     execute,
     maxSizeWebp,
     checkLinks,
-    strict,
   } = opts || {};
   if (!siteProject.path) {
     const slugSuffix = siteProject.slug ? `: ${siteProject.slug}` : '';
@@ -604,7 +603,7 @@ export async function processProject(
     pagesToTransform.map((page) =>
       postProcessMdast(session, {
         file: page.file,
-        checkLinks: checkLinks || strict,
+        checkLinks,
         pageReferenceStates,
         extraLinkTransformers,
         site: true,

--- a/packages/mystmd/tests/endToEnd.spec.ts
+++ b/packages/mystmd/tests/endToEnd.spec.ts
@@ -13,6 +13,7 @@ type TestCase = {
   env?: Record<string, any>;
   timeout?: number;
   command: string;
+  expectFailure?: boolean;
   outputs: {
     path: string;
     content?: string;
@@ -43,7 +44,7 @@ describe.concurrent('End-to-end cli export tests', { timeout: TIMEOUT }, () => {
   const cases = loadCases('exports.yml');
   test.each(
     cases.filter((c) => !only || c.title === only).map((c): [string, TestCase] => [c.title, c]),
-  )('%s', async (_, { cwd, env, command, outputs, timeout }) => {
+  )('%s', async (_, { cwd, env, command, expectFailure, outputs, timeout }) => {
     // Clean expected outputs if they already exist
     await Promise.all(
       outputs.map(async (output) => {
@@ -52,8 +53,13 @@ describe.concurrent('End-to-end cli export tests', { timeout: TIMEOUT }, () => {
         }
       }),
     );
-    // Run CLI command
-    await exec(command, { cwd: resolve(cwd), env: { ...process.env, ...env }, timeout });
+    // Run CLI command and assert non-zero exit when expectFailure is set
+    const run = exec(command, { cwd: resolve(cwd), env: { ...process.env, ...env }, timeout });
+    if (expectFailure) {
+      await expect(run).rejects.toThrow();
+    } else {
+      await run;
+    }
     // Expect correct output
     outputs.forEach((output) => {
       expect(fs.existsSync(resolve(output.path))).toBeTruthy();

--- a/packages/mystmd/tests/exports.yml
+++ b/packages/mystmd/tests/exports.yml
@@ -183,6 +183,11 @@ cases:
     cwd: strict-no-check-links
     command: myst build --strict
     outputs: []
+  - title: Check-links with strict fails on broken links
+    cwd: strict-no-check-links
+    command: myst build --check-links --strict
+    expectFailure: true
+    outputs: []
   - title: Basic site build
     cwd: basic-site
     command: myst build

--- a/packages/mystmd/tests/exports.yml
+++ b/packages/mystmd/tests/exports.yml
@@ -181,11 +181,11 @@ cases:
         content: dois/outputs/dois.bib
   - title: Strict build does not check external links
     cwd: strict-no-check-links
-    command: myst build --strict
+    command: myst build --site --strict
     outputs: []
   - title: Check-links with strict fails on broken links
     cwd: strict-no-check-links
-    command: myst build --check-links --strict
+    command: myst build --site --check-links --strict
     expectFailure: true
     outputs: []
   - title: Basic site build

--- a/packages/mystmd/tests/exports.yml
+++ b/packages/mystmd/tests/exports.yml
@@ -179,6 +179,10 @@ cases:
         content: dois/outputs/dois.tex
       - path: dois/_build/main.bib
         content: dois/outputs/dois.bib
+  - title: Strict build does not check external links
+    cwd: strict-no-check-links
+    command: myst build --strict
+    outputs: []
   - title: Basic site build
     cwd: basic-site
     command: myst build

--- a/packages/mystmd/tests/strict-no-check-links/index.md
+++ b/packages/mystmd/tests/strict-no-check-links/index.md
@@ -1,0 +1,4 @@
+# Strict without check-links
+
+This page has a [broken external link](https://does-not-exist-12345.invalid/foo)
+that would fail `--check-links`, but `--strict` alone must not check it.

--- a/packages/mystmd/tests/strict-no-check-links/myst.yml
+++ b/packages/mystmd/tests/strict-no-check-links/myst.yml
@@ -3,3 +3,5 @@
 version: 1
 project:
   id: 9e6a0c77-2122-4444-8888-222233334444
+site:
+  template: ../templates/site/myst/book-theme

--- a/packages/mystmd/tests/strict-no-check-links/myst.yml
+++ b/packages/mystmd/tests/strict-no-check-links/myst.yml
@@ -1,0 +1,5 @@
+# Regression fixture for https://github.com/jupyter-book/mystmd/issues/2122
+# --strict should NOT trigger external link checking.
+version: 1
+project:
+  id: 9e6a0c77-2122-4444-8888-222233334444


### PR DESCRIPTION
This separates the `--strict` and the `--check-links` logic in our build. It means that:

1. Links will only be checked if `--check-links` is explicitly given
2. Link warnings will only result in a fail if `--strict` is given

It also cleans up the documentation about this in general a little bit, so that information is a bit clearer and easier to find.

This _doesn't_ implement a deprecation pathway. Is that a huge problem? (personally, I think it'd be OK to not do this with a deprecation pathway, but if folks feel strongly I'm fine w/ it)

**Note**: The failing test doesn't seem to be related to this:

```
 FAIL  src/transforms/doi.spec.ts > DOI Resolvers for 'BibTeX' > markdown link with strange characters resolves
```

---

- resolves https://github.com/jupyter-book/mystmd/issues/2122
- resolves https://github.com/jupyter-book/mystmd/issues/2818