### PR TITLE
Expose content server with sockets on starting dev server

### DIFF
--- a/.changeset/tasty-gifts-study.md
+++ b/.changeset/tasty-gifts-study.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Expose content server, websocket and sendJson helper

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -78,7 +78,7 @@ export async function startContentServer(session: ISession, opts?: ServerOptions
   /**
    * Send a message to all connections.
    */
-  const sendJson = (data: { type: 'LOG' | 'RELOAD'; message?: string }) => {
+  const sendJson = (data: { type: 'LOG' | 'RELOAD'; message?: string; [s: string]: any }) => {
     Object.entries(connections).forEach(([, ws]) => {
       ws.send(JSON.stringify(data));
     });
@@ -186,5 +186,6 @@ export async function startServer(
     killProcessTree(appServer.process);
     contentServer.stop();
   };
+
   return appServer satisfies AppServer;
 }

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -128,9 +128,9 @@ export function warnOnHostEnvironmentVariable(session: ISession, opts?: StartOpt
   return DEFAULT_HOST;
 }
 
-export type AppServer = {
-  port: number;
-  process: child_process.ChildProcess;
+export type ServerInfo = {
+  port?: number;
+  process?: child_process.ChildProcess;
   contentServer: Awaited<ReturnType<typeof startContentServer>>;
   stop: () => void;
 };
@@ -138,7 +138,7 @@ export type AppServer = {
 export async function startServer(
   session: ISession,
   opts: StartOptions,
-): Promise<AppServer | undefined> {
+): Promise<ServerInfo | undefined> {
   // Ensure we are on the latest version of the configs
   await session.reload();
   const host = warnOnHostEnvironmentVariable(session, opts);
@@ -154,13 +154,20 @@ export async function startServer(
     session.log.info(
       `\n🔌 Content server started on port ${contentServer.port}!  🥳 🎉\n\n\n\t👉  ${local}  👈\n\n`,
     );
-    return undefined;
+    // Return a headless AppServer so callers (e.g. curvenote-cli's
+    // startServerWithLoggers) can still reach contentServer.sendJson to wire
+    // up websocket loggers. `port` and `process` are intentionally omitted
+    // since no template server is spawned.
+    return {
+      contentServer,
+      stop: () => contentServer.stop(),
+    } satisfies ServerInfo;
   }
   session.log.info(
     `\n\n\t✨✨✨  Starting ${mystTemplate.getValidatedTemplateYml().title}  ✨✨✨\n\n`,
   );
   const port = opts?.port ?? (await getPort({ port: portNumbers(3000, 3100) }));
-  const appServer = { port, contentServer } as AppServer;
+  const appServer = { port, contentServer } as ServerInfo;
   await new Promise<void>((resolve) => {
     const start = makeExecutable(
       mystTemplate.getValidatedTemplateYml().build?.start ?? DEFAULT_START_COMMAND,
@@ -183,9 +190,9 @@ export async function startServer(
     start().catch((e) => session.log.debug(e));
   });
   appServer.stop = () => {
-    killProcessTree(appServer.process);
+    if (appServer.process) killProcessTree(appServer.process);
     contentServer.stop();
   };
 
-  return appServer satisfies AppServer;
+  return appServer satisfies ServerInfo;
 }

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -83,20 +83,25 @@ export async function startContentServer(session: ISession, opts?: ServerOptions
       ws.send(JSON.stringify(data));
     });
   };
-  // Create log and reload functions for later
-  const log = (message: string) => sendJson({ type: 'LOG', message });
-  const reload = () => sendJson({ type: 'RELOAD' });
+
+  /**
+   * @deprecated Use the websocket server exposed via `sockets.wss` to broadcast
+   * messages directly instead.
+   */
+  const sendReload = () => sendJson({ type: 'RELOAD' });
 
   server.on('upgrade', (request, socket, head) => {
     wss.handleUpgrade(request, socket, head, (websocket) => {
       wss.emit('connection', websocket, request);
     });
   });
+
   const stop = () => {
     server.close();
     wss.close();
   };
-  return { host, port, reload, log, stop };
+
+  return { host, port, stop, sendReload, sendJson, wss, connections };
 }
 
 export function warnOnHostEnvironmentVariable(session: ISession, opts?: StartOptions): string {
@@ -126,6 +131,7 @@ export function warnOnHostEnvironmentVariable(session: ISession, opts?: StartOpt
 export type AppServer = {
   port: number;
   process: child_process.ChildProcess;
+  contentServer: Awaited<ReturnType<typeof startContentServer>>;
   stop: () => void;
 };
 
@@ -139,14 +145,14 @@ export async function startServer(
   const mystTemplate = await getSiteTemplate(session, opts);
   if (!opts.headless && !opts.template) await installSiteTemplate(session, mystTemplate);
   await buildSite(session, opts);
-  const server = await startContentServer(session, { ...opts, serverHost: host });
+  const contentServer = await startContentServer(session, { ...opts, serverHost: host });
   if (!opts.buildStatic) {
-    watchContent(session, server.reload, opts);
+    watchContent(session, contentServer.sendReload, opts);
   }
   if (opts.headless) {
-    const local = chalk.green(`http://${host}:${server.port}`);
+    const local = chalk.green(`http://${host}:${contentServer.port}`);
     session.log.info(
-      `\n🔌 Content server started on port ${server.port}!  🥳 🎉\n\n\n\t👉  ${local}  👈\n\n`,
+      `\n🔌 Content server started on port ${contentServer.port}!  🥳 🎉\n\n\n\t👉  ${local}  👈\n\n`,
     );
     return undefined;
   }
@@ -154,7 +160,7 @@ export async function startServer(
     `\n\n\t✨✨✨  Starting ${mystTemplate.getValidatedTemplateYml().title}  ✨✨✨\n\n`,
   );
   const port = opts?.port ?? (await getPort({ port: portNumbers(3000, 3100) }));
-  const appServer = { port } as AppServer;
+  const appServer = { port, contentServer } as AppServer;
   await new Promise<void>((resolve) => {
     const start = makeExecutable(
       mystTemplate.getValidatedTemplateYml().build?.start ?? DEFAULT_START_COMMAND,
@@ -164,7 +170,7 @@ export async function startServer(
         env: {
           ...process.env,
           HOST: host,
-          CONTENT_CDN_PORT: String(server.port),
+          CONTENT_CDN_PORT: String(contentServer.port),
           PORT: String(port),
           MODE: opts.buildStatic ? 'static' : 'app',
           BASE_URL: opts.baseurl || undefined,
@@ -178,7 +184,7 @@ export async function startServer(
   });
   appServer.stop = () => {
     killProcessTree(appServer.process);
-    server.stop();
+    contentServer.stop();
   };
-  return appServer;
+  return appServer satisfies AppServer;
 }

--- a/packages/myst-cli/src/init/init.ts
+++ b/packages/myst-cli/src/init/init.ts
@@ -205,5 +205,5 @@ export async function init(session: ISession, opts: InitOptions) {
     );
     process.exit(0);
   }
-  await startServer(session, {});
+  return await startServer(session, {});
 }


### PR DESCRIPTION
This exposes the content server details throught the `startServer` opening up more possibilities for the cli, and clients of the `myst-cli` library to interact directly with the content server and front ends via wockets.
