### PR TITLE
Await signals to terminate processes

### DIFF
--- a/.changeset/green-hairs-wonder.md
+++ b/.changeset/green-hairs-wonder.md
@@ -1,0 +1,6 @@
+---
+"myst-cli-utils": patch
+"myst-cli": patch
+---
+
+Await signals to terminate processes

--- a/packages/myst-cli-utils/src/exec.ts
+++ b/packages/myst-cli-utils/src/exec.ts
@@ -48,17 +48,27 @@ export function makeExecutable(
 }
 
 /**
- * On Linux, child processes will not be terminated when attempting to kill their parent
- * This function uses `tree-kill` to kill the process and all its child processes
+ * On Unix-like systems, killing a process does not propagate to its children,
+ * they get re-parented and keep running. This uses                           
+ * `tree-kill` to discover and kill the parent process *and* all of its descendants.
+ *
+ * Returns a Promise that resolves once `tree-kill` has issued its signals.
+ * This allows callers to await these signals before moving on, which prevents a case
+ * where node exits before the signals are sent, and we're left with orphaned processes.
  */
-export function killProcessTree(process: child_process.ChildProcess) {
-  if (!process.pid) {
-    process.kill('SIGTERM');
-    return;
-  }
-  treeKill(process.pid, 'SIGTERM', (err) => {
-    if (err && process.pid) {
-      treeKill(process.pid, 'SIGKILL');
+export function killProcessTree(process: child_process.ChildProcess): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (!process.pid) {
+      process.kill('SIGTERM');
+      resolve();
+      return;
     }
+    treeKill(process.pid, 'SIGTERM', (err) => {
+      if (err && process.pid) {
+        treeKill(process.pid, 'SIGKILL', () => resolve());
+      } else {
+        resolve();
+      }
+    });
   });
 }

--- a/packages/myst-cli-utils/src/exec.ts
+++ b/packages/myst-cli-utils/src/exec.ts
@@ -49,7 +49,7 @@ export function makeExecutable(
 
 /**
  * On Unix-like systems, killing a process does not propagate to its children,
- * they get re-parented and keep running. This uses                           
+ * they get re-parented and keep running. This uses
  * `tree-kill` to discover and kill the parent process *and* all of its descendants.
  *
  * Returns a Promise that resolves once `tree-kill` has issued its signals.

--- a/packages/myst-cli/src/build/html/index.ts
+++ b/packages/myst-cli/src/build/html/index.ts
@@ -185,7 +185,7 @@ export async function buildHtml(session: ISession, opts: StartOptions) {
       }),
     ),
   );
-  appServer.stop();
+  await appServer.stop();
 
   // Copy the files for the template used
   const templateBuildDir = path.join(template.templatePath, 'public');

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -126,7 +126,7 @@ export function warnOnHostEnvironmentVariable(session: ISession, opts?: StartOpt
 export type AppServer = {
   port: number;
   process: child_process.ChildProcess;
-  stop: () => void;
+  stop: () => Promise<void>;
 };
 
 export async function startServer(
@@ -176,8 +176,9 @@ export async function startServer(
     );
     start().catch((e) => session.log.debug(e));
   });
-  appServer.stop = () => {
-    killProcessTree(appServer.process);
+  appServer.stop = async () => {
+    // Await to ensure that all processes have completed
+    await killProcessTree(appServer.process);
     server.stop();
   };
   return appServer;


### PR DESCRIPTION
This adds an await step to our code that kills processes during the build. I think that it will resolve #2833. I think what happened was that we were exiting the parent mystmd process _before_ confirming that all the child-processes had been signaled for being killed, and as a result some of them were sticking around instead of being killed. This adds logic to make sure we don't move on until those signals have been sent.

it seemed to work locally, but @ryanlovett could you take a look and see if you can reproduce with this PR? I'm not sure how to test this one...

---

- resolves #2833 