### PR TITLE
fix: in static builds, redirect index.html to canonical route for hydration

### DIFF
--- a/.changeset/cold-actors-say.md
+++ b/.changeset/cold-actors-say.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': minor
+'mystmd': minor
+---
+
+Redirect /foo/index.html to canonical URL (/foo/) to fix hydration.

--- a/packages/myst-cli/src/build/html/index.ts
+++ b/packages/myst-cli/src/build/html/index.ts
@@ -72,9 +72,21 @@ export async function currentSiteRoutes(
 // This is defined in the remix `publicPath` and allows us to overwrite it here.
 const ASSETS_FOLDER = 'myst_assets_folder';
 
+// Script injected into every index.html to redirect "/foo/index.html" → "/foo/"
+// before Remix hydrates, preventing a URL mismatch that breaks client-side routing.
+// Remix renders the root index for URL "/" but static servers also serve the same
+// file at "/index.html", where the URL doesn't match any Remix route → runtime error.
+const INDEX_REDIRECT_SCRIPT =
+  `<script>(function(){` +
+  `var p=window.location.pathname;` +
+  `if(p.endsWith('/index.html'))` +
+  `window.location.replace((p.slice(0,-10)||'/')+window.location.search+window.location.hash);` +
+  `})();</script>`;
+
 /**
  * Rewrite URLs in HTML/JS/JSON files pointing to the default assets folder in
- * terms of the provided base URL
+ * terms of the provided base URL, and inject a URL-normalisation script into
+ * every index.html so that direct access via /foo/index.html redirects to /foo/.
  *
  * @param directory directory of files to recursively rewrite
  * @param baseurl base URL of the built site
@@ -91,12 +103,15 @@ function rewriteAssetsFolder(directory: string, baseurl?: string): void {
       return;
     }
     if (!['.html', '.js', '.json'].includes(path.extname(file))) return;
-    const data = fs.readFileSync(file).toString();
-    const modified = data.replace(
+    let data = fs.readFileSync(file).toString();
+    data = data.replace(
       new RegExp(`\\/${ASSETS_FOLDER}\\/`, 'g'),
       `${baseurl || ''}/build/`,
     );
-    fs.writeFileSync(file, modified);
+    if (filename === 'index.html') {
+      data = data.replace('<head>', `<head>${INDEX_REDIRECT_SCRIPT}`);
+    }
+    fs.writeFileSync(file, data);
   });
 }
 

--- a/packages/myst-cli/src/build/html/index.ts
+++ b/packages/myst-cli/src/build/html/index.ts
@@ -104,10 +104,7 @@ function rewriteAssetsFolder(directory: string, baseurl?: string): void {
     }
     if (!['.html', '.js', '.json'].includes(path.extname(file))) return;
     let data = fs.readFileSync(file).toString();
-    data = data.replace(
-      new RegExp(`\\/${ASSETS_FOLDER}\\/`, 'g'),
-      `${baseurl || ''}/build/`,
-    );
+    data = data.replace(new RegExp(`\\/${ASSETS_FOLDER}\\/`, 'g'), `${baseurl || ''}/build/`);
     if (filename === 'index.html') {
       data = data.replace('<head>', `<head>${INDEX_REDIRECT_SCRIPT}`);
     }


### PR DESCRIPTION
When a static site is served and /foo/index.html is accessed, Remix tries to hydrate with that URL, which matches the catch-all route instead of the intended index route.  No page data exists for the slug "index.html", causing a runtime error.

Inject a script into every index.html that redirects to the canonical URL before Remix hydrates. We need to preserve any query string and anchor fragments.

Closes #2824 