### PR TITLE
Add special case for sept for DOI metadata

### DIFF
--- a/.changeset/quiet-papayas-teach.md
+++ b/.changeset/quiet-papayas-teach.md
@@ -1,0 +1,5 @@
+---
+"citation-js-utils": patch
+---
+
+Add special case for sept

--- a/packages/citation-js-utils/src/index.ts
+++ b/packages/citation-js-utils/src/index.ts
@@ -180,13 +180,25 @@ function parseCitationStyle(style: string): string {
 }
 
 /**
+ * Normalize non-standard BibTeX month string macros that citation-js does not recognize.
+ * Add to this if we find other edge-cases / one-offs to fix.
+ */
+function normalizeBibTeXMonths(source: string): string {
+  // Crossref's BibTeX export from doi.org sometimes emits `month=sept` for
+  // September. citation-js drops it when this happens because it only
+  // expects "sep". So convert sept -> sep below.
+  source = source.replace(/(\bmonth\s*=\s*\{?)sept(\b)/gi, '$1sep$2');
+  return source;
+}
+
+/**
  * Parse a BibTeX string into an array of CSL items
  *
  * @param source - BibTeX string
  *
  */
 export function parseBibTeX(source: string): CSL[] {
-  return new Cite(source).data;
+  return new Cite(normalizeBibTeXMonths(source)).data;
 }
 
 /**

--- a/packages/citation-js-utils/tests/basic.spec.ts
+++ b/packages/citation-js-utils/tests/basic.spec.ts
@@ -42,6 +42,14 @@ describe('Test reference rendering', () => {
     expect(citations['cury2020sparse'].getDOI()).toBe(TEST_DOI_IN_OTHER_FIELD);
     expect(citations['cury2020sparse'].getURL()).toBe(`https://doi.org/${TEST_DOI_IN_OTHER_FIELD}`);
   });
+  it('non-standard month=sept is normalized to September', async () => {
+    const data = parseBibTeX('@article{a, year={1997}, month=sept}');
+    expect(data[0].issued).toEqual({ 'date-parts': [[1997, 9]] });
+  });
+  it('standard month=sep still parses as September', async () => {
+    const data = parseBibTeX('@article{a, year={1997}, month=sep}');
+    expect(data[0].issued).toEqual({ 'date-parts': [[1997, 9]] });
+  });
 });
 
 describe('yearFromCitation', () => {


### PR DESCRIPTION
It seems like doi.org is returning `sept` instead of `sep` and this was causing our bibtex parsing to skip it... this normalizes `sept` to `sep` if it encounters it.

Ideally, citation-js would know how to parse `sept` but this feels like a reasonable fix to add here in the meantime. I'm not sure why the data would suddenly change on us, so I noted that we might need to extend the function if we notice other kinds of changes to the DOI data structure

---
- closes https://github.com/jupyter-book/mystmd/issues/2821