### PR TITLE
Await connection end for jupyter kernel

### DIFF
--- a/.changeset/lucky-buckets-poke.md
+++ b/.changeset/lucky-buckets-poke.md
@@ -1,0 +1,5 @@
+---
+"myst-execute": patch
+---
+
+Await connection end for jupyter kernel

--- a/packages/myst-execute/src/transform.ts
+++ b/packages/myst-execute/src/transform.ts
@@ -167,7 +167,7 @@ export async function kernelExecutionTransform(tree: GenericParent, vfile: VFile
   } finally {
     // Ensure that we shut-down the kernel
     if (!sessionConnection.isDisposed) {
-      sessionConnection.shutdown();
+      await sessionConnection.shutdown();
     }
   }
 }


### PR DESCRIPTION
I think that this fixes #2852 - it does the same `await` logic that we were using elsewhere to make sure that things are cleaned up before more things are requested. Testing locally this seemed to fix the problem for me - I am not really sure how to test this without a lot of extra complexity since it's an "only happens sometimes" race condition (I think anyway haha)